### PR TITLE
chore(scripts): improve generate_index with validation and CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML>=6.0
+jsonschema>=4.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,33 @@
+generate_index
+===============
+
+This folder contains the `generate_index.py` utility used to build a
+canonical `index.json` for the `pact-contract-catalog` repository.
+
+What it does
+- Scans `contracts/<slug>/metadata.yaml` files
+- Performs lightweight validation and an allowlist of safe fields
+- Emits an `index.json` file at the repository root (or a specified path)
+
+Usage
+
+Install dependencies:
+
+```bash
+cd pact-contract-catalog
+pip3 install --user -r requirements.txt
+```
+
+Run the generator:
+
+```bash
+./scripts/generate_index.sh
+# or
+python3 ./scripts/generate_index.py . --out ./index.json
+```
+
+Notes
+- The script will warn and skip metadata files that are missing required
+  fields.
+- Keep `metadata.yaml` files free of secrets; the generator will
+  include permitted fields in the published `index.json`.

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+generate_index.py
+
+Scan a `contracts/` directory for `metadata.yaml` files and produce a
+canonical `index.json` containing an array of metadata objects.
+
+Usage: ./generate_index.py /path/to/repo-root --out /path/to/index.json
+
+This script performs a lightweight validation and an allowlist of fields
+to avoid publishing arbitrary private keys or internal fields.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+try:
+    import yaml
+except Exception as e:
+    print("Missing dependency 'PyYAML'. Install with: pip3 install -r requirements.txt", file=sys.stderr)
+    raise
+
+ALLOWED_KEYS = [
+    "name",
+    "description",
+    "repository",
+    "version",
+    "auditState",
+    "tags",
+    "authors",
+]
+
+REQUIRED_KEYS = ["name", "repository", "version"]
+
+
+def load_meta(path):
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"metadata at {path} did not parse to a mapping")
+    # allowlist keys
+    item = {k: data.get(k) for k in ALLOWED_KEYS if k in data}
+    # simple validation
+    missing = [k for k in REQUIRED_KEYS if k not in item or item.get(k) in (None, "")]
+    if missing:
+        raise ValueError(f"metadata at {path} missing required keys: {missing}")
+    return item
+
+
+def build_index(root, contracts_dir, out_path):
+    items = []
+    if os.path.isdir(contracts_dir):
+        for slug in sorted(os.listdir(contracts_dir)):
+            path = os.path.join(contracts_dir, slug)
+            meta = os.path.join(path, "metadata.yaml")
+            if os.path.isfile(meta):
+                try:
+                    item = load_meta(meta)
+                    items.append(item)
+                except Exception as e:
+                    print(f"Warning: skipping {meta}: {e}", file=sys.stderr)
+    # write output
+    with open(out_path, "w", encoding="utf-8") as o:
+        json.dump(items, o, indent=2, ensure_ascii=False)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("root", help="Repository root (containing contracts/)")
+    p.add_argument("--contracts-dir", help="contracts directory (optional)")
+    p.add_argument("--out", help="output path for index.json (optional)")
+    args = p.parse_args(argv)
+
+    root = os.path.abspath(args.root)
+    contracts_dir = args.contracts_dir or os.path.join(root, "contracts")
+    out_path = args.out or os.path.join(root, "index.json")
+
+    build_index(root, contracts_dir, out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_index.sh
+++ b/scripts/generate_index.sh
@@ -3,6 +3,29 @@ set -euo pipefail
 ROOT="$(dirname "$0")/.."
 OUT="$ROOT/index.json"
 
+# Generate index.json (written to $OUT). This script calls the
+# Python CLI `generate_index.py` which performs validation and an
+# allowlist of fields before writing JSON to the output file.
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required to run this script" >&2
+  exit 2
+fi
+
+PY_SCRIPT="$ROOT/scripts/generate_index.py"
+if [ ! -f "$PY_SCRIPT" ]; then
+  echo "Missing $PY_SCRIPT" >&2
+  exit 2
+fi
+
+python3 "$PY_SCRIPT" "$ROOT" --out "$OUT"
+
+exit 0
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(dirname "$0")/.."
+OUT="$ROOT/index.json"
+
 # Generate index.json (written to $OUT). No other stdout should be emitted
 python3 - "$ROOT" <<'PY' > "$OUT"
 import sys, os, yaml, json


### PR DESCRIPTION
Add a Python CLI to generate index.json from contracts/*/metadata.yaml, add requirements and documentation. The script includes a safe allowlist and basic validation. Runs locally and in CI.