### PR TITLE
chore: add labels and security runbook

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,3 +1,23 @@
+# Labels copied from foundation
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+
+- name: security
+  color: 5319e7
+  description: Security issue or vulnerability
+
+- name: help wanted
+  color: 008672
+  description: Extra attention is needed
 labels:
   - name: bug
     color: ff0000

--- a/SECURITY_RUNBOOK.md
+++ b/SECURITY_RUNBOOK.md
@@ -1,0 +1,19 @@
+## Security Runbook (copied from foundation)
+
+Purpose: provide a minimal, practical response playbook for common security events.
+
+1. Triage
+   - Assign a Security WG member.
+   - Create a private issue (if sensitive) and label `security`.
+
+2. Containment
+   - If code is vulnerable, open a draft PR with the fix in a private branch.
+   - Revoke any compromised tokens/secrets and rotate keys.
+
+3. Communication
+   - Notify maintainers and org owners.
+   - For public incidents, prepare coordinated disclosure timeline.
+
+4. Post-Incident
+   - Run a security post-mortem.
+   - Update docs and checklist in `SECURITY.md`.


### PR DESCRIPTION
Adds standard labels and a security runbook copied from foundation. See tracking issue #57.