### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Catalog ownership
+/contracts/             @Pact-Community-Organization/catalog-team
+/metadata/              @Pact-Community-Organization/catalog-team
+/scripts/               @Pact-Community-Organization/catalog-team @Pact-Community-Organization/core-maintainers
+*                      @Pact-Community-Organization/core-maintainers


### PR DESCRIPTION
Adds CODEOWNERS to delegate ownership to Catalog-Team and Core-Maintainers. See docs/teams.md and tracking issue #57.