### PR TITLE
feat(library): harden token-fungible template to v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,23 @@ jobs:
         fi
         echo "Contract index is up to date."
 
+    - name: Run library test suites (BLOCKING)
+      # Every library/ template ships a self-contained .repl suite that loads
+      # its interface dependencies from the in-repo registry/ tree. A failing
+      # assertion fails the build. NOTE: cross-chain resume steps need SPV and
+      # are provable only on devnet — suites test step-0 guards in the REPL.
+      run: |
+        fail=0
+        for f in $(find contracts/library -name "*.repl"); do
+          echo "=== pact $f"
+          if ! (cd "$(dirname "$f")" && pact "$(basename "$f")"); then
+            echo "::error::Test suite failed: $f"
+            fail=1
+          fi
+        done
+        [ "$fail" -eq 0 ] || exit 1
+        echo "All library test suites passed."
+
     - name: Lint library Pact contracts
       # Only lint library/ — registry/ entries are verbatim artifacts from the
       # chain or upstream; they have external dependencies that require a full

--- a/contracts/library/hello-world/examples/hello-world-test.repl
+++ b/contracts/library/hello-world/examples/hello-world-test.repl
@@ -1,203 +1,61 @@
-(env-keys ["admin"])
+;; hello-world-test.repl — PCO library template test suite
+;;
+;; Self-contained: no external sandbox needed. Exercises the actual module
+;; functions and the ADMIN capability, with assertions (expect/expect-failure).
 
-(load "../../../../kadena_repl_sandbox/kda-env/init.repl")
+(env-data {"hello-world-admin": ["admin-key"], "user-keyset": ["user-key"]})
+(env-sigs [{"key": "admin-key", "caps": []}])
+(env-chain-data {"block-time": (time "2026-07-05T00:00:00Z")})
 
-(begin-tx)
-
-; Set up keysets for testing
-(env-data
-  {"admin-keyset": ["admin"],
-   "hello-world-admin": ["admin"],
-   "user-keyset": ["user"]})
-
-; Define keysets
-(define-keyset 'admin-keyset (read-keyset "admin-keyset"))
-(define-keyset 'hello-world-admin (read-keyset "hello-world-admin"))
-(define-keyset 'user-keyset (read-keyset "user-keyset"))
-
-; Load the contract for validation
+;; ---------------------------------------------------------------------------
+;; Setup
+;; ---------------------------------------------------------------------------
+(begin-tx "setup")
+(define-keyset "hello-world-admin" (read-keyset "hello-world-admin"))
 (load "../hello-world.pact")
-
+(create-table messages)
 (commit-tx)
 
-; ===== COMPREHENSIVE CONTRACT LOGIC TESTING =====
-; This test validates all core operations that the hello-world contract relies on.
-; We demonstrate the fundamental building blocks work correctly.
-
-(begin-tx)
-
-; Test 1: hello-world function logic - string concatenation simulation
-; Contract uses: (format "Hello, {}! Welcome to Pact." [name])
-; We test the core string operations that make this work
-(format "String length test - Alice: {}" [(length "Alice")]) ; Should be 5
-(format "String length test - Bob: {}" [(length "Bob")])     ; Should be 3
-(format "String length test - empty: {}" [(length "")])      ; Should be 0
-
-; Test 2: Hash function consistency (critical for message storage)
-(let ((hash1 (hash "First test message"))
-      (hash2 (hash "First test message")))
-  (format "Hash consistency test: {} = {} -> {}" [hash1 hash2 (= hash1 hash2)]))
-
-; Test 3: Hash function produces different results for different inputs
-(let ((hash1 (hash "First test message"))
-      (hash2 (hash "Second message")))
-  (format "Hash uniqueness test: {} ≠ {} -> {}" [hash1 hash2 (not (= hash1 hash2))]))
-
-; Test 4: Hash with empty string
-(let ((empty-hash (hash "")))
-  (format "Empty string hash length: {}" [(length empty-hash)]))
-
-; Test 5: Hash with special characters
-(let ((special-hash (hash "Special chars: !@#$%^&*()")))
-  (format "Special chars hash length: {}" [(length special-hash)]))
-
-; Test 6: String manipulation functions (used in get-message)
-(format "Take 5 from 'Hello World': '{}'" [(take 5 "Hello World")])
-(format "Take 0 from 'Hello': '{}'" [(take 0 "Hello")])
-(format "Take 20 from 'Hello World': '{}'" [(take 20 "Hello World")])
-
-; Test 7: Length comparisons (used for message comparison)
-(format "Length comparison: 'Second message' > 'First' -> {}" [(> (length "Second message") (length "First"))])
-
-; Test 8: Unicode character handling
-(let ((unicode-hash (hash "Unicode: 你好 🌟 αβγ")))
-  (format "Unicode hash length: {}" [(length unicode-hash)]))
-
+;; ---------------------------------------------------------------------------
+;; Greeting (pure function)
+;; ---------------------------------------------------------------------------
+(begin-tx "greeting")
+(expect "personalized greeting"
+  "Hello, Alice! Welcome to Pact."
+  (hello-world.hello-world "Alice"))
+(expect "empty name still formats"
+  "Hello, ! Welcome to Pact."
+  (hello-world.hello-world ""))
 (commit-tx)
 
-; ===== NEGATIVE TEST CASES & ERROR HANDLING =====
-
-(begin-tx)
-
-; Test 9: Type validation concepts - contract would reject non-string inputs
-; (In actual contract execution, these would fail with type mismatches)
-; We demonstrate the concept by showing what valid inputs look like
-
-; Test 10: Invalid hash lookup simulation
-; (Contract would return "row not found" for non-existent hashes)
-(let ((invalid-hash "non-existent-hash"))
-  (format "Invalid hash length: {}" [(length invalid-hash)]))
-
-; Test 11: String length validation
-(format "String lengths - empty: {}, Alice: {}, Bob: {}" [(length "") (length "Alice") (length "Bob")])
-
+;; ---------------------------------------------------------------------------
+;; Message storage — ADMIN capability enforced
+;; ---------------------------------------------------------------------------
+(begin-tx "store-and-read")
+(env-sigs [{"key": "admin-key", "caps": []}])
+(hello-world.store-message "first message")
+(expect "stored message roundtrip"
+  (format "Message: first message at {}" [(time "2026-07-05T00:00:00Z")])
+  (hello-world.get-message (hash "first message")))
 (commit-tx)
 
-; ===== EDGE CASES & BOUNDARY CONDITIONS =====
+(begin-tx "store-requires-admin")
+;; a non-admin key must NOT be able to write
+(env-sigs [{"key": "user-key", "caps": []}])
+(expect-failure "non-admin cannot store" "Keyset failure"
+  (hello-world.store-message "unauthorized write"))
+(rollback-tx)
 
-(begin-tx)
+(begin-tx "duplicate-message")
+(env-sigs [{"key": "admin-key", "caps": []}])
+;; key is (hash message): storing identical content twice must fail on insert
+(expect-failure "duplicate message rejected"
+  (hello-world.store-message "first message"))
+(rollback-tx)
 
-; Test 12: Very long message handling
-(let ((long-msg "This is a very long message that tests the limits of string handling in Pact smart contracts. It should still work properly and not cause any issues with storage or retrieval operations. This message is intentionally long to test boundary conditions.")
-      (long-hash (hash long-msg)))
-  (format "Long message hash length: {}" [(length long-hash)]))
+(begin-tx "missing-message")
+(expect-failure "reading a missing hash fails"
+  (hello-world.get-message "no-such-hash"))
+(rollback-tx)
 
-; Test 13: Empty message handling
-(let ((empty-msg "")
-      (empty-hash (hash empty-msg)))
-  (format "Empty message formatted: '{}'" [(format "Message: {} at {}" [empty-msg "2024-01-01T00:00:00Z"])]))
-
-; Test 14: Whitespace-only message
-(let ((ws-msg "   ")
-      (ws-hash (hash ws-msg)))
-  (format "Whitespace message formatted: '{}'" [(format "Message: {} at {}" [ws-msg "2024-01-01T00:00:00Z"])]))
-
-; Test 15: Unicode and emoji support
-(let ((unicode-msg "Unicode: 你好 🌟 αβγ")
-      (unicode-hash (hash unicode-msg)))
-  (format "Unicode message formatted: '{}'" [(format "Message: {} at {}" [unicode-msg "2024-01-01T00:00:00Z"])]))
-
-; Test 16: Duplicate message content (same hash)
-(let ((dup-hash1 (hash "Duplicate message"))
-      (dup-hash2 (hash "Duplicate message")))
-  (format "Duplicate hash consistency: {} = {} -> {}" [dup-hash1 dup-hash2 (= dup-hash1 dup-hash2)]))
-
-; Test 17: String manipulation functions
-(format "String operations: take 5: '{}', take 0: '{}', take 20: '{}'"
-  [(take 5 "Hello World") (take 0 "Hello") (take 20 "Hello World")])
-
-(commit-tx)
-
-; ===== SECURITY & CAPABILITY TESTING =====
-
-(begin-tx)
-
-; Test 18: Keyset guard validation
-(format "Keyset guard validation: {}" [(keyset-ref-guard "hello-world-admin")])
-
-; Test 19: Chain data access (timestamp functionality)
-(let ((block-time (at 'block-time (chain-data))))
-  (format "Chain data access: block-time available: {}" [(not (= block-time (time "1970-01-01T00:00:00Z")))]))
-
-; Test 20: Keyset structure validation
-; (Verifies the keyset configuration that would be used for ADMIN capability)
-(format "Keyset validations: admin: {}, user: {}"
-  [(keyset-ref-guard "admin-keyset") (keyset-ref-guard "user-keyset")])
-
-(commit-tx)
-
-; ===== CONTRACT STRUCTURE VALIDATION =====
-
-(begin-tx)
-
-; Test 21: Module loading confirmation
-; (The load command above should have succeeded)
-
-; Test 22: Environment setup validation
-; (Keysets should be properly defined)
-(format "Environment validation: hello-world-admin keyset: {}" [(keyset-ref-guard "hello-world-admin")])
-
-; Test 23: Data integrity checks
-(let ((test-data "integrity check"))
-  (format "Data integrity: '{}' = '{}' -> {}" [test-data test-data (= test-data test-data)]))
-
-(commit-tx)
-
-; ===== PERFORMANCE & SCALING TESTS =====
-
-(begin-tx)
-
-; Test 24: Hash performance with various string lengths
-(let ((short-hash (hash "a"))
-      (medium-hash (hash "This is a medium length string"))
-      (long-hash (hash "This is a very long string that should still hash properly and consistently")))
-  (format "Hash performance - lengths: short: {}, medium: {}, long: {}"
-    [(length short-hash) (length medium-hash) (length long-hash)]))
-
-; Test 25: String formatting with various data types
-; (Contract uses string formatting extensively)
-(format "String formatting tests: number: '{}', boolean: '{}'"
-  [(format "Result: {}" [42]) (format "Result: {}" [true])])
-
-(commit-tx)
-
-; ===== SUMMARY =====
-; Comprehensive contract logic validation completed:
-; ✓ String formatting (hello-world function behavior)
-; ✓ Hash consistency and uniqueness (message storage/retrieval)
-; ✓ Message formatting (get-message output structure)
-; ✓ Edge cases (long strings, special chars, empty values, unicode)
-; ✓ Type validation concepts (string parameter requirements)
-; ✓ Keyset and capability structure validation
-; ✓ Chain data access (timestamp functionality)
-; ✓ Data integrity and consistency checks
-; ✓ Performance characteristics (hash operations)
-;
-; Contract Security Model Validated:
-; - ADMIN capability enforcement via keyset-ref-guard
-; - Table operations using hash-based keys
-; - Type checking for all function parameters
-; - Capability-controlled write operations
-; - Public read operations
-;
-; Test Coverage: 25 comprehensive test cases covering:
-; - Positive functionality (7 tests)
-; - Negative cases & error handling (4 tests)
-; - Edge cases & boundary conditions (7 tests)
-; - Security & capabilities (4 tests)
-; - Contract structure (3 tests)
-; - Performance & scaling (2 tests)
-;
-; For complete end-to-end testing including live capability enforcement
-; and table operations, deploy the contract on a testnet with proper
-; keyset configuration and ADMIN capability grants.
+"All hello-world template tests passed"

--- a/contracts/library/hello-world/metadata.yaml
+++ b/contracts/library/hello-world/metadata.yaml
@@ -5,7 +5,7 @@ repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalo
 license: 'Apache-2.0'
 authors:
   - name: 'Pact Community Organization'
-    email: 'maintainers@pact.org'
+    email: 'info@pact-community.org'
 audit_status: 'self-reviewed'
 tags: ['hello-world', 'tutorial', 'basic']
 keywords: ['pact', 'smart-contract', 'example']

--- a/contracts/library/token-fungible/AUDIT.md
+++ b/contracts/library/token-fungible/AUDIT.md
@@ -5,58 +5,89 @@
 | Field | Value |
 |---|---|
 | **Module** | `token` (namespace: project-specific) |
+| **Version** | 0.2.0 |
 | **Audit Status** | self-reviewed |
-| **Category** | PCO Community Template |
+| **Category** | PCO Library Template |
 | **Source** | PCO-authored reference implementation |
+| **Last review** | 2026-07-05 (PCO, template hardening) |
 
 ## Purpose
 
-This module is a **neutral reference template** for a fungible token implementing
-`fungible-v2` and `fungible-xchain-v1`. It is designed for use as a starting point,
-not for direct deployment without customization.
+Deployable template for a fungible token implementing `fungible-v2` and
+`fungible-xchain-v1`. Designed as a hardened starting point; adapt namespace,
+governance keyset, and tokenomics before deployment.
 
-## Security Assessment
+## v0.1 → v0.2: remediated findings
 
-### Capability Model
+Version 0.1 of this template contained a **CRITICAL authorization flaw**, and its
+audit record at the time incorrectly rated authorization bypass as "Low". Recorded
+here permanently for transparency:
 
-| Capability | Type | Notes |
-|---|---|---|
-| `GOV` | Governance | `(keyset-ref-guard "token-gov")` — admin-only |
-| `DEBIT` | Internal | Restricts sender; required by `transfer` and `transfer-crosschain` |
-| `CREDIT` | Internal | Restricts receiver; required by `transfer` |
-| `TRANSFER` | `@managed` | Amount-managed; enforces positive, correct precision |
-| `ROTATE` | `@managed` | Single-use guard rotation |
+| # | Severity | v0.1 finding | v0.2 remediation |
+|---|----------|--------------|-------------------|
+| 1 | **CRITICAL** | `DEBIT` only checked `sender != ""` — it never enforced the sender's account guard. Any signer scoping the managed `TRANSFER` cap could transfer **anyone's** funds. | `DEBIT` now enforces the sender's stored guard (coin pattern, read let-bound before enforcement). Regression-tested: attacker-scoped `TRANSFER` fails with `Keyset failure`. |
+| 2 | **CRITICAL** | `transfer-crosschain` step 0 acquired plain `DEBIT` directly — no managed cap, no guard: anyone could burn/redirect anyone's funds cross-chain. | Step 0 now requires the managed `TRANSFER_XCHAIN` cap which composes the guard-enforcing `DEBIT`; target-chain validated against `VALID_CHAIN_IDS` and same-chain transfers rejected. Regression-tested. |
+| 3 | High | No reserved-account protocol: anyone could create `k:<key>` accounts with their own guard (squatting). | `enforce-reserved` (coin pattern) at `create-account` and inside `credit` for implicit creation. Regression-tested. |
+| 4 | Medium | `@doc` claimed `fungible-xchain-v1` compliance but the module did not implement the interface (no `TRANSFER_XCHAIN`/`TRANSFER_XCHAIN_RECD`). | `(implements fungible-xchain-v1)` with the full capability surface. |
+| 5 | Medium | No account validation (length/charset); no supply mechanism (tests seeded balances by acquiring internal caps directly). | `validate-account` bounds + charset; governed `mint` with `MINT` event. |
+| 6 | Low | Test suite used invalid 3-argument `(try ...)` forms and never exercised the attack paths; a REPL pass proved nothing. | Suite rewritten: self-contained (loads registry interfaces), 31 assertions including both drain-attack regressions and the doomed-yield fast-fail; runs blocking in CI. |
 
-### Known Considerations
+## Capability model (v0.2)
 
-1. **Missing AUDIT.md** — addressed in this file.
-2. **`fungible-v2.account-details`** — the `details` function return type references the
-   interface type; module must be deployed in an environment where `fungible-v2` is already
-   installed.
-3. **`@managed true` on ROTATE** — allows any call when capability has been granted; callers
-   should validate guard equality before calling `rotate`.
-4. **No gas station** — intended for projects to add their own, or use `kadena.spirekey`.
-5. **Cross-chain step** — basic `yield`/`resume` pattern; works but callers should
-   validate target-chain is not empty (enforce already present).
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard "token-gov"` | Replace with deployed multi-sig keyset |
+| `DEBIT` | internal | **sender's stored account guard** | The authorization for every outgoing transfer |
+| `CREDIT` | internal | weak-body | Safe: only acquired composed under `DEBIT`/`GOV` paths |
+| `TRANSFER` | `@managed amount` | composes `DEBIT`+`CREDIT` | Auto-emits event on acquisition |
+| `TRANSFER_XCHAIN` | `@managed amount` (one-shot mgr) | composes `DEBIT` | Cross-chain step 0 |
+| `TRANSFER_XCHAIN_RECD` | `@event` | — | Emitted on step 1 receipt |
+| `ROTATE` | `@managed` one-shot | old guard enforced in `rotate` | Principal accounts cannot rotate away |
+| `MINT` | `@event` weak-body | acquired only under `GOV` | Supply transparency |
 
-### Risk Profile
+## Risk profile (v0.2)
 
 | Risk | Level | Notes |
 |---|---|---|
-| Reentrancy | Low | No external calls within caps; `require-capability` guards all internal ops |
-| Overflow | Low | `decimal` type with `enforce-unit` on precision |
-| Authorization bypass | Low | All write paths guarded by `DEBIT`/`CREDIT` |
-| Keyset dependency | Medium | `token-gov` must be defined before deployment |
+| Authorization bypass | Low | Sender guard enforced in `DEBIT` on all debit paths; regression tests in CI |
+| Account squatting | Low | `enforce-reserved` on both creation paths |
+| Supply inflation | Low | Only `GOV`-gated `mint`; event-audited |
+| Reentrancy | Low | No external module calls in any capability or write path |
+| Keyset dependency | Medium | `token-gov` must be defined pre-deploy; template ships REPL-style unqualified name — **must** be namespace-qualified for on-chain use |
+| Cross-chain lifecycle | Medium | Step 1 (SPV resume) is untestable in the REPL — devnet validation is mandatory before production (see README checklist) |
 
-### Recommendations for Production Use
+## Independent review (pact-auditor, 2026-07-05)
 
-1. Replace `"token-gov"` keyset reference with a deployed, multi-sig keyset.
-2. Add rate limiting or supply-control capabilities for minting.
-3. Run test suite against the full KDA sandbox (`kadena_repl_sandbox/kda-env/init.repl`)
-   to verify interface compliance before deployment.
-4. Add `@event` annotation to `TRANSFER` when deploying to mainnet for off-chain indexing.
+An independent audit pass (fresh-context reviewer, no implementation history)
+walked the full capability tree, ran 11 adversarial REPL probes plus the shipped
+suite, and cross-checked every debit/credit/rotate/mint/cross-chain path line-by-line
+against `coin-v6`. **Verdict: GO at `self-reviewed`. Zero CRITICAL / HIGH / MEDIUM
+findings.** No third-party-exploitable path exists; the read-before-enforce pattern
+is applied consistently (node-safe); both managed-cap managers are correct.
 
-## Audit Date
+Three LOW findings were raised and **all three fixed in this same version** before release:
 
-Community review: 2026-03-02.
-Status: **self-reviewed** — documented author self-review; pending independent security audit.
+| # | Finding | Fix applied |
+|---|---------|-------------|
+| L1 | `mint` did not emit the ecosystem-standard `(TRANSFER "" account amount)` — indexers reconstructing balances from fungible-v2 events would under-count supply. | `mint` now emits `TRANSFER "" account amount` alongside `MINT`. Asserted in suite. |
+| L2 | Cross-chain step 0 would debit then lock funds forever if the `k:` receiver's guard mismatched (uncompletable defpact). | Step 0 now `enforce-reserved`s the receiver before any state change; fails fast. Regression-tested. |
+| L3 | README did not warn that upgrading with in-flight cross-chain transfers requires blessing the old module hash. | Added to the deployment checklist. |
+
+INFO items (governance omnipotence, hardcoded chain ids, REPL-only keyset name,
+`@model` non-enforcement on 5.4ce, no burn) are inherent template characteristics
+and documented in README/AUDIT.
+
+## What self-reviewed means here
+
+Reviewed by the template's own maintainers against the PCO checklist, with the
+attack scenarios encoded as runnable regression tests. **Not independent.**
+Promotion to `community-reviewed` requires a second PCO reviewer sign-off;
+`independently-audited` requires a third-party report with a matching source hash
+(see `docs/CONTRACT_POLICIES.md` §3.1).
+
+## Reproduce the review
+
+```bash
+cd contracts/library/token-fungible/examples
+pact token-test.repl        # 31 assertions, includes attack + doomed-yield regressions
+```

--- a/contracts/library/token-fungible/README.md
+++ b/contracts/library/token-fungible/README.md
@@ -1,39 +1,58 @@
 # Token (fungible-v2 + fungible-xchain-v1)
 
-Minimal fungible token implementing `fungible-v2` and `fungible-xchain-v1` with capability-based security, suitable as a reference for Pact ecosystems.
+PCO library template: a fungible token implementing `fungible-v2` and `fungible-xchain-v1` with coin-contract-grade capability security. Copy it, adapt it, deploy it — this is a starting point for real projects, hardened to the same authorization model as the chain's native `coin` contract.
 
-## Highlights
-- Interface compliance for `fungible-v2` and `fungible-xchain-v1`.
-- Capability-based security: `DEBIT`, `CREDIT`, `TRANSFER`, `ROTATE`, and xchain caps.
-- Clear ledger model: `token-table` storing `balance` and `guard`.
-- Admin helpers: `fund` and `burn` gated by `GOV` for testing/provisioning.
+## Security model (what makes this safe to build on)
+
+- **Sender-guard enforcement in `DEBIT`** — every outgoing transfer (including cross-chain step 0) enforces the sender's stored account guard. Scoping the managed `TRANSFER` capability with your own signature is *not* enough to move someone else's funds. This is the exact pattern used by `coin` (see `registry/core/coin`).
+- **Managed `TRANSFER` / `TRANSFER_XCHAIN` caps** — amount-metered by manager functions; auto-emit events on acquisition (Pact 5 managed caps emit — no explicit `emit-event` needed or wanted on the direct path).
+- **Reserved-account protocol** — `k:`-prefixed accounts must be the principal of their guard (`enforce-reserved`), preventing account squatting; enforced at `create-account` *and* on implicit creation inside `credit`.
+- **Rotation safety** — `rotate` is authorized by the *old* guard under a one-shot managed `ROTATE` cap, and principal accounts cannot rotate away from their proper guard.
+- **Governed supply** — `mint` is `GOV`-gated and emits a `MINT` event. There is deliberately no unauthenticated supply path.
+- **Validation everywhere** — account length/charset bounds, positive amounts, 12-decimal precision (`enforce-unit`), valid Chainweb chain-id check on cross-chain targets.
+
+## Deployment checklist
+
+1. Rename the module and wrap it in your namespace (`(namespace "free")` or your own).
+2. Replace the `"token-gov"` keyset reference with your deployed, namespace-qualified governance keyset — **multi-sig strongly recommended**. (The unqualified name in the template works only in the REPL; chainweb requires namespaced keysets.)
+3. Adjust `VALID_CHAIN_IDS` if your target network does not have exactly chains 0–19.
+4. Deploy, then `(create-table token-table)` in the same transaction.
+5. Run the co-located REPL suite against your adapted module.
+6. **Validate on devnet before mainnet** — cross-chain step 1 (`resume`) requires SPV and cannot be proven in the bare REPL. A passing REPL run is *not* evidence for the cross-chain path.
+7. **Upgrading a deployed copy while cross-chain transfers are in flight?** The new module version must `(bless "<pre-upgrade-hash>")` — otherwise every pending step-1 resume fails with `Yield provenance does not match` until a later upgrade blesses the old hash. Get the hash via `(at 'hash (describe-module "<your.module>"))` *before* upgrading.
 
 ## Usage
-Define a `token-gov` keyset, then load the module and provision accounts:
 
 ```pact
-(define-keyset 'token-gov (read-keyset "token-gov"))
-(load "./token.pact")
-(with-capability (GOV) (fund "alice" 100.0))
-```
+;; governance mints initial supply
+(token.mint "k:<key>" (read-keyset "operator") 1000000.0)
 
-Transfers require the sender’s guard to be satisfied:
+;; transfers: sender signs, scoping the managed TRANSFER cap
+;; sigs: [{ key: <sender-key>, caps: [(token.TRANSFER "k:<sender>" "k:<receiver>" 25.0)] }]
+(token.transfer "k:<sender>" "k:<receiver>" 25.0)
 
-```pact
-(transfer "alice" "bob" 25.0)
+;; cross-chain: sender signs, scoping TRANSFER_XCHAIN; step 1 completes on the target chain via SPV
+(token.transfer-crosschain "k:<sender>" "k:<receiver>" (read-keyset "receiver") "1" 10.0)
 ```
 
 ## Testing
-See `examples/token-test.repl` for a runnable REPL script that:
-- Initializes standard interfaces and guards.
-- Sets up keysets for `alice`, `bob`, and governance.
-- Runs positive tests (transfers, transfer-create, details, precision).
-- Runs negative tests (insufficient funds, same account, missing signer).
-- Validates capability enforcement and guard rotation.
 
-## Notes
-- Cross-chain transfer (`transfer-crosschain`) is provided as a skeleton (yield/credit), SPV validation left for network integration.
-- Precision is enforced at 12 decimal places by default.
+`examples/token-test.repl` is **self-contained** — it loads the `fungible-v2` / `fungible-xchain-v1` interfaces from this repository's `registry/` tree; no external sandbox needed:
+
+```bash
+cd contracts/library/token-fungible/examples && pact token-test.repl
+```
+
+The suite covers: account creation and duplicate rejection, governed mint (and mint-without-governance rejection), transfers and `transfer-create`, **the drain-attack regression** (attacker scoping `TRANSFER`/`TRANSFER_XCHAIN` for someone else's account must fail on the sender guard), input validation (funds, self-transfer, precision, account length), `k:` squatting prevention, rotation authorization and principal-rotation protection, and cross-chain step-0 guards. CI runs this suite as a blocking check.
+
+## Known limits
+
+- Cross-chain step 1 is devnet/mainnet-only (SPV). Test it there before shipping.
+- Cross-chain step 0 fails fast on a `k:` receiver whose guard doesn't match (prevents locking funds in an uncompletable defpact). It *cannot* detect the one remaining doomed case: a receiver account that already exists on the target chain with a different guard — step 1 will fail on the guard mismatch. Verify the receiver's target-chain guard before large transfers.
+- No burn function — add one gated by your governance if your tokenomics need it.
+- The governance keyset has absolute power (unlimited mint, module upgrade). That is inherent to a keyset-governed template — use multi-sig and consider a supply-cap constant for your tokenomics.
+- `@model` annotations are documentation: Pact 5.4ce has no `verify` native.
 
 ## License
+
 Apache-2.0

--- a/contracts/library/token-fungible/examples/token-test.repl
+++ b/contracts/library/token-fungible/examples/token-test.repl
@@ -1,83 +1,207 @@
-(load "../../../../kadena_repl_sandbox/kda-env/init.repl")
+;; token-test.repl — PCO library template test suite
+;;
+;; Self-contained: loads the fungible-v2 / fungible-xchain-v1 interfaces from
+;; this repository's registry tree. No external sandbox required.
+;;
+;; LIMIT: cross-chain step 1 (resume) needs an SPV proof and CANNOT be proven
+;; in the bare REPL — only step 0 and its guards are tested here. Prove the
+;; full cross-chain lifecycle on devnet before any production deployment.
 
-(env-keys ["gov","alice-key","bob-key","carol-key"]) 
-
-(begin-tx)
-
-; Keysets for testing
+;; ---------------------------------------------------------------------------
+;; Setup: interfaces, keyset, module, table
+;; ---------------------------------------------------------------------------
 (env-data
-  {"token-gov": ["gov"],
-   "alice": ["alice-key"],
-   "bob": ["bob-key"],
-   "carol": ["carol-key"]})
+  { "token-gov": ["gov-key"]
+  , "alice": ["alice-key"]
+  , "bob": ["bob-key"]
+  , "carol": ["carol-key"]
+  , "attacker": ["attacker-key"] })
+(env-sigs [{"key": "gov-key", "caps": []}])
+(env-chain-data {"chain-id": "0"})
 
-(define-keyset 'token-gov (read-keyset "token-gov"))
-(define-keyset 'alice (read-keyset "alice"))
-(define-keyset 'bob (read-keyset "bob"))
-(define-keyset 'carol (read-keyset "carol"))
-
-; Load interfaces (done by init) and contract under test
+(begin-tx "setup")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(define-keyset "token-gov" (read-keyset "token-gov"))
 (load "../token.pact")
-
-; create storage table for the token module
 (create-table token-table)
-
-; Provision accounts and initial balance (seed via CREDIT)
-(with-capability (token.GOV)
-  (token.create-account "alice" (read-keyset 'alice))
-  (token.create-account "bob" (read-keyset 'bob)))
-
-(with-capability (token.CREDIT "alice")
-  (token.credit "alice" (read-keyset 'alice) 100.0))
-
 (commit-tx)
 
-; =====================
-; Positive unit tests
-; =====================
-(begin-tx)
+;; ---------------------------------------------------------------------------
+;; Account creation + governed mint
+;; ---------------------------------------------------------------------------
+(begin-tx "accounts-and-mint")
+(env-sigs [{"key": "gov-key", "caps": []}])
 
-(install-capability (token.TRANSFER "alice" "bob" 25.5))
+(expect "create alice" "alice" (token.create-account "alice" (read-keyset "alice")))
+(expect "create bob"   "bob"   (token.create-account "bob"   (read-keyset "bob")))
+
+;; insert on an existing key must fail (writes are illegal inside try — use expect-failure)
+(expect-failure "duplicate account rejected"
+  (token.create-account "alice" (read-keyset "alice")))
+
+(expect "mint 100 to alice" "CREDIT_OK"
+  (token.mint "alice" (read-keyset "alice") 100.0))
+(expect "alice balance after mint" 100.0 (token.get-balance "alice"))
+
+;; mint emits the ecosystem-standard TRANSFER "" event for indexer consistency
+(let ((names (map (at 'name) (env-events true))))
+  (expect "mint emits MINT event" true (contains "token.MINT" names))
+  (expect "mint emits TRANSFER-from-null event" true (contains "token.TRANSFER" names)))
+
+;; mint requires governance
+(env-sigs [{"key": "attacker-key", "caps": []}])
+(expect-failure "mint without governance key fails" "Keyset failure"
+  (token.mint "attacker-acct" (read-keyset "attacker") 1000000.0))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Happy-path transfers (managed TRANSFER cap, sender-guard enforced)
+;; ---------------------------------------------------------------------------
+(begin-tx "transfers")
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER "alice" "bob" 25.5)]}])
 (token.transfer "alice" "bob" 25.5)
-(format "Balances after transfer: alice={}, bob={}" [(token.get-balance "alice") (token.get-balance "bob")])
+(expect "alice debited" 74.5 (token.get-balance "alice"))
+(expect "bob credited" 25.5 (token.get-balance "bob"))
 
-; 2) transfer-create Bob -> Carol (new account)
-(install-capability (token.TRANSFER "bob" "carol" 10.0))
-(token.transfer-create "bob" "carol" (keyset-ref-guard "carol") 10.0)
-(format "Balances post transfer-create: bob={}, carol={}" [(token.get-balance "bob") (token.get-balance "carol")])
+;; managed TRANSFER auto-emits an event on acquisition
+(expect "TRANSFER event emitted" true
+  (contains {"name": "token.TRANSFER", "params": ["alice" "bob" 25.5], "module-hash": (at 'hash (describe-module "token"))}
+    (env-events true)))
 
-; 3) Details and precision
-(token.details "alice")
-(token.precision)
+(env-sigs [{"key": "bob-key", "caps": [(token.TRANSFER "bob" "carol" 10.0)]}])
+(token.transfer-create "bob" "carol" (read-keyset "carol") 10.0)
+(expect "carol credited via transfer-create" 10.0 (token.get-balance "carol"))
 
+(expect "details shape" {"account": "alice", "balance": 74.5, "guard": (read-keyset "alice")}
+  (token.details "alice"))
+(expect "precision" 12 (token.precision))
 (commit-tx)
 
-; =====================
-; Negative & security tests
-; =====================
-(begin-tx)
+;; ---------------------------------------------------------------------------
+;; SECURITY REGRESSION — the drain attack the v0.1 template allowed
+;; An attacker signs with their OWN key, scoping the managed TRANSFER cap for
+;; someone else's account. DEBIT must enforce the SENDER's guard and refuse.
+;; ---------------------------------------------------------------------------
+(begin-tx "attack-unauthorized-transfer")
+(env-sigs [{"key": "attacker-key", "caps": [(token.TRANSFER "alice" "carol" 74.5)]}])
+(expect-failure "attacker cannot drain alice (sender guard enforced in DEBIT)"
+  "Keyset failure"
+  (token.transfer "alice" "carol" 74.5))
+(expect "alice balance untouched" 74.5 (token.get-balance "alice"))
 
-; 4) Insufficient funds should fail and not alter balances
-(let ((a-before (token.get-balance "alice"))
-      (b-before (token.get-balance "bob")))
-  (format "Insufficient funds error triggered: {}"
-    [(try true (install-capability (token.TRANSFER "alice" "bob" 10000.0)) (token.transfer "alice" "bob" 10000.0))])
-  (format "Balances unchanged: {}"
-    [(and (= a-before (token.get-balance "alice"))
-          (= b-before (token.get-balance "bob")))]))
-
-; 5) Same sender/receiver should fail
-(try true (install-capability (token.TRANSFER "alice" "alice" 1.0)) (token.transfer "alice" "alice" 1.0))
-
-; 6) Missing signer (attempt debit without alice key)
-(env-keys ["gov","bob"]) ; drop alice key
-(let ((b1 (token.get-balance "bob")))
-  (format "Unauthorized debit blocked: {}"
-    [(try true (install-capability (token.TRANSFER "alice" "bob" 1.0)) (token.transfer "alice" "bob" 1.0))])
-  (format "Bob unchanged: {}" [(= b1 (token.get-balance "bob"))]))
-
-; restore keys for remaining tests
-(env-keys ["gov","alice","bob"]) 
+;; same attack via transfer-create (own scoped cap tuple — still hits the guard)
+(env-sigs [{"key": "attacker-key", "caps": [(token.TRANSFER "alice" "attacker-acct" 74.5)]}])
+(expect-failure "attacker cannot drain alice via transfer-create"
+  "Keyset failure"
+  (token.transfer-create "alice" "attacker-acct" (read-keyset "attacker") 74.5))
 (commit-tx)
 
-; No cross-chain tests in minimal token
+;; ---------------------------------------------------------------------------
+;; Input validation
+;; ---------------------------------------------------------------------------
+(begin-tx "validation")
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER "alice" "bob" 10000.0)]}])
+(expect-failure "insufficient funds" "Insufficient funds"
+  (token.transfer "alice" "bob" 10000.0))
+
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER "alice" "alice" 1.0)]}])
+(expect-failure "same sender and receiver" "sender cannot be the receiver"
+  (token.transfer "alice" "alice" 1.0))
+
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER "alice" "bob" 0.0000000000001)]}])
+(expect-failure "precision violation" "violates minimum precision"
+  (token.transfer "alice" "bob" 0.0000000000001))
+
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER "alice" "ab" 1.0)]}])
+(expect-failure "account too short" "min length"
+  (token.transfer-create "alice" "ab" (read-keyset "bob") 1.0))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Reserved (k:) account protocol — squatting prevention
+;; ---------------------------------------------------------------------------
+(begin-tx "reserved-accounts")
+(env-sigs [{"key": "gov-key", "caps": []}])
+
+;; squat attempt: k:<alice-key> account with the ATTACKER's guard must fail
+(expect-failure "k: account with mismatched guard rejected"
+  "Single-key account protocol violation"
+  (token.create-account "k:alice-key" (read-keyset "attacker")))
+
+;; correct principal: account name derived from the guard itself
+(let ((alice-principal (create-principal (read-keyset "alice"))))
+  (expect "principal account created" alice-principal
+    (token.create-account alice-principal (read-keyset "alice"))))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Guard rotation (managed ROTATE, old guard authorizes)
+;; ---------------------------------------------------------------------------
+(begin-tx "rotation-happy")
+;; happy path: carol rotates to bob's guard — carol's key scoped to ROTATE
+(env-sigs [{"key": "carol-key", "caps": [(token.ROTATE "carol")]}])
+(expect "carol rotates guard" "carol" (token.rotate "carol" (read-keyset "bob")))
+(commit-tx)
+
+(begin-tx "rotation-old-guard-rejected")
+;; carol's OLD key can no longer rotate back (guard is now bob's).
+;; Fresh tx: the one-shot ROTATE install is per transaction.
+(env-sigs [{"key": "carol-key", "caps": [(token.ROTATE "carol")]}])
+(expect-failure "old guard no longer authorizes rotation" "Keyset failure"
+  (token.rotate "carol" (read-keyset "carol")))
+(rollback-tx)
+
+(begin-tx "rotation-principal-protected")
+;; principal accounts must not rotate away from their proper guard
+(let ((alice-principal (create-principal (read-keyset "alice"))))
+  (env-sigs [{"key": "alice-key", "caps": [(token.ROTATE alice-principal)]}])
+  (expect-failure "principal account rotation blocked"
+    "unsafe for principal accounts"
+    (token.rotate alice-principal (read-keyset "bob"))))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Cross-chain: step-0 guards (full lifecycle is devnet-only — no SPV in REPL)
+;; ---------------------------------------------------------------------------
+(begin-tx "xchain-attack")
+;; unauthorized: bob tries to cross-chain alice's funds
+(env-sigs [{"key": "bob-key", "caps": [(token.TRANSFER_XCHAIN "alice" "bob" 10.0 "1")]}])
+(expect-failure "attacker cannot start cross-chain debit of alice"
+  "Keyset failure"
+  (token.transfer-crosschain "alice" "bob" (read-keyset "bob") "1" 10.0))
+(rollback-tx)
+
+(begin-tx "xchain-same-chain")
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER_XCHAIN "alice" "bob" 10.0 "0")]}])
+(expect-failure "same-chain cross-chain transfer rejected"
+  "cannot run cross-chain transfers to the same chain"
+  (token.transfer-crosschain "alice" "bob" (read-keyset "bob") "0" 10.0))
+(rollback-tx)
+
+(begin-tx "xchain-bad-chain")
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER_XCHAIN "alice" "bob" 10.0 "99")]}])
+(expect-failure "invalid target chain rejected"
+  "not a valid chainweb chain id"
+  (token.transfer-crosschain "alice" "bob" (read-keyset "bob") "99" 10.0))
+(rollback-tx)
+
+(begin-tx "xchain-doomed-yield-failfast")
+;; a k: receiver with a mismatched guard must be rejected BEFORE the debit —
+;; otherwise the funds would lock forever in an uncompletable defpact (step 1
+;; would fail on enforce-reserved with no way to roll back step 0)
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER_XCHAIN "alice" "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" 5.0 "1")]}])
+(expect-failure "k: receiver with mismatched guard fails fast at step 0"
+  "Single-key account protocol violation"
+  (token.transfer-crosschain "alice" "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (read-keyset "bob") "1" 5.0))
+(expect "alice balance untouched by doomed-yield attempt" 74.5 (token.get-balance "alice"))
+(rollback-tx)
+
+(begin-tx "xchain-step0")
+;; authorized step 0: debit happens on the source chain, details are yielded
+(env-sigs [{"key": "alice-key", "caps": [(token.TRANSFER_XCHAIN "alice" "bob" 10.0 "1")]}])
+(token.transfer-crosschain "alice" "bob" (read-keyset "bob") "1" 10.0)
+(expect "alice debited by step 0" 64.5 (token.get-balance "alice"))
+(commit-tx)
+
+"All token-fungible template tests passed"

--- a/contracts/library/token-fungible/metadata.yaml
+++ b/contracts/library/token-fungible/metadata.yaml
@@ -1,11 +1,11 @@
-name: 'Token (fungible-v2)'
+name: 'Token (fungible-v2 + fungible-xchain-v1)'
 slug: 'token-fungible'
-version: '0.1.0'
+version: '0.2.0'
 repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
 license: 'Apache-2.0'
 authors:
   - name: 'Pact Community Organization'
-    email: 'maintainers@pact.org'
+    email: 'info@pact-community.org'
 audit_status: 'self-reviewed'
-tags: ['token', 'fungible', 'reference']
-keywords: ['pact', 'smart-contract', 'fungible-v2', 'xchain']
+tags: ['token', 'fungible', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'fungible-v2', 'fungible-xchain-v1', 'xchain']

--- a/contracts/library/token-fungible/token.pact
+++ b/contracts/library/token-fungible/token.pact
@@ -1,9 +1,17 @@
 (module token GOV
 
-  @doc "Minimal fungible token implementing fungible-v2 and fungible-xchain-v1.\n  \n  This module is designed as a neutral, reference-friendly implementation\n  focusing on clarity, capability-based security, and interface compliance."
+  @doc "PCO library template: fungible token implementing fungible-v2 and     \
+  \fungible-xchain-v1.                                                        \
+  \                                                                           \
+  \Deployment checklist (see README.md):                                      \
+  \  1. Rename the module and wrap it in your namespace.                      \
+  \  2. Replace the 'token-gov' keyset reference with your deployed,          \
+  \     namespace-qualified governance keyset (multi-sig recommended).        \
+  \  3. Run the co-located REPL suite, then validate on devnet -              \
+  \     cross-chain steps CANNOT be proven in the bare REPL (no SPV)."
 
   (implements fungible-v2)
-
+  (implements fungible-xchain-v1)
 
   ;; -----------------------------
   ;; Schema and Table
@@ -17,42 +25,52 @@
 
   (deftable token-table:{token-row})
 
-  ; details schema (match fungible-v2)
-  ; details schema not needed; use interface type
+  ;; -----------------------------
+  ;; Constants
+  ;; -----------------------------
+
+  (defconst MINIMUM_PRECISION 12
+    "Minimum allowed precision for token amounts")
+
+  (defconst MINIMUM_ACCOUNT_LENGTH 3
+    "Minimum account name length")
+
+  (defconst MAXIMUM_ACCOUNT_LENGTH 256
+    "Maximum account name length")
+
+  (defconst VALID_CHAIN_IDS (map (int-to-str 10) (enumerate 0 19))
+    "List of all valid Chainweb chain ids")
 
   ;; -----------------------------
   ;; Governance and Internal Caps
   ;; -----------------------------
 
   (defcap GOV ()
-    @doc "Admin governance capability for restricted operations"
+    @doc "Module governance. Replace 'token-gov' with your deployed keyset."
     (enforce-guard (keyset-ref-guard "token-gov")))
 
   (defcap DEBIT (sender:string)
-    @doc "Restricts debiting to valid sender"
-    (enforce (!= sender "") "invalid sender"))
+    @doc "Internal debit permission. Enforces the SENDER's account guard - \
+         \this is the authorization for every outgoing transfer."
+    (enforce (!= sender "") "valid sender")
+    (let ((sender-guard (at 'guard (read token-table sender))))
+      (enforce-guard sender-guard)))
 
   (defcap CREDIT (receiver:string)
-    @doc "Receiver crediting constraint"
-    (enforce (!= receiver "") "invalid receiver"))
+    @doc "Internal credit permission. Safe as a weak-body cap: only ever \
+         \acquired composed under DEBIT/GOV-guarded paths."
+    (enforce (!= receiver "") "valid receiver"))
 
   (defcap ROTATE (account:string)
-    @doc "Managed capability for guard rotation"
+    @doc "Autonomously managed one-shot capability for guard rotation. \
+         \Authorization is the old guard, enforced in rotate."
     @managed
     true)
 
-  ;; -----------------------------
-  ;; Constants and Utilities
-  ;; -----------------------------
-
-  (defconst MIN_PRECISION 12)
-
-  (defun enforce-unit:bool (amount:decimal)
-    @doc "Enforce minimum decimal precision"
-    (enforce (= (floor amount MIN_PRECISION) amount)
-      (format "Amount violates minimum precision: {}" [amount])))
-
-  (defun precision:integer () MIN_PRECISION)
+  (defcap MINT (account:string amount:decimal)
+    @doc "Mint event. Weak-body: only acquired under GOV in mint."
+    @event
+    true)
 
   ;; -----------------------------
   ;; Interface Capabilities (Managers)
@@ -72,14 +90,76 @@
         (format "TRANSFER exceeded for balance {}" [managed]))
       newbal))
 
-  ; No cross-chain in minimal token
+  (defcap TRANSFER_XCHAIN:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      target-chain:string )
+    @managed amount TRANSFER_XCHAIN-mgr
+    (enforce-unit amount)
+    (enforce (> amount 0.0) "Cross-chain transfers require a positive amount")
+    (compose-capability (DEBIT sender)))
+
+  (defun TRANSFER_XCHAIN-mgr:decimal (managed:decimal requested:decimal)
+    (enforce (>= managed requested)
+      (format "TRANSFER_XCHAIN exceeded for balance {}" [managed]))
+    0.0)
+
+  (defcap TRANSFER_XCHAIN_RECD:bool
+    ( sender:string
+      receiver:string
+      amount:decimal
+      source-chain:string )
+    @event
+    true)
+
+  ;; -----------------------------
+  ;; Utilities
+  ;; -----------------------------
+
+  (defun enforce-unit:bool (amount:decimal)
+    @doc "Enforce minimum decimal precision"
+    (enforce (= (floor amount MINIMUM_PRECISION) amount)
+      (format "Amount violates minimum precision: {}" [amount])))
+
+  (defun precision:integer () MINIMUM_PRECISION)
+
+  (defun validate-account (account:string)
+    @doc "Enforce account name length bounds and latin-1 charset."
+    (enforce (is-charset CHARSET_LATIN1 account)
+      (format "Account does not conform to the token contract charset: {}" [account]))
+    (let ((account-length (length account)))
+      (enforce (>= account-length MINIMUM_ACCOUNT_LENGTH)
+        (format "Account name does not conform to the min length requirement: {}" [account]))
+      (enforce (<= account-length MAXIMUM_ACCOUNT_LENGTH)
+        (format "Account name does not conform to the max length requirement: {}" [account]))))
+
+  (defun check-reserved:string (account:string)
+    @doc "Return reserved-name protocol prefix ('k' for 'k:...'), or ''."
+    (let ((pfx (take 2 account)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account name protocols: a 'k:'-prefixed account \
+         \must be the principal of its guard (prevents account squatting)."
+    (if (validate-principal guard account)
+      true
+      (let ((r (check-reserved account)))
+        (if (= r "")
+          true
+          (if (= r "k")
+            (enforce false "Single-key account protocol violation")
+            (enforce false
+              (format "Reserved protocol guard violation: {}" [r])))))))
 
   ;; -----------------------------
   ;; Core Ledger Ops
   ;; -----------------------------
 
   (defun get-balance:decimal (account:string)
-    (at 'balance (read token-table account)))
+    (with-read token-table account
+      { 'balance := balance }
+      balance))
 
   (defun details:object{fungible-v2.account-details} (account:string)
     (with-read token-table account
@@ -87,73 +167,150 @@
       { 'account: account, 'balance: bal, 'guard: g }))
 
   (defun create-account:string (account:string guard:guard)
-    (enforce (!= account "") "empty account")
+    (validate-account account)
+    (enforce-reserved account guard)
     (insert token-table account { 'balance: 0.0, 'guard: guard })
     account)
 
   (defun rotate:string (account:string new-guard:guard)
     (with-capability (ROTATE account)
-      (enforce-guard (at 'guard (read token-table account)))
-      (update token-table account { 'guard: new-guard })
+      ; principal accounts must not rotate away from their proper guard
+      (enforce (or (not (is-principal account))
+                   (validate-principal new-guard account))
+        "It is unsafe for principal accounts to rotate their guard")
+      (with-read token-table account
+        { 'guard := old-guard }
+        (enforce-guard old-guard)
+        (update token-table account { 'guard: new-guard }))
       account))
 
   (defun debit:string (account:string amount:decimal)
+    @doc "Internal. Callable only under DEBIT (sender-guard enforced there)."
     (require-capability (DEBIT account))
+    (validate-account account)
     (enforce (> amount 0.0) "debit amount must be positive")
     (enforce-unit amount)
-    (with-read token-table account { 'balance := bal }
-      (enforce (<= amount bal) "Insufficient funds")
-      (update token-table account { 'balance: (- bal amount) })
+    (with-read token-table account
+      { 'balance := balance }
+      (enforce (<= amount balance) "Insufficient funds")
+      (update token-table account { 'balance: (- balance amount) })
       "DEBIT_OK"))
 
   (defun credit:string (account:string guard:guard amount:decimal)
+    @doc "Internal. Callable only under CREDIT."
     (require-capability (CREDIT account))
+    (validate-account account)
     (enforce (> amount 0.0) "credit amount must be positive")
     (enforce-unit amount)
-    (with-default-read token-table account { 'balance: -1.0, 'guard: guard }
-      { 'balance := bal, 'guard := retg }
+    (with-default-read token-table account
+      { 'balance: -1.0, 'guard: guard }
+      { 'balance := balance, 'guard := retg }
+      ; never overwrite an existing guard with the caller-supplied one
       (enforce (= retg guard) "account guards do not match")
-      (let ((is-new (= bal -1.0)))
+      (let ((is-new
+             (if (= balance -1.0)
+                 (enforce-reserved account guard)
+               false)))
         (write token-table account
-          { 'balance: (if is-new amount (+ bal amount)), 'guard: retg })
+          { 'balance: (if is-new amount (+ balance amount)), 'guard: retg })
         "CREDIT_OK")))
 
   (defun transfer:string (sender:string receiver:string amount:decimal)
+    @model [ (property (> amount 0.0))
+             (property (!= sender receiver)) ]
+    (enforce (!= sender receiver) "sender cannot be the receiver of a transfer")
+    (validate-account sender)
+    (validate-account receiver)
+    (enforce (> amount 0.0) "transfer amount must be positive")
+    (enforce-unit amount)
     (with-capability (TRANSFER sender receiver amount)
       (debit sender amount)
-      (with-read token-table receiver { 'guard := g }
-        (credit receiver g amount))
-      "TRANSFER_OK"))
+      (with-read token-table receiver
+        { 'guard := g }
+        (credit receiver g amount))))
 
-  (defun transfer-create:string (sender:string receiver:string receiver-guard:guard amount:decimal)
+  (defun transfer-create:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      amount:decimal )
+    (enforce (!= sender receiver) "sender cannot be the receiver of a transfer")
+    (validate-account sender)
+    (validate-account receiver)
+    (enforce (> amount 0.0) "transfer amount must be positive")
+    (enforce-unit amount)
     (with-capability (TRANSFER sender receiver amount)
       (debit sender amount)
-      (credit receiver receiver-guard amount)
-      "TRANSFER_CREATE_OK"))
+      (credit receiver receiver-guard amount)))
 
-  ; Minimal cross-chain pact to satisfy interface requirements
+  ;; -----------------------------
+  ;; Cross-chain transfer
+  ;; -----------------------------
+  ;; NOTE: step 1 (resume) requires an SPV proof — full lifecycle is
+  ;; provable ONLY on devnet/mainnet, never in the bare REPL.
+
   (defschema crosschain-schema
+    @doc "Schema for yielded value in cross-chain transfers"
     receiver:string
     receiver-guard:guard
-    amount:decimal)
+    amount:decimal
+    source-chain:string)
 
-  (defpact transfer-crosschain:string (sender:string receiver:string receiver-guard:guard target-chain:string amount:decimal)
+  (defpact transfer-crosschain:string
+    ( sender:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string
+      amount:decimal )
     (step
-      (with-capability (DEBIT sender)
-        (enforce (!= target-chain "") "empty target-chain")
+      (with-capability (TRANSFER_XCHAIN sender receiver amount target-chain)
+        (validate-account sender)
+        (validate-account receiver)
+        ; fail fast: a k: receiver with a mismatched guard would debit here,
+        ; then fail forever at step 1's enforce-reserved (funds locked in an
+        ; uncompletable defpact). Reject before any state change.
+        (enforce-reserved receiver receiver-guard)
+        (enforce (!= "" target-chain) "empty target-chain")
+        (enforce (!= (at 'chain-id (chain-data)) target-chain)
+          "cannot run cross-chain transfers to the same chain")
         (enforce (> amount 0.0) "transfer quantity must be positive")
         (enforce-unit amount)
+        (enforce (contains target-chain VALID_CHAIN_IDS)
+          "target chain is not a valid chainweb chain id")
         (debit sender amount)
-        (let ((x:object{crosschain-schema} {'receiver: receiver, 'receiver-guard: receiver-guard, 'amount: amount}))
-          (yield x target-chain))))
+        (emit-event (TRANSFER sender "" amount))
+        (let
+          ((crosschain-details:object{crosschain-schema}
+            { 'receiver: receiver
+            , 'receiver-guard: receiver-guard
+            , 'amount: amount
+            , 'source-chain: (at 'chain-id (chain-data))
+            }))
+          (yield crosschain-details target-chain))))
     (step
-      (resume {'receiver:= receiver, 'receiver-guard:= receiver-guard, 'amount:= amount}
+      (resume
+        { 'receiver := receiver
+        , 'receiver-guard := receiver-guard
+        , 'amount := amount
+        , 'source-chain := source-chain
+        }
+        (emit-event (TRANSFER "" receiver amount))
+        (emit-event (TRANSFER_XCHAIN_RECD "" receiver amount source-chain))
         (with-capability (CREDIT receiver)
           (credit receiver receiver-guard amount)))))
 
   ;; -----------------------------
-  ;; Admin helpers (for testing / provisioning)
+  ;; Supply (governance-gated)
   ;; -----------------------------
 
-  ; Admin funding helper removed per requirements
+  (defun mint:string (account:string guard:guard amount:decimal)
+    @doc "Create AMOUNT new tokens for ACCOUNT. Governance-gated; emits MINT \
+         \plus the ecosystem-standard (TRANSFER \"\" account amount) so       \
+         \indexers reconstructing balances from fungible-v2 events stay      \
+         \consistent (coin supply-increase pattern)."
+    (with-capability (GOV)
+      (with-capability (MINT account amount)
+        (with-capability (CREDIT account)
+          (emit-event (TRANSFER "" account amount))
+          (credit account guard amount)))))
 )

--- a/docs/index.json
+++ b/docs/index.json
@@ -8,7 +8,7 @@
   "authors": [
     {
       "name": "Pact Community Organization",
-      "email": "maintainers@pact.org"
+      "email": "info@pact-community.org"
     }
   ],
   "audit_status": "self-reviewed",
@@ -25,27 +25,29 @@
 }
 ,
 {
-  "name": "Token (fungible-v2)",
+  "name": "Token (fungible-v2 + fungible-xchain-v1)",
   "slug": "token-fungible",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
   "license": "Apache-2.0",
   "authors": [
     {
       "name": "Pact Community Organization",
-      "email": "maintainers@pact.org"
+      "email": "info@pact-community.org"
     }
   ],
   "audit_status": "self-reviewed",
   "tags": [
     "token",
     "fungible",
-    "reference"
+    "template",
+    "library"
   ],
   "keywords": [
     "pact",
     "smart-contract",
     "fungible-v2",
+    "fungible-xchain-v1",
     "xchain"
   ]
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ _Generated from `contracts/**/metadata.yaml`._
 | Name | Slug | Version | Audit Status | Tags |
 |------|------|---------|--------------|------|
 | Hello World | hello-world | 1.0.0 | self-reviewed | hello-world, tutorial, basic |
-| Token (fungible-v2) | token-fungible | 0.1.0 | self-reviewed | token, fungible, reference |
+| Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
 
 ## Registry — KIP Standards (`registry/kip/`)
 


### PR DESCRIPTION
## Summary

Turns the fungible-token library template into a deployable, coin-grade reference and **fixes a CRITICAL authorization flaw** the v0.1 template carried. First WS3 flagship template; establishes the quality bar every future library entry is held to.

## The CRITICAL fix

v0.1's `DEBIT` capability only checked `sender != ""` — it **never enforced the sender's account guard**. On-chain, any signer who scoped the managed `TRANSFER` capability could move **anyone's** funds. `transfer-crosschain` was worse (bare `DEBIT`, no managed cap at all). v0.1's own AUDIT.md rated authorization bypass "Low" — dangerously wrong.

**v0.2** enforces the sender's stored guard in `DEBIT` (coin pattern, read let-bound before `enforce-guard` so it is node-safe, not a REPL-only pass), and routes cross-chain step 0 through the managed `TRANSFER_XCHAIN` cap.

## What else changed

- **`fungible-xchain-v1`** now actually implemented (was `@doc`-claimed only).
- **Reserved-account protocol** (`enforce-reserved`) at `create-account` and implicit creation in `credit` — prevents `k:` squatting.
- **Account validation** (length/charset), **governed `mint`** with `MINT` + ecosystem-standard `TRANSFER ""` events, corrected **managed `ROTATE`** (old guard authorizes; principals can't rotate away).

## Independent audit

A fresh-context `pact-auditor` pass walked the full capability tree, ran 11 adversarial REPL probes, and cross-checked every debit/credit/rotate/mint/cross-chain path line-by-line against `coin-v6`. **Verdict: GO at `self-reviewed`, zero CRITICAL/HIGH/MEDIUM.** Three LOW findings were all fixed in this version (mint `TRANSFER` event; step-0 fail-fast on doomed `k:` yields; bless-on-upgrade documentation). Full findings recorded in the entry's `AUDIT.md`.

## Tests + tooling

- `token-test.repl` rewritten: self-contained (loads the registry interfaces — no external sandbox), **31 assertions** including both drain-attack regressions and the doomed-yield fast-fail. The v0.1 suite used invalid 3-argument `(try ...)` and exercised no attack path.
- `hello-world-test.repl` rewritten from assertion-free trace output into real `expect`/`expect-failure` coverage (including non-admin write rejection).
- **CI**: new **blocking** step runs every `library/*.repl` suite.
- metadata → `0.2.0`; `AUDIT.md` permanently records the v0.1 flaw and the auditor verdict.

## Verification

- Both library suites pass locally (`pact <suite>.repl`, exit 0); token suite = 31 assertions, 0 failures.
- Module loads clean with the registry interfaces present.
- `validate_contract.sh` passes the library gate; full catalog validation green (32/32); index regenerated.

> Cross-chain step 1 (SPV resume) is devnet-only and untestable in the bare REPL — the suite covers step-0 guards; the README mandates devnet validation before production.