### PR TITLE
feat(library): add drain-defended gas-station template

### DIFF
--- a/contracts/library/gas-station/AUDIT.md
+++ b/contracts/library/gas-station/AUDIT.md
@@ -1,0 +1,132 @@
+# AUDIT — library/gas-station
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `gas-station` (namespace: project-specific) |
+| **Version** | 1.0.0 |
+| **Audit Status** | self-reviewed |
+| **Category** | PCO Library Template |
+| **Source** | PCO-authored reference implementation |
+| **Implements** | `gas-payer-v1` |
+| **Last review** | 2026-07-05 |
+
+## Purpose
+
+Deployable template for a gas station that funds users' gas from an on-chain,
+sponsor-controlled allowlist under strict per-transaction and per-user bounds.
+
+## Design history: why this is allowlist-based, not code-introspecting
+
+The first draft of this template used the common pattern of inspecting the
+transaction's `exec-code` / `tx-type` via `read-msg` to fund only calls to a
+named module. An independent `pact-auditor` pass **rejected it (NO-GO) with a
+CONFIRMED CRITICAL drain**, and the finding was reproduced:
+
+- `read-msg` returns the mutable tx `data` payload, which is **not bound** to the
+  code the transaction executes (the gas-station-design skill flags `read-msg`
+  keys as project-defined convention, not enforced introspection).
+- A single `exec-code` string carrying two top-level forms —
+  `"(free.my-dapp.ping) (coin.transfer \"station\" \"attacker\" 9999.0)"` —
+  passed the "one list element + prefix match" check and was **approved** by the
+  station (verified: `GAS_PAYER` returned success). The station would have funded
+  an attacker-chosen operation.
+
+String-prefix allowlisting cannot deliver a drain guarantee, so the template was
+**redesigned**: authorization now comes from a governance-controlled on-chain
+allowlist (`enroll-user`), and the executable path contains **no `read-msg`**.
+
+A **second** independent auditor pass on that redesign returned another **NO-GO**
+with a fresh CRITICAL, all three findings now fixed:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| F1 | **CRITICAL** | The price/limit bounds and cap accounting used the signer-supplied `GAS_PAYER` **arguments**, which are not bound to the transaction's real gas. An attacker naming an enrolled user could pass tiny decoy args while setting a huge actual gas limit, draining the station past every bound at ~zero recorded cost. | `GAS_PAYER` now reads `(chain-data)` `gas-price`/`gas-limit` — the amounts coin actually debits — and bounds/accounts against **those**, ignoring the args for money math. Mirrors `flux-gas-station`'s `enforce-below-or-at-gas-*`. Regression-tested (`F1-drain-*`). |
+| F2 | MEDIUM | `user` was not authenticated — anyone naming an enrolled user could spend that user's budget on arbitrary transactions. | Each enrollment stores a `guard`; `GAS_PAYER` calls `enforce-guard` on it. Regression-tested (`F2-unauthenticated-user`). |
+| F3 | LOW | No events for enroll/disable/reset/withdraw/funding (weak audit trail). | `@event` caps `ENROLL`/`DISABLE`/`RESET`/`FUNDED`/`WITHDRAW` emitted on each path; asserted in suite. |
+
+A **third** pass on the fixed design returned **GO** at `self-reviewed` — all
+three prior findings verified genuinely closed, no drain path, zero
+CRITICAL/HIGH/MEDIUM. Its one LOW and the actionable INFO items were applied
+before release:
+
+- **LOW** — the governance keyset name was a literal duplicated in the `GOV` cap
+  and the station guard's withdraw branch; a deployer editing one but not the
+  other would split governance. Hoisted to a single `GOV_KEYSET` defconst
+  referenced by both.
+- **INFO** — added a defense-in-depth `(enforce (>= tx-max-cost 0.0) ...)` (an
+  on-chain-unreachable case, but it keeps `spent` provably monotonic).
+- **Test coverage** — added a positive funding test under a **scoped** signature
+  (the real wallet flow) and a `reset-user-spent` / `RESET` path test.
+
+The redesign is a stronger, enforceable guarantee at the cost of requiring the
+sponsor to enroll accounts (name + guard) explicitly.
+
+## Threat model & defenses
+
+| Vector | Defense | Test |
+|---|---|---|
+| Fund a non-sponsored account | Only enrolled + enabled users pass `GAS_PAYER` | `reject-non-enrolled`, `reject-disabled` |
+| Spend another user's budget by naming them | `enforce-guard` on the enrolled user's stored guard | `F2-unauthenticated-user` |
+| Pass tiny cap args but consume huge real gas | Bounds/accounting use **actual** `(chain-data)` gas, not args | `F1-drain-actual-gas-over-bound`, `F1-drain-actual-limit-over-bound` |
+| Zero/negative declared limit or price | canonical `gas-payer-v1` positivity checks | `reject-nonpositive-args` |
+| Exhaust the station via one user | per-user cumulative `cap` on `spent += actual-limit*actual-price` | `carol-second-fund-over-cap` |
+| Spend the station outside gas eval or governance | account guard requires (`coin.GAS` + `ALLOW_GAS`) OR the gov keyset | `guard-denies` |
+| Non-governance withdrawal | station guard's governance branch enforces `gas-station-gov` | `withdraw-requires-gov` |
+| Tamper the funded operation via tx `data` | **Not applicable** — no `read-msg` in the executable path | — (structural) |
+
+## Capability model
+
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard GOV_KEYSET` | Gates enroll/disable/reset/init/upgrade |
+| `GAS_PAYER` | `gas-payer-v1` | on-chain allowlist + bounds | Composes `ALLOW_GAS` **only after all checks pass** |
+| `ALLOW_GAS` | weak-body | — | Safe: composed only inside `GAS_PAYER`; not externally acquirable; required by the station guard |
+
+The station account guard (`gas-payer-guard-pred`) uses `enforce-one` over two
+branches: (1) `require-capability coin.GAS` **and** `require-capability ALLOW_GAS`
+(the gas-payment path), or (2) `enforce-guard` on the governance keyset (the
+withdrawal path). Neither branch is satisfiable by an unauthorized caller.
+
+## Node-safety
+
+The only table read in an authorization path is `with-read allowlist user` inside
+`GAS_PAYER`; it is bound (via `with-read`) before any `enforce`, so it is
+node-safe (the REPL-vs-node "table read inside enforce" trap does not apply). The
+static gate passes with 0 violations.
+
+## Risk profile
+
+| Risk | Level | Notes |
+|---|---|---|
+| Drain / unauthorized spend | Low | Allowlist + bounds + cap, all regression-tested; no code-introspection surface |
+| Reentrancy | Low | No external module calls in `GAS_PAYER`; `coin` calls only in GOV/guard-gated `init`/`withdraw` |
+| Governance dependency | Medium | `gas-station-gov` must be defined pre-deploy; template ships an unqualified REPL name — **must** be namespace-qualified on-chain |
+| End-to-end gas flow | Medium | REPL tests the policy + guard directly; coin buy/redeem wrapping validated on devnet |
+| Enrollment trust | By design | The station does not constrain which module an enrolled user calls; enrollment is the sponsor's trust boundary |
+
+## What self-reviewed means here
+
+Reviewed by the template's maintainers against the PCO checklist, with all
+authorization/bounds/drain scenarios encoded as runnable regression tests, across
+**three independent auditor passes** — the first two drove full redesigns away
+from two distinct CRITICAL drains, and the third returned GO on the final code
+with the LOW/INFO items applied.
+
+We keep the status at **`self-reviewed`** rather than `community-reviewed`
+deliberately: the auditor passes were automated fresh-context reviews by the same
+tooling maintained alongside this template, not a review by an independent second
+PCO maintainer, and — critically — the on-chain `buy-gas`/`redeem-gas` wrapping
+and the scoped-signature authentication path are behaviors the bare REPL
+**cannot** prove. A **mandatory devnet end-to-end run** (README deployment step 6)
+is the remaining evidence gate before any production claim. `independently-audited`
+additionally requires a third-party report with a matching source hash
+(`docs/CONTRACT_POLICIES.md` §3.1).
+
+## Reproduce the review
+
+```bash
+cd contracts/library/gas-station/examples
+pact gas-station-test.repl   # 30 assertions
+```

--- a/contracts/library/gas-station/README.md
+++ b/contracts/library/gas-station/README.md
@@ -1,0 +1,77 @@
+# Gas Station (allowlist-based)
+
+PCO library template: an autonomous coin account that pays gas on behalf of users, enabling **gasless UX**. Implements `gas-payer-v1`. A gas station holds spendable KDA, so the whole design problem is **drain defense** — this template solves it with an **on-chain, sponsor-controlled allowlist** plus strict per-transaction bounds.
+
+## Why not "allowlist the called module"?
+
+A common gas-station pattern inspects the transaction's `exec-code` / `tx-type` via `read-msg` and funds only calls to a specific module. **That is not a sound defense**, for two reasons:
+
+1. `read-msg` returns the transaction's mutable `data` payload, which is **not bound** to the code the transaction actually executes. A benign-looking `data` can accompany arbitrary code.
+2. Even if it were bound, a single code string can carry **multiple top-level forms** — `"(good.call) (coin.transfer station attacker 9999.0)"` passes a "single element, prefix matches" check and drains the station.
+
+So this template does **not** allowlist by inspecting tx code. It authorizes funding from state the sponsor controls on-chain.
+
+## What it actually guarantees
+
+The station funds a transaction's gas only if **all** hold:
+
+1. **The user is enrolled** — the sponsor has called `enroll-user` (governance-gated) with the user's account name **and a guard**.
+2. **The signer controls the user's guard** — `GAS_PAYER` calls `enforce-guard` on the stored guard, so merely *naming* an enrolled user is not enough (authentication).
+3. **The user is enabled** — not disabled via `disable-user`.
+4. **The ACTUAL gas is within bounds** — the station reads `(chain-data)` `gas-price`/`gas-limit` (the amounts coin actually debits) and enforces `≤ MAX_GAS_PRICE` / `≤ MAX_GAS_LIMIT`. **It does not trust the `GAS_PAYER` price/limit arguments for the money math** — those are signer-supplied and unbound to the real gas.
+5. **Within the user's cumulative cap** — each funding adds `actual-limit × actual-price` to the user's `spent`; a funding that would push `spent` past the user's `cap` is rejected.
+
+> **Why actual gas, not the cap arguments?** The `limit`/`price` passed to `GAS_PAYER` are chosen by the transaction signer and are not bound to the transaction's real gas. Bounding/accounting against them lets an attacker pass tiny decoy values while setting a huge real gas limit — draining the station past every bound. This template reads `chain-data` instead, mirroring the production `runonflux.flux-gas-station` (`enforce-below-or-at-gas-*`).
+
+What an enrolled user *does* with the funded gas is up to them — the station does not (and cannot soundly) constrain which module they call. If you need module-level constraints, enforce them in your dApp. **Enrollment (a named account + its guard) is your trust boundary.**
+
+## Security model
+
+The station account is a **principal backed by a capability guard**. Its guard predicate is satisfied by **either**:
+- the gas-payment path — `coin.GAS` (granted only by coin's gas machinery) **and** `ALLOW_GAS` (composed only inside `GAS_PAYER`, after all checks pass); or
+- **governance** — the `gas-station-gov` keyset, used by `withdraw` to recover residual funds.
+
+`ALLOW_GAS` is a weak-body internal cap that is not acquirable from outside the module, so gas can be released only through a policy-approved `GAS_PAYER`. There is no `read-msg` in the executable path.
+
+## Deployment checklist
+
+1. Wrap the module in your namespace; replace the `"gas-station-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig recommended**).
+2. Tune `MAX_GAS_PRICE`, `MAX_GAS_LIMIT`, and `DEFAULT_USER_CAP` to your traffic. Keep the limit well under the 150,000 gas per-transaction ceiling.
+3. Deploy, then call `(init)` **once** to create the station coin account (a second call aborts).
+4. **Fund** `GAS_STATION` with KDA (`get-station-account` returns its name); top it up as it is spent down.
+5. **Enroll users**: `(enroll-user "k:..." guard cap)` or `(enroll-user-default "k:..." guard)` — the guard authenticates the user at funding time. Disable with `(disable-user ...)`, reset a spend period with `(reset-user-spent ...)`. All emit events (`ENROLL`/`DISABLE`/`RESET`).
+6. Validate the end-to-end gas flow on **devnet** before mainnet.
+
+## Client usage
+
+The user's transaction sets the station as gas payer and signs a capability scoped to `GAS_PAYER`:
+
+- **Gas payer / sender**: the station account (`get-station-account`).
+- **Signed capability**: `(<your-ns>.gas-station.GAS_PAYER user limit price)`, signed with the **key that satisfies the user's enrolled guard** (authentication).
+
+If the user is not enrolled/enabled, the signer does not control the user's guard, or the **actual** gas exceeds the bounds/cap, the transaction is not funded.
+
+## Withdrawing residual funds
+
+`withdraw` recovers unspent KDA to a treasury account. The caller signs with the `gas-station-gov` key, scoping `(coin.TRANSFER GAS_STATION receiver amount)` — that signature both installs the managed transfer and satisfies the station guard's governance branch.
+
+## Testing
+
+`examples/gas-station-test.repl` is self-contained (loads `coin` + interfaces from `registry/`):
+
+```bash
+cd contracts/library/gas-station/examples && pact gas-station-test.repl
+```
+
+30 assertions. Every funding test sets the **real gas context** via `env-chain-data` and passes deliberately misleading `GAS_PAYER` arguments, proving the policy bounds/accounts against actual gas — including the **F1 drain regression** (tiny decoy cap args + huge actual gas → rejected) and the **F2 authentication regression** (naming an enrolled user without its guard → rejected). Also: governance-gated init/enrollment, approved funding, non-enrolled/disabled rejection, non-positive args, cumulative-cap exceeded, event emission, the guard predicate, and governance withdrawal (with non-governance withdrawal rejected). CI runs this suite as a blocking check.
+
+## Known limits
+
+- **Devnet-validate before mainnet.** The REPL exercises the `GAS_PAYER` policy and guard directly; coin's `buy-gas`/`redeem-gas` wrapping around a real transaction should be confirmed on devnet.
+- The station does not constrain which module an enrolled user calls (see "Why not…" above). Enrollment is your trust boundary — enroll only accounts you intend to sponsor.
+- `spent` is monotonic until `reset-user-spent`; design your cap/reset cadence (e.g. per-epoch) to match your budget.
+- Governance holds absolute power (upgrade, enroll, withdraw). Use multi-sig.
+
+## License
+
+Apache-2.0

--- a/contracts/library/gas-station/examples/gas-station-test.repl
+++ b/contracts/library/gas-station/examples/gas-station-test.repl
@@ -1,0 +1,240 @@
+;; gas-station-test.repl — PCO library template test suite
+;;
+;; Self-contained: loads coin + interfaces from this repo's registry tree.
+;;
+;; CRITICAL TEST DISCIPLINE: the station bounds and accounts against the
+;; transaction's ACTUAL gas — (chain-data) 'gas-price / 'gas-limit — NOT the
+;; GAS_PAYER capability arguments (which the signer controls). Every funding
+;; test therefore sets the real gas context via (env-chain-data ...) and passes
+;; DELIBERATELY MISLEADING cap args, proving the policy ignores the args for the
+;; money math. This is the test the drain-vulnerable earlier design lacked.
+
+;; ---------------------------------------------------------------------------
+;; Setup
+;; ---------------------------------------------------------------------------
+(begin-tx "setup")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../../registry/kip/gas-payer-v1/gas-payer-v1.pact")
+(load "../../../registry/core/coin/coin-v6.pact")
+(create-table coin-table)
+(env-data {"gas-station-gov": ["gov-key"]})
+(define-keyset "gas-station-gov" (read-keyset "gas-station-gov"))
+(load "../gas-station.pact")
+(create-table allowlist)
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Lifecycle: init is governance-gated; fund the station.
+;; ---------------------------------------------------------------------------
+(begin-tx "init-requires-gov")
+(env-sigs [])
+(expect-failure "init without governance fails" "Keyset failure"
+  (gas-station.init))
+(rollback-tx)
+
+(begin-tx "init-and-fund")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(gas-station.init)
+(expect "station account created with 0 balance" 0.0
+  (coin.get-balance (gas-station.get-station-account)))
+(test-capability (coin.CREDIT (gas-station.get-station-account)))
+(coin.credit (gas-station.get-station-account)
+  (gas-station.create-gas-payer-guard) 10.0)
+(expect "station funded" 10.0
+  (coin.get-balance (gas-station.get-station-account)))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Enrollment is governance-gated and stores a per-user guard.
+;; ---------------------------------------------------------------------------
+(begin-tx "enroll-requires-gov")
+(env-data {"alice": ["alice-key"]})
+(env-sigs [])
+(expect-failure "enroll without governance fails" "Keyset failure"
+  (gas-station.enroll-user "alice" (read-keyset "alice") 1.0))
+(rollback-tx)
+
+(begin-tx "enroll")
+(env-data {"alice": ["alice-key"]})
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "enroll alice" "enrolled"
+  (gas-station.enroll-user "alice" (read-keyset "alice") 1.0))
+(expect "ENROLL event emitted" true
+  (contains "gas-station.ENROLL" (map (at 'name) (env-events true))))
+(expect "alice enrolled: enabled, cap 1.0, spent 0"
+  {"guard": (read-keyset "alice"), "enabled": true, "cap": 1.0, "spent": 0.0}
+  (gas-station.get-user "alice"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; APPROVED path: enrolled + authenticated + actual gas within bounds.
+;; ---------------------------------------------------------------------------
+(begin-tx "approved")
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})  ;; actual cost 0.0005
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect "GAS_PAYER funds an authenticated enrolled user within bounds" "()"
+  (format "{}" [(test-capability (gas-station.GAS_PAYER "alice" 1000 0.0000005))]))
+(expect "spent accounts ACTUAL gas cost (limit*price)" 0.0005
+  (at "spent" (gas-station.get-user "alice")))
+(expect "FUNDED event emitted" true
+  (contains "gas-station.FUNDED" (map (at 'name) (env-events true))))
+(commit-tx)
+
+;; the real wallet flow: the user's signature is SCOPED to GAS_PAYER (not
+;; unscoped). enforce-guard on the stored guard must still be satisfied.
+(begin-tx "approved-scoped-sig")
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})
+(env-sigs [{"key": "alice-key"
+          , "caps": [(gas-station.GAS_PAYER "alice" 1000 0.0000005)]}])
+(expect "GAS_PAYER funds under a scoped signature (real wallet flow)" "()"
+  (format "{}" [(test-capability (gas-station.GAS_PAYER "alice" 1000 0.0000005))]))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; F1 REGRESSION — the drain the second audit found. An attacker passes tiny
+;; cap args to dodge the bounds/cap, but sets HIGH actual gas. The station must
+;; bound and account against the ACTUAL gas and REJECT.
+;; ---------------------------------------------------------------------------
+(begin-tx "F1-drain-actual-gas-over-bound")
+;; actual gas is huge; cap args are a decoy that would pass the old design
+(env-chain-data {"gas-price": 0.00001, "gas-limit": 150000})  ;; actual cost 1.5 KDA
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "high actual gas price rejected despite tiny cap args"
+  "actual gas price"
+  (test-capability (gas-station.GAS_PAYER "alice" 1 0.0000001)))
+(rollback-tx)
+
+(begin-tx "F1-drain-actual-limit-over-bound")
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 150000})  ;; over MAX_GAS_LIMIT
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "high actual gas limit rejected despite tiny cap args"
+  "actual gas limit"
+  (test-capability (gas-station.GAS_PAYER "alice" 1 0.0000001)))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; F2 REGRESSION — authentication. An attacker who merely KNOWS an enrolled
+;; user's name, without controlling its guard, must be rejected.
+;; ---------------------------------------------------------------------------
+(begin-tx "F2-unauthenticated-user")
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})
+(env-sigs [{"key": "attacker-key", "caps": []}])   ;; not alice's key
+(expect-failure "naming an enrolled user without its guard is rejected"
+  "Keyset failure"
+  (test-capability (gas-station.GAS_PAYER "alice" 1000 0.0000005)))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Allowlist authorization
+;; ---------------------------------------------------------------------------
+(begin-tx "reject-non-enrolled")
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})
+(env-sigs [{"key": "bob-key", "caps": []}])
+(expect-failure "non-enrolled user rejected" "No value found in table"
+  (test-capability (gas-station.GAS_PAYER "bob" 1000 0.0000005)))
+(rollback-tx)
+
+(begin-tx "reject-disabled")
+(env-data {"alice": ["alice-key"]})
+(env-sigs [{"key": "gov-key", "caps": []}])
+(gas-station.disable-user "alice")
+(expect "DISABLE event emitted" true
+  (contains "gas-station.DISABLE" (map (at 'name) (env-events true))))
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "disabled user rejected" "user is not enrolled"
+  (test-capability (gas-station.GAS_PAYER "alice" 1000 0.0000005)))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Canonical gas-payer-v1 invariants on the declared args
+;; ---------------------------------------------------------------------------
+(begin-tx "reject-nonpositive-args")
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "zero declared limit rejected" "gas limit must be positive"
+  (test-capability (gas-station.GAS_PAYER "alice" 0 0.0000005)))
+(expect-failure "zero declared price rejected" "gas price must be positive"
+  (test-capability (gas-station.GAS_PAYER "alice" 1000 0.0)))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Per-user cumulative cap (accounted from ACTUAL gas), across txs.
+;; ---------------------------------------------------------------------------
+(begin-tx "enroll-carol")
+(env-data {"carol": ["carol-key"]})
+(env-sigs [{"key": "gov-key", "caps": []}])
+(gas-station.enroll-user "carol" (read-keyset "carol") 0.0006)
+(commit-tx)
+
+(begin-tx "carol-first-fund")
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})   ;; actual cost 0.0005
+(env-sigs [{"key": "carol-key", "caps": []}])
+(test-capability (gas-station.GAS_PAYER "carol" 1000 0.0000005))
+(commit-tx)
+
+(begin-tx "carol-second-fund-over-cap")
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect "carol spent 0.0005 after first fund" 0.0005
+  (at "spent" (gas-station.get-user "carol")))
+(expect-failure "second funding exceeding cumulative cap rejected" "funding cap"
+  (test-capability (gas-station.GAS_PAYER "carol" 1000 0.0000005)))  ;; total 0.001 > 0.0006
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; reset-user-spent: governance clears the cumulative counter (new period).
+;; ---------------------------------------------------------------------------
+(begin-tx "reset-spent")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "carol has non-zero spent before reset" 0.0005
+  (at "spent" (gas-station.get-user "carol")))
+(gas-station.reset-user-spent "carol")
+(expect "RESET event emitted" true
+  (contains "gas-station.RESET" (map (at 'name) (env-events true))))
+(expect "carol spent reset to 0" 0.0
+  (at "spent" (gas-station.get-user "carol")))
+;; after reset, carol can be funded again
+(env-chain-data {"gas-price": 0.0000005, "gas-limit": 1000})
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect "funding resumes after reset" "()"
+  (format "{}" [(test-capability (gas-station.GAS_PAYER "carol" 1000 0.0000005))]))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Guard predicate denies station spend with no authorization in scope
+;; ---------------------------------------------------------------------------
+(begin-tx "guard-denies")
+(env-sigs [])
+(expect-failure "station guard denies spend with no auth in scope"
+  "station spend not authorized"
+  (gas-station.gas-payer-guard-pred))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Governance withdrawal of residual funds
+;; ---------------------------------------------------------------------------
+(begin-tx "withdraw")
+(env-data {"rk": ["r-key"]})
+(coin.create-account "treasury" (read-keyset "rk"))
+(env-sigs [{"key": "gov-key"
+          , "caps": [(coin.TRANSFER (gas-station.get-station-account) "treasury" 4.0)]}])
+(gas-station.withdraw "treasury" 4.0)
+(expect "treasury received withdrawal" 4.0 (coin.get-balance "treasury"))
+(expect "station balance reduced" 6.0
+  (coin.get-balance (gas-station.get-station-account)))
+(expect "WITHDRAW event emitted" true
+  (contains "gas-station.WITHDRAW" (map (at 'name) (env-events true))))
+(commit-tx)
+
+(begin-tx "withdraw-requires-gov")
+(env-data {"attacker": ["attacker-key"]})
+(coin.create-account "attacker-acct" (read-keyset "attacker"))
+(env-sigs [{"key": "attacker-key"
+          , "caps": [(coin.TRANSFER (gas-station.get-station-account) "attacker-acct" 6.0)]}])
+(expect-failure "non-governance cannot withdraw" "station spend not authorized"
+  (gas-station.withdraw "attacker-acct" 6.0))
+(rollback-tx)
+
+"All gas-station template tests passed"

--- a/contracts/library/gas-station/gas-station.pact
+++ b/contracts/library/gas-station/gas-station.pact
@@ -1,0 +1,249 @@
+(module gas-station GOV
+
+  @doc "PCO library template: a gas station with an on-chain, sponsor-controlled \
+  \allowlist.                                                                    \
+  \                                                                              \
+  \A gas station is an autonomous coin account that pays gas on behalf of users, \
+  \enabling gasless UX. Because it holds spendable KDA, an unconstrained station \
+  \is a free-money faucet.                                                       \
+  \                                                                              \
+  \DESIGN NOTE 1 (drain defense). A common pattern inspects the transaction's    \
+  \`exec-code`/`tx-type` via `read-msg` to allowlist a module. That is NOT sound:\
+  \`read-msg` returns the mutable tx `data` payload, which is not bound to the   \
+  \code the transaction executes, and a single code string can carry multiple    \
+  \top-level forms past a naive prefix check. This template does NOT allowlist    \
+  \by code string.                                                               \
+  \                                                                              \
+  \DESIGN NOTE 2 (bound the REAL gas). The gas price/limit passed to GAS_PAYER   \
+  \are signer-supplied and are NOT bound to the transaction's actual gas. All    \
+  \bounds and cap accounting here therefore use (chain-data) 'gas-price /        \
+  \'gas-limit - the values coin actually debits - NOT the capability arguments.  \
+  \                                                                              \
+  \This template funds a transaction only if:                                    \
+  \  1. the signer proves control of an ENROLLED user's guard (authentication),  \
+  \  2. that user is enabled,                                                     \
+  \  3. the ACTUAL gas price/limit are within the station bounds, and            \
+  \  4. the user's cumulative funding cap would not be exceeded.                 \
+  \                                                                              \
+  \Deployment checklist (see README.md):                                         \
+  \  1. Wrap in your namespace; replace the 'gas-station-gov' keyset.            \
+  \  2. Tune MAX_GAS_PRICE / MAX_GAS_LIMIT / DEFAULT_USER_CAP.                    \
+  \  3. Deploy, then (init) to create the station account.                       \
+  \  4. Fund GAS_STATION with KDA; enroll users with (enroll-user ...).          \
+  \  5. Validate the end-to-end gas flow on devnet before mainnet."
+
+  (implements gas-payer-v1)
+
+  ;; -----------------------------
+  ;; Governance
+  ;; -----------------------------
+
+  (defconst GOV_KEYSET:string "gas-station-gov"
+    @doc "Governance keyset name. Replace with your deployed, namespace- \
+         \qualified keyset. Referenced by BOTH the GOV cap and the station \
+         \guard's withdrawal branch, so editing it here updates both.")
+
+  (defcap GOV ()
+    @doc "Module governance."
+    (enforce-guard (keyset-ref-guard GOV_KEYSET)))
+
+  ;; -----------------------------
+  ;; Policy constants — TUNE THESE
+  ;; -----------------------------
+
+  (defconst MAX_GAS_PRICE:decimal 0.000001
+    "Maximum ACTUAL gas price this station will fund per transaction")
+
+  (defconst MAX_GAS_LIMIT:integer 1500
+    "Maximum ACTUAL gas limit this station will fund per transaction")
+
+  (defconst DEFAULT_USER_CAP:decimal 1.0
+    "Default cumulative KDA a newly enrolled user may be funded, unless overridden")
+
+  ;; -----------------------------
+  ;; Events (audit trail)
+  ;; -----------------------------
+
+  (defcap ENROLL (user:string cap:decimal)
+    @doc "Emitted when a user is enrolled / re-enrolled."
+    @event
+    true)
+
+  (defcap DISABLE (user:string)
+    @doc "Emitted when a user is disabled."
+    @event
+    true)
+
+  (defcap RESET (user:string)
+    @doc "Emitted when a user's spent counter is reset."
+    @event
+    true)
+
+  (defcap FUNDED (user:string amount:decimal)
+    @doc "Emitted when the station funds gas for a user (actual max cost)."
+    @event
+    true)
+
+  (defcap WITHDRAW (receiver:string amount:decimal)
+    @doc "Emitted on governance withdrawal of residual station funds."
+    @event
+    true)
+
+  ;; -----------------------------
+  ;; Allowlist storage
+  ;; -----------------------------
+
+  (defschema allow-row
+    @doc "Per-user funding allowance."
+    guard:guard      ;; authenticates the user; must be satisfied to draw funding
+    enabled:bool
+    cap:decimal      ;; cumulative KDA this user may be funded
+    spent:decimal)   ;; cumulative KDA funded so far (from ACTUAL gas)
+
+  (deftable allowlist:{allow-row})
+
+  ;; -----------------------------
+  ;; Station account (capability-guarded)
+  ;; -----------------------------
+
+  (defcap ALLOW_GAS ()
+    @doc "Internal permission token. Weak body by design: it is composed ONLY \
+         \inside GAS_PAYER, after every policy check passes, and is required by \
+         \the station account guard. It is not acquirable from outside this \
+         \module, so it grants no authority on its own."
+    true)
+
+  (defun gas-payer-guard-pred:bool ()
+    @doc "User-guard predicate controlling the station account. Satisfied by \
+         \EITHER the gas-payment path (coin.GAS + ALLOW_GAS in scope) OR the \
+         \governance keyset (for residual-fund recovery via withdraw). \
+         \enforce-one short-circuits on the first passing branch."
+    (enforce-one "station spend not authorized"
+      [ (and (require-capability (coin.GAS))
+             (require-capability (ALLOW_GAS)))
+        (enforce-guard (keyset-ref-guard GOV_KEYSET)) ]))
+
+  (defun create-gas-payer-guard:guard ()
+    @doc "gas-payer-v1: the guard controlling the station coin account."
+    (create-user-guard (gas-payer-guard-pred)))
+
+  (defconst GAS_STATION:string
+    (create-principal (create-gas-payer-guard))
+    "Principal account name derived from the gas-payer guard")
+
+  ;; -----------------------------
+  ;; GAS_PAYER policy
+  ;; -----------------------------
+
+  (defcap GAS_PAYER:bool
+    ( user:string
+      limit:integer
+      price:decimal )
+    @doc "Fund gas for an ENROLLED, AUTHENTICATED user, bounding and accounting \
+         \against the transaction's ACTUAL gas (chain-data), not the signer- \
+         \supplied cap arguments. Composes ALLOW_GAS iff all checks pass."
+
+    ; canonical gas-payer-v1 invariants (on the declared args)
+    (enforce (> limit 0) "gas limit must be positive")
+    (enforce (> price 0.0) "gas price must be positive")
+
+    ; bind the ACTUAL gas the tx will consume — this is what coin debits.
+    (let ( (actual-price:decimal (at 'gas-price (chain-data)))
+           (actual-limit:integer (at 'gas-limit (chain-data))) )
+
+      ; bound the real spend
+      (enforce (<= actual-price MAX_GAS_PRICE)
+        (format "actual gas price {} exceeds station max {}" [actual-price MAX_GAS_PRICE]))
+      (enforce (<= actual-limit MAX_GAS_LIMIT)
+        (format "actual gas limit {} exceeds station max {}" [actual-limit MAX_GAS_LIMIT]))
+
+      ; authenticate + authorize against the sponsor-controlled allowlist.
+      ; read is let-bound before any enforce (node-safe).
+      (with-read allowlist user
+        { "guard" := user-guard, "enabled" := enabled, "cap" := cap, "spent" := spent }
+        (enforce-guard user-guard)                 ; F2: signer must control the user
+        (enforce enabled "user is not enrolled for gas sponsorship")
+        (let ((tx-max-cost:decimal (* (dec actual-limit) actual-price)))
+          ; defense-in-depth: chainweb + coin.buy-gas already reject non-positive
+          ; gas, so this is unreachable on-chain, but it guarantees spent is
+          ; monotonic even if a future coin change relaxed that.
+          (enforce (>= tx-max-cost 0.0) "invalid gas cost")
+          (enforce (<= (+ spent tx-max-cost) cap)
+            (format "user funding cap {} would be exceeded" [cap]))
+          (update allowlist user { "spent": (+ spent tx-max-cost) })
+          (emit-event (FUNDED user tx-max-cost)))))
+
+    (compose-capability (ALLOW_GAS)))
+
+  ;; -----------------------------
+  ;; Sponsor administration (governance-gated)
+  ;; -----------------------------
+
+  (defun enroll-user:string (user:string guard:guard cap:decimal)
+    @doc "Enroll USER (authenticated by GUARD) for gas sponsorship with a \
+         \cumulative funding CAP (KDA). Re-enrolling updates guard and cap and \
+         \re-enables without resetting spent."
+    (with-capability (GOV)
+      (enforce (!= user "") "user required")
+      (enforce (>= cap 0.0) "cap must be non-negative")
+      (with-default-read allowlist user
+        { "spent": 0.0 }
+        { "spent" := spent }
+        (write allowlist user
+          { "guard": guard, "enabled": true, "cap": cap, "spent": spent }))
+      (emit-event (ENROLL user cap))
+      "enrolled"))
+
+  (defun enroll-user-default:string (user:string guard:guard)
+    @doc "Enroll USER at DEFAULT_USER_CAP."
+    (enroll-user user guard DEFAULT_USER_CAP))
+
+  (defun disable-user:string (user:string)
+    @doc "Disable gas sponsorship for USER (preserves guard, cap, spent)."
+    (with-capability (GOV)
+      (with-read allowlist user
+        { "guard" := guard, "cap" := cap, "spent" := spent }
+        (write allowlist user
+          { "guard": guard, "enabled": false, "cap": cap, "spent": spent }))
+      (emit-event (DISABLE user))
+      "disabled"))
+
+  (defun reset-user-spent:string (user:string)
+    @doc "Reset USER's cumulative spent counter to zero (e.g. new period)."
+    (with-capability (GOV)
+      (with-read allowlist user
+        { "guard" := guard, "enabled" := enabled, "cap" := cap }
+        (write allowlist user
+          { "guard": guard, "enabled": enabled, "cap": cap, "spent": 0.0 }))
+      (emit-event (RESET user))
+      "reset"))
+
+  (defun get-user:object{allow-row} (user:string)
+    @doc "Read a user's allowlist row."
+    (read allowlist user))
+
+  ;; -----------------------------
+  ;; Lifecycle & treasury
+  ;; -----------------------------
+
+  (defun init:string ()
+    @doc "Create the station coin account. Call exactly once; a second call \
+         \aborts because the account already exists. Fund GAS_STATION with \
+         \KDA separately."
+    (with-capability (GOV)
+      (coin.create-account GAS_STATION (create-gas-payer-guard))))
+
+  (defun withdraw:string (receiver:string amount:decimal)
+    @doc "Governance recovery of residual KDA from the station. Authorization \
+         \is the station account guard itself: its governance branch enforces \
+         \the gas-station-gov keyset. The caller must sign the transaction with \
+         \the gas-station-gov key scoping (coin.TRANSFER GAS_STATION receiver  \
+         \amount) - that signature both installs the managed transfer cap and  \
+         \satisfies the station guard. No separate GOV acquisition is needed."
+    (emit-event (WITHDRAW receiver amount))
+    (coin.transfer GAS_STATION receiver amount))
+
+  (defun get-station-account:string ()
+    @doc "Return the station principal account name."
+    GAS_STATION)
+)

--- a/contracts/library/gas-station/metadata.yaml
+++ b/contracts/library/gas-station/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'Gas Station (drain-defended)'
+slug: 'gas-station'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['gas-station', 'gas-payer-v1', 'gasless', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'gas-payer-v1', 'gas-station', 'capability-guard']

--- a/docs/index.json
+++ b/docs/index.json
@@ -1,5 +1,34 @@
 [
 {
+  "name": "Gas Station (drain-defended)",
+  "slug": "gas-station",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "gas-station",
+    "gas-payer-v1",
+    "gasless",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "gas-payer-v1",
+    "gas-station",
+    "capability-guard"
+  ]
+}
+,
+{
   "name": "Hello World",
   "slug": "hello-world",
   "version": "1.0.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ _Generated from `contracts/**/metadata.yaml`._
 
 | Name | Slug | Version | Audit Status | Tags |
 |------|------|---------|--------------|------|
+| Gas Station (drain-defended) | gas-station | 1.0.0 | self-reviewed | gas-station, gas-payer-v1, gasless, template, library |
 | Hello World | hello-world | 1.0.0 | self-reviewed | hello-world, tutorial, basic |
 | Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
 


### PR DESCRIPTION
## Summary

Second WS3 flagship template: a `gas-payer-v1` gas station for gasless UX. A gas station holds spendable KDA, so **drain defense is the entire design problem** — and this entry is a case study in why the independent auditor gate is non-negotiable.

## Three audit passes, two CRITICAL drains caught before shipping

- **Pass 1 — CRITICAL (fixed).** The first design allowlisted the funded operation by inspecting `exec-code`/`tx-type` via `read-msg`. But `read-msg` returns the mutable tx `data` payload (not bound to the executed code), and a single code string can carry a second top-level form past a prefix check — a **confirmed, reproduced drain**. → Removed all `read-msg`; authorization is now an on-chain, governance-controlled **per-user allowlist**.
- **Pass 2 — CRITICAL + MEDIUM + LOW (fixed).** The redesign bounded and accounted against the signer-supplied `GAS_PAYER` `limit`/`price` **arguments**, which aren't bound to the real gas — decoy args + a huge actual gas limit drained the station. → `GAS_PAYER` now reads `(chain-data)` `gas-price`/`gas-limit` (what `coin` actually debits) for all bounds and accounting (mirrors `runonflux.flux`). Plus per-user **guard authentication** and **`@event`** audit trail.
- **Pass 3 — GO.** Zero CRITICAL/HIGH/MEDIUM, all three prior findings verified closed. Its one LOW (duplicated gov-keyset literal → hoisted to a `GOV_KEYSET` defconst) and INFO items applied.

## Design

Capability-guarded station principal, spendable only via the gas path (`coin.GAS` + `ALLOW_GAS`) or governance withdrawal. `GAS_PAYER` enforces: user enrolled + **signer controls the user's guard** + **actual** gas within bounds + within the user's cumulative cap. Governance-gated enroll/disable/reset and residual withdraw.

## Tests + tooling

- **30-assertion self-contained suite** (loads `coin` + interfaces from `registry/`), including the **F1 drain regression** (decoy cap args + hostile `env-chain-data` → rejected) and the **F2 authentication regression** (naming an enrolled user without its guard → rejected) — the exact tests the vulnerable earlier designs lacked.
- Static gate: **PASS, 0 violations.** Entry passes the library quality gate. CI runs the suite as a blocking check.

## Verification

- `pact gas-station-test.repl`: 30 assertions, 0 failures.
- `validate_contract.sh` on the entry: OK. Index regenerated.

> The on-chain `buy-gas`/`redeem-gas` wrapping and the scoped-signature path are behaviors the bare REPL structurally cannot prove — a **mandatory devnet end-to-end run** is flagged in the README and AUDIT before any production use.