### PR TITLE
feat(library): add M-of-N multisig treasury template

### DIFF
--- a/contracts/library/multisig-treasury/AUDIT.md
+++ b/contracts/library/multisig-treasury/AUDIT.md
@@ -1,0 +1,143 @@
+# AUDIT — library/multisig-treasury
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `treasury` (namespace: project-specific) |
+| **Version** | 1.0.0 |
+| **Audit Status** | self-reviewed |
+| **Category** | PCO Library Template |
+| **Source** | PCO-authored reference implementation |
+| **Last review** | 2026-07-06 |
+
+## Purpose
+
+Deployable template for an M-of-N multisig treasury: KDA custody in a
+capability-guarded vault, spendable only via an on-chain proposal that reaches an
+approval threshold from an authenticated signer set.
+
+## Audit history: findings and fixes
+
+An independent `pact-auditor` pass returned **NO-GO** on the first version, with a
+HIGH ship-stopper. All findings were fixed:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| F1 | **HIGH** | `enforce-signer` read the `config` table **inside an `enforce` condition** (`(enforce (is-signer account) ...)`). This passes in the REPL but **aborts on the KDA-CE node** ("Operation is not allowed in read-only or system-only mode"). It gates both `propose` and `approve`, so on a real node no proposal could be created or approved — a funded vault could **accept KDA but never spend it** (funds locked). | `enforce-signer` now `let`-binds `(is-signer account)` before the `enforce`. Same fix applied to the new recipient-existence and vault-existence checks. |
+| F2 | MEDIUM | `init` could be front-run bricked: anyone could pre-create the vault account, causing `init`'s `coin.create-account` to abort ("value already exists") and roll back the whole GOV setup. | `init` now creates the vault via `ensure-vault-account`, which skips creation if the account already exists (the vault guard is deterministic, so a pre-created vault necessarily carries the correct guard — coin enforces name==principal(guard)). |
+| F3 | LOW | `propose` lacked `enforce-unit` and a recipient-existence check, so a proposal could reach threshold yet be un-executable (stuck `pending`), recoverable only by governance `cancel`. | `propose` now calls `coin.enforce-unit` and rejects a non-existent recipient at creation. |
+| F4 | LOW | `init` emitted no event, unlike every other state transition. | `init` now emits `SIGNERS_ROTATED`. |
+| F5 | INFO | Stale approvals survive a signer rotation (a proposal that met threshold under the old set can still execute). | Superseded by the R2-1 fix below: `execute` now drops rotated-out signers' approvals. |
+
+> **F1 is REPL-invisible.** The fix (bind-before-enforce) is the verified remedy
+> for this class, but a REPL pass is **not** evidence that it works on-node. A
+> **devnet run of `propose`/`approve`/`execute` is mandatory** before any
+> production use of this template — see the README deployment checklist. This is
+> the single most important gate for this entry.
+
+A **second** independent pass verified F1–F4 closed (F2 confirmed down to the
+pinned interpreter source) and zero read-in-enforce remaining, but raised one
+MEDIUM and two LOWs — all fixed:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| R2-1 | **MEDIUM** | Signer rotation did not revoke recorded approvals — a rotated-out (e.g. compromised) signer's stale approval still counted toward the threshold, breaking the M-of-N guarantee in the exact scenario rotation exists for. | `execute` now counts **only** approvals from **current** signers: `(filter (lambda (a) (contains a current-signers)) approvals)` before the threshold check. Regression-tested (`stale-execute-blocked`: a rotated-out signer's approval no longer counts; execution requires a fresh current-signer approval). |
+| R2-2 | LOW | Signer authentication was a bare defun, forcing signers to sign **unscoped** — their approval signature also authorized anything else their key could satisfy in the transaction. | `SIGNER-AUTH` is now a **capability**; `propose`/`approve` acquire it via `with-capability`, so signers scope their signature to `(treasury.SIGNER-AUTH "alice")`. Regression-tested (`scoped-sig-*`). |
+| R2-3 | LOW | No duplicate-signer check — `["alice" "alice" "bob"]` with threshold 3 passed validation but could never reach 3 distinct approvals (silent N-of-M misrepresentation). | Shared `enforce-valid-config` (used by `init` and `rotate-signers`) now rejects duplicate signers via `(distinct signers)`. Regression-tested (`rotate-dup-signers`). |
+
+A **third** pass returned **GO** (R2-1/2/3 all verified closed, node-safe, no
+regression). It raised one residual LOW: approval identity is the account *name*,
+so re-keying a signer **in place** (same name, new guard) revives any approvals
+the old key made on still-pending proposals. **Disposition: documented** — the
+README instructs responding to a key compromise by *removing the signer's name*
+(and/or cancelling affected proposals), never swapping its guard in place. A
+structural fix (per-approval rotation epoch) is noted for a future version.
+
+## Threat model & defenses
+
+| Vector | Defense | Test |
+|---|---|---|
+| Non-signer proposes/approves | `SIGNER-AUTH` cap checks set membership | `propose-non-signer`, `approve-non-signer` |
+| Impersonate a signer by name | `SIGNER-AUTH` enforces the signer's enrolled guard | `propose-unauthenticated` |
+| Spend below threshold | `execute` enforces `valid-approvals >= threshold` | `execute-under-threshold` |
+| Inflate approvals by re-approving | per-signer dedup (`not (contains signer approvals)`) | `approve-double` |
+| Double-spend / re-execute | status set to `executed` before transfer; re-entry re-checks `pending` | `re-execute` |
+| Drain the vault directly | vault guard requires `SPEND`, acquired only inside `execute` after threshold | `vault-guard-denies` |
+| Self-deal to the vault | `propose` rejects the vault as recipient | `propose-to-vault` |
+| Execute a cancelled/settled proposal | status re-checked on entry | `execute-cancelled`, `approve-cancelled` |
+| Non-governance cancel/rotate | `GOV` keyset gate | `cancel-requires-gov`, `init-requires-gov` |
+| Rotated-out signer's stale approval counts | `execute` counts only current-signer approvals | `stale-execute-blocked` |
+| Duplicate signers silently break N-of-M | `enforce-valid-config` rejects `distinct` mismatch | `rotate-dup-signers` |
+| Signer approval sig authorizes bundled ops | `SIGNER-AUTH` is a cap; signers sign scoped | `scoped-sig-propose`, `scoped-sig-approve` |
+
+## Capability model
+
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard GOV_KEYSET` | init / rotate-signers / cancel / upgrade |
+| `SIGNER-AUTH` | authentication | set membership + signer's enrolled guard | Acquired by `propose`/`approve`; signers scope their signature to it |
+| `SPEND` | weak-body | — | Safe: acquired ONLY inside `execute` after the threshold check; required by the vault guard; not externally acquirable |
+| `PROPOSED` / `APPROVED` / `EXECUTED` / `CANCELLED` / `SIGNERS_ROTATED` | `@event` | — | Emit-only audit trail |
+
+The vault account guard (`vault-guard-pred`) is a user guard that requires `SPEND`
+in scope. Since `SPEND` is composed only within `execute` — and only after
+`(enforce (>= (length approvals) threshold) ...)` — coin can debit the vault only
+through a threshold-approved execution.
+
+## Authorization: the threshold is the trust boundary
+
+`execute` is intentionally **permissionless** — once approvals meet the threshold,
+anyone may trigger the settled transfer. This is standard for multisig: the M
+approvals *are* the authorization, and letting any party (or a relayer) execute
+avoids a liveness dependency on a specific signer being online. A single
+compromised signer key cannot move funds — it can add at most one approval and
+cannot lower the threshold (only governance can rotate).
+
+## Node-safety
+
+The first version tripped the KDA-CE "table read inside an `enforce` condition"
+trap (F1 above). It is now fixed: every table read that feeds an `enforce` is
+`let`/`with-read`-bound **first**, then the bound local is enforced
+(`SIGNER-AUTH`, `propose` recipient check, `ensure-vault-account`, `execute`
+threshold + current-signer filter). This class is REPL-invisible, so **devnet
+validation is the required evidence** — see the F1 caveat above.
+
+## Risk profile
+
+| Risk | Level | Notes |
+|---|---|---|
+| Unauthorized spend | Low | Threshold + per-signer auth + dedup, all regression-tested |
+| Double-spend | Low | Settle-before-transfer + status re-check |
+| Direct vault drain | Low | Capability-guarded principal; `SPEND` internal-only |
+| Reentrancy | Low | Only `coin.transfer` is external; status already settled before it |
+| Governance dependency | Medium | `treasury-gov` must be defined pre-deploy; template ships an unqualified REPL name — **must** be namespace-qualified on-chain |
+| In-flight proposals across rotation | Low | `execute` counts only current-signer approvals, so a rotated-out signer's stale approval is dropped (R2-1) |
+| No proposal expiry | By design | Add a block-time deadline to `execute` if needed; documented |
+
+## Static analysis note
+
+`pact-static-check.sh` reports **PASS, 0 violations**. A bare `pact <file>` load
+cannot resolve the module's `coin` calls (the standalone CLI ships only a stub of
+`coin` lacking `get-balance`), so this class of missing-upstream-dependency load
+error is treated as a WARN, scoped to a known allowlist of pre-deployed modules —
+a typo against the module's *own* members still fails the gate as a VIOLATION. The
+authoritative evidence is the full `.repl` harness (43 assertions green), which
+loads the real `coin`, plus the blocking CI test step. The two Tier-2 WARNs
+(`enforce-guard` in `GOV` and in `SIGNER-AUTH`) are dispositioned SAFE — both sit
+inside defcaps.
+
+## What self-reviewed means here
+
+Reviewed by the template's maintainers against the PCO checklist, with all
+authorization/threshold/double-spend scenarios encoded as runnable regression
+tests. **Not independent.** Promotion requires a second reviewer
+(`community-reviewed`) or a third-party report with a matching source hash
+(`independently-audited`) — see `docs/CONTRACT_POLICIES.md` §3.1.
+
+## Reproduce the review
+
+```bash
+cd contracts/library/multisig-treasury/examples
+pact treasury-test.repl   # 43 assertions
+```

--- a/contracts/library/multisig-treasury/README.md
+++ b/contracts/library/multisig-treasury/README.md
@@ -1,0 +1,69 @@
+# Multisig Treasury (M-of-N)
+
+PCO library template: an **M-of-N multisig treasury** for custody of KDA under threshold control. Funds live in a module-owned vault that can be spent **only** through an on-chain proposal that collects approvals from a threshold of authorized signers. This is the primitive every DAO, foundation, and company treasury needs first.
+
+## How it works
+
+Funds sit in a **capability-guarded vault account** (a principal whose guard is satisfied only while the internal `SPEND` capability is in scope). `SPEND` is acquired **only** inside `execute`, and only after the on-chain approval count meets the threshold. So the vault can be debited only by a threshold-approved proposal — never directly.
+
+The flow is **asynchronous** — signers approve in separate transactions, no co-signing ceremony required:
+
+1. **`init [signers] threshold [guards]`** (governance) — configure the signer set, the M-of-N threshold, and each signer's authenticating guard; create the vault account.
+2. **`propose id proposer recipient amount`** — any signer proposes a spend. The proposer counts as the first approval. `id` must be unique.
+3. **`approve id signer`** — another signer adds their approval. Each signer may approve at most once; a signer cannot approve a settled proposal.
+4. **`execute id`** — once approvals ≥ threshold, **anyone** may execute; the approvals are the authorization. The vault debits the recipient exactly once and the proposal is marked `executed`.
+5. **`cancel id`** (governance) — cancel a pending proposal.
+6. **`rotate-signers [signers] threshold [guards]`** (governance) — replace the signer set / threshold.
+
+Every step emits an event (`PROPOSED`, `APPROVED`, `EXECUTED`, `CANCELLED`, `SIGNERS_ROTATED`) for off-chain audit.
+
+## Security model
+
+- **Authenticated signers.** A signer isn't just a name in a list — `propose`/`approve` acquire the `SIGNER-AUTH` capability, which enforces the signer's enrolled guard. Signers scope their signature to `(treasury.SIGNER-AUTH "alice")`, so an approval signature does not also authorize other operations their key could satisfy in the same transaction.
+- **Threshold is the authorization, over the *current* signer set.** `execute` counts only approvals from signers who are current at execution time, and is permissionless once that count meets the threshold. A compromised single key cannot move funds below threshold, and rotating a signer out drops their stale approvals.
+- **No direct vault access.** The vault guard requires `SPEND`, which is acquirable only inside `execute` after the threshold check. A direct `coin.transfer` from the vault fails.
+- **No double-spend.** `execute` marks the proposal `executed` before the transfer and re-checks `pending` on entry, so a proposal settles at most once.
+- **No self-dealing to the vault.** `propose` rejects the vault as recipient.
+
+## Deployment checklist
+
+1. Wrap the module in your namespace; replace the `"treasury-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig recommended** — governance can rotate signers and cancel proposals).
+2. Deploy, then call `(init signers threshold guards)` **once** with your signer accounts and their guards (positionally aligned).
+3. **Fund** the vault with KDA (`get-vault-account` returns its name).
+4. Validate the end-to-end flow on **devnet** before mainnet — **mandatory**, not optional (see Known Limits; on-chain table-read behavior cannot be proven in the REPL).
+
+## Usage
+
+```pact
+;; a signer proposes (signs with their own key)
+(treasury.propose "spend-2026-01" "k:alice..." "k:vendor..." 500.0)
+
+;; another signer approves (signs with their own key)
+(treasury.approve "spend-2026-01" "k:bob...")
+
+;; once threshold reached, anyone executes
+(treasury.execute "spend-2026-01")
+```
+
+## Testing
+
+`examples/treasury-test.repl` is self-contained (loads `coin` + interfaces from `registry/`):
+
+```bash
+cd contracts/library/multisig-treasury/examples && pact treasury-test.repl
+```
+
+43 assertions covering the full 2-of-3 flow and every authorization/threshold attack: non-signer propose/approve, proposing as a signer without its guard, double approval, execute below threshold, re-execution, self-dealing to the vault, executing/approving a cancelled proposal, the vault guard denying a direct debit, and governance-gated cancel + signer rotation. CI runs this suite as a blocking check.
+
+## Known limits
+
+- **Devnet validation is MANDATORY before mainnet — not optional.** Several correctness checks (signer/recipient/vault existence) read on-chain tables. The template binds every such read before its `enforce` (the node-safe pattern), but this class of bug is **invisible in the REPL** — a green test suite does not prove the on-chain path works. Deploy to a devnet node and drive a full `propose → approve → execute` cycle before trusting this with real funds.
+- **Proposal `id`s are caller-supplied and must be unique** — `propose` uses `insert`, so a reused id aborts. Use a scheme like `"<purpose>-<nonce>"`.
+- **Rotating signers revokes rotated-out signers' approvals.** `execute` counts only approvals from *current* signers, so a proposal loses any approval from a signer removed by a later rotation and must re-reach the threshold among the current set. (It does not expire on its own — see next.)
+- **Respond to a key compromise by REMOVING the signer's account name, not re-keying it in place.** Approval identity is the account name. Rotating a signer *out* drops their stale approvals, but re-enrolling the *same name* with a new guard revives any approvals the old (compromised) key made on still-pending proposals. When responding to a compromise, remove the name from the signer set (and/or `cancel` affected pending proposals) rather than swapping its guard under the same name.
+- **No per-proposal expiry.** Add a deadline (block-time) check to `execute` if you want proposals to lapse.
+- Governance holds absolute power (rotate signers, cancel, upgrade). Use multi-sig.
+
+## License
+
+Apache-2.0

--- a/contracts/library/multisig-treasury/examples/treasury-test.repl
+++ b/contracts/library/multisig-treasury/examples/treasury-test.repl
@@ -1,0 +1,299 @@
+;; treasury-test.repl — PCO library template test suite
+;;
+;; Self-contained: loads coin + interfaces from this repo's registry tree.
+;;
+;; Exercises the full 2-of-3 multisig flow — init, propose, approve, execute —
+;; plus every authorization and threshold attack: non-signer propose/approve,
+;; double approval, under-threshold execute, re-execution, self-dealing to the
+;; vault, and the vault guard denying a direct debit.
+
+;; ---------------------------------------------------------------------------
+;; Setup: coin, gov keyset, module, tables. Three signers (alice/bob/carol).
+;; ---------------------------------------------------------------------------
+(begin-tx "setup")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../../registry/core/coin/coin-v6.pact")
+(create-table coin-table)
+(env-data
+  { "treasury-gov": ["gov-key"]
+  , "alice": ["alice-key"], "bob": ["bob-key"]
+  , "carol": ["carol-key"], "dave": ["dave-key"]
+  , "recipient": ["rcpt-key"] })
+(define-keyset "treasury-gov" (read-keyset "treasury-gov"))
+(load "../treasury.pact")
+(create-table config)
+(create-table proposals)
+(create-table signer-guards)
+;; recipient + a non-signer (dave) coin accounts
+(coin.create-account "recipient" (read-keyset "recipient"))
+(coin.create-account "dave" (read-keyset "dave"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; init is governance-gated; sets a 2-of-3 signer set and funds the vault.
+;; ---------------------------------------------------------------------------
+(begin-tx "init-requires-gov")
+(env-sigs [])
+(expect-failure "init without governance fails" "Keyset failure"
+  (treasury.init ["alice" "bob" "carol"] 2
+    [(read-keyset "alice") (read-keyset "bob") (read-keyset "carol")]))
+(rollback-tx)
+
+(begin-tx "init-bad-threshold")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "threshold above signer count rejected" "threshold exceeds signer count"
+  (treasury.init ["alice" "bob"] 3
+    [(read-keyset "alice") (read-keyset "bob")]))
+(rollback-tx)
+
+;; F2 regression: a front-runner pre-creates the vault account before init.
+;; init must tolerate it (create-account is skipped) rather than aborting.
+(begin-tx "front-run-vault")
+(env-sigs [])
+(coin.create-account (treasury.get-vault-account) (treasury.create-vault-guard))
+(commit-tx)
+
+(begin-tx "init")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "init 2-of-3 succeeds despite pre-created vault" "initialized"
+  (treasury.init ["alice" "bob" "carol"] 2
+    [(read-keyset "alice") (read-keyset "bob") (read-keyset "carol")]))
+(expect "init emits SIGNERS_ROTATED event" true
+  (contains "treasury.SIGNERS_ROTATED" (map (at 'name) (env-events true))))
+;; fund the vault
+(test-capability (coin.CREDIT (treasury.get-vault-account)))
+(coin.credit (treasury.get-vault-account) (treasury.create-vault-guard) 100.0)
+(expect "vault funded" 100.0 (treasury.vault-balance))
+(commit-tx)
+
+(begin-tx "init-once")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "init cannot be run twice (config insert)" "already found while in Insert mode"
+  (treasury.init ["alice" "bob"] 2 [(read-keyset "alice") (read-keyset "bob")]))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; propose — only a signer, authenticated by their guard.
+;; ---------------------------------------------------------------------------
+(begin-tx "propose-non-signer")
+(env-sigs [{"key": "dave-key", "caps": []}])
+(expect-failure "non-signer cannot propose" "not an authorized signer"
+  (treasury.propose "p1" "dave" "recipient" 30.0))
+(rollback-tx)
+
+(begin-tx "propose-unauthenticated")
+;; alice IS a signer, but the caller does not hold alice's key
+(env-sigs [{"key": "dave-key", "caps": []}])
+(expect-failure "proposing as a signer without its guard fails" "Keyset failure"
+  (treasury.propose "p1" "alice" "recipient" 30.0))
+(rollback-tx)
+
+(begin-tx "propose-to-vault")
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "cannot propose a spend to the vault itself" "recipient cannot be the vault"
+  (treasury.propose "p1" "alice" (treasury.get-vault-account) 30.0))
+(rollback-tx)
+
+(begin-tx "propose-nonexistent-recipient")
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "cannot propose to a non-existent recipient" "recipient account does not exist"
+  (treasury.propose "p1" "alice" "ghost-account" 30.0))
+(rollback-tx)
+
+(begin-tx "propose-over-precision")
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "over-precision amount rejected at propose" "precision"
+  (treasury.propose "p1" "alice" "recipient" 0.0000000000001))
+(rollback-tx)
+
+(begin-tx "propose")
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect "alice proposes p1" "p1"
+  (treasury.propose "p1" "alice" "recipient" 30.0))
+(expect "proposal recorded pending with alice as first approval"
+  { "proposer": "alice", "recipient": "recipient", "amount": 30.0
+  , "approvals": ["alice"], "status": "pending" }
+  (treasury.get-proposal "p1"))
+(expect "PROPOSED + APPROVED events emitted" true
+  (let ((names (map (at 'name) (env-events true))))
+    (and (contains "treasury.PROPOSED" names) (contains "treasury.APPROVED" names))))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; execute below threshold must fail (only 1 of 2 approvals).
+;; ---------------------------------------------------------------------------
+(begin-tx "execute-under-threshold")
+(expect-failure "cannot execute below threshold" "below threshold"
+  (treasury.execute "p1"))
+(expect "vault untouched" 100.0 (treasury.vault-balance))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; approve — dedup + signer auth.
+;; ---------------------------------------------------------------------------
+(begin-tx "approve-double")
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "a signer cannot approve twice" "already approved"
+  (treasury.approve "p1" "alice"))
+(rollback-tx)
+
+(begin-tx "approve-non-signer")
+(env-sigs [{"key": "dave-key", "caps": []}])
+(expect-failure "non-signer cannot approve" "not an authorized signer"
+  (treasury.approve "p1" "dave"))
+(rollback-tx)
+
+(begin-tx "approve")
+(env-sigs [{"key": "bob-key", "caps": []}])
+(expect "bob approves p1" "p1" (treasury.approve "p1" "bob"))
+(expect "p1 now has 2 approvals"
+  ["alice" "bob"] (at 'approvals (treasury.get-proposal "p1")))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; execute at threshold — vault debits recipient exactly once.
+;; ---------------------------------------------------------------------------
+(begin-tx "execute")
+(expect "anyone can execute once threshold met" "p1" (treasury.execute "p1"))
+(expect "recipient received 30" 30.0 (coin.get-balance "recipient"))
+(expect "vault reduced to 70" 70.0 (treasury.vault-balance))
+(expect "proposal marked executed" "executed" (at 'status (treasury.get-proposal "p1")))
+(expect "EXECUTED event emitted" true
+  (contains "treasury.EXECUTED" (map (at 'name) (env-events true))))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; re-execution must fail (no double spend).
+;; ---------------------------------------------------------------------------
+(begin-tx "re-execute")
+(expect-failure "cannot re-execute a settled proposal" "not pending"
+  (treasury.execute "p1"))
+(expect "vault unchanged at 70" 70.0 (treasury.vault-balance))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; governance cancel prevents execution of a pending proposal.
+;; ---------------------------------------------------------------------------
+(begin-tx "cancel")
+(env-sigs [{"key": "carol-key", "caps": []}])
+(treasury.propose "p2" "carol" "recipient" 10.0)
+(commit-tx)
+
+(begin-tx "cancel-requires-gov")
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect-failure "non-governance cannot cancel" "Keyset failure"
+  (treasury.cancel "p2"))
+(rollback-tx)
+
+(begin-tx "cancel-gov")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "governance cancels p2" "p2" (treasury.cancel "p2"))
+(commit-tx)
+
+(begin-tx "approve-cancelled")
+(env-sigs [{"key": "bob-key", "caps": []}])
+(expect-failure "cannot approve a cancelled proposal" "not pending"
+  (treasury.approve "p2" "bob"))
+(rollback-tx)
+
+(begin-tx "execute-cancelled")
+(expect-failure "cannot execute a cancelled proposal" "not pending"
+  (treasury.execute "p2"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; vault guard denies a direct debit outside an approved execute.
+;; ---------------------------------------------------------------------------
+(begin-tx "vault-guard-denies")
+(env-sigs [{"key": "dave-key"
+          , "caps": [(coin.TRANSFER (treasury.get-vault-account) "dave" 70.0)]}])
+(expect-failure "direct vault debit denied (SPEND not in scope)"
+  "not granted: (treasury.SPEND)"
+  (coin.transfer (treasury.get-vault-account) "dave" 70.0))
+(expect "vault still 70" 70.0 (treasury.vault-balance))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; governance signer rotation.
+;; ---------------------------------------------------------------------------
+(begin-tx "rotate-dup-signers")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "duplicate signers rejected" "duplicate signers"
+  (treasury.rotate-signers ["alice" "alice"] 2
+    [(read-keyset "alice") (read-keyset "alice")]))
+(rollback-tx)
+
+(begin-tx "rotate")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "rotate to alice+dave, 2-of-2" "rotated"
+  (treasury.rotate-signers ["alice" "dave"] 2
+    [(read-keyset "alice") (read-keyset "dave")]))
+(expect "dave is now a signer" true (treasury.is-signer "dave"))
+(expect "carol is no longer a signer" false (treasury.is-signer "carol"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; MEDIUM regression: a rotated-out signer's stale approval must NOT count
+;; toward the threshold at execute time.
+;; ---------------------------------------------------------------------------
+(begin-tx "stale-approval-setup")
+;; fresh signer set alice+bob+carol, 2-of-3
+(env-sigs [{"key": "gov-key", "caps": []}])
+(treasury.rotate-signers ["alice" "bob" "carol"] 2
+  [(read-keyset "alice") (read-keyset "bob") (read-keyset "carol")])
+(commit-tx)
+
+(begin-tx "stale-propose")
+;; bob (now considered compromised) proposes -> counts as approval #1
+(env-sigs [{"key": "bob-key", "caps": []}])
+(treasury.propose "p-stale" "bob" "recipient" 5.0)
+(commit-tx)
+
+(begin-tx "stale-approve")
+;; carol adds approval #2 -> 2 approvals, would meet threshold
+(env-sigs [{"key": "carol-key", "caps": []}])
+(treasury.approve "p-stale" "carol")
+(commit-tx)
+
+(begin-tx "rotate-out-bob")
+;; governance responds to bob's compromise: rotate bob out (alice+carol, 2-of-2)
+(env-sigs [{"key": "gov-key", "caps": []}])
+(treasury.rotate-signers ["alice" "carol"] 2
+  [(read-keyset "alice") (read-keyset "carol")])
+(commit-tx)
+
+(begin-tx "stale-execute-blocked")
+;; p-stale has [bob carol]; bob is no longer a signer, so only 1 VALID
+;; approval remains -> below the 2-of-2 threshold -> must NOT execute.
+(expect-failure "rotated-out signer's approval does not count" "below threshold"
+  (treasury.execute "p-stale"))
+(expect "vault unchanged" 70.0 (treasury.vault-balance))
+;; alice (a current signer) approves -> now 2 valid -> executes
+(env-sigs [{"key": "alice-key", "caps": []}])
+(treasury.approve "p-stale" "alice")
+(commit-tx)
+
+(begin-tx "stale-execute-ok")
+(expect "executes once threshold met by current signers" "p-stale"
+  (treasury.execute "p-stale"))
+(expect "recipient received the 5" 35.0 (coin.get-balance "recipient"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; LOW regression: a signer can approve with a SCOPED signature (scoped to
+;; SIGNER-AUTH), i.e. their approval signature need not be unscoped.
+;; ---------------------------------------------------------------------------
+(begin-tx "scoped-sig-propose")
+(env-sigs [{"key": "alice-key", "caps": [(treasury.SIGNER-AUTH "alice")]}])
+(expect "propose works under a scoped SIGNER-AUTH signature" "p-scoped"
+  (treasury.propose "p-scoped" "alice" "recipient" 1.0))
+(commit-tx)
+
+(begin-tx "scoped-sig-approve")
+(env-sigs [{"key": "carol-key", "caps": [(treasury.SIGNER-AUTH "carol")]}])
+(expect "approve works under a scoped SIGNER-AUTH signature" "p-scoped"
+  (treasury.approve "p-scoped" "carol"))
+(commit-tx)
+
+"All multisig-treasury template tests passed"

--- a/contracts/library/multisig-treasury/metadata.yaml
+++ b/contracts/library/multisig-treasury/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'Multisig Treasury (M-of-N)'
+slug: 'multisig-treasury'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['treasury', 'multisig', 'governance', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'multisig', 'm-of-n', 'treasury', 'capability-guard']

--- a/contracts/library/multisig-treasury/treasury.pact
+++ b/contracts/library/multisig-treasury/treasury.pact
@@ -1,0 +1,289 @@
+(module treasury GOV
+
+  @doc "PCO library template: an M-of-N multisig treasury.                       \
+  \                                                                              \
+  \Holds KDA in a module-owned (capability-guarded) vault account that can be    \
+  \spent ONLY through an on-chain proposal that collects approvals from a        \
+  \threshold of authorized signers. Approvals are asynchronous - each signer     \
+  \approves in their own transaction - and every step emits an event for audit.  \
+  \                                                                              \
+  \Model:                                                                        \
+  \  - A fixed set of SIGNER accounts and a THRESHOLD (M of N) are configured    \
+  \    at init and rotatable by governance.                                      \
+  \  - Anyone in the signer set may `propose` a spend (recipient, amount).       \
+  \  - Each signer `approve`s at most once; approvals are counted on-chain.      \
+  \  - Once approvals >= threshold, anyone may `execute` the proposal, which     \
+  \    debits the vault to the recipient exactly once.                           \
+  \  - Governance may `cancel` a pending proposal and rotate the signer set.     \
+  \                                                                              \
+  \Deployment checklist (see README.md):                                         \
+  \  1. Wrap in your namespace; replace the 'treasury-gov' keyset.               \
+  \  2. Deploy, then (init [signers] threshold) with your signer accounts.       \
+  \  3. Fund VAULT with KDA (get-vault-account returns its name).                \
+  \  4. Validate on devnet before mainnet."
+
+  ;; -----------------------------
+  ;; Governance
+  ;; -----------------------------
+
+  (defconst GOV_KEYSET:string "treasury-gov"
+    @doc "Governance keyset name. Replace with your deployed, namespace- \
+         \qualified keyset (multi-sig recommended).")
+
+  (defcap GOV ()
+    @doc "Module governance: rotate signers/threshold, cancel proposals, upgrade."
+    (enforce-guard (keyset-ref-guard GOV_KEYSET)))
+
+  ;; -----------------------------
+  ;; Schemas & tables
+  ;; -----------------------------
+
+  (defschema config-row
+    @doc "Singleton treasury config."
+    signers:[string]     ;; authorized signer account names
+    threshold:integer)   ;; approvals required to execute
+
+  (deftable config:{config-row})
+
+  (defschema proposal-row
+    @doc "A pending or settled spend proposal."
+    proposer:string
+    recipient:string
+    amount:decimal
+    approvals:[string]   ;; signer accounts that have approved (deduplicated)
+    status:string)       ;; "pending" | "executed" | "cancelled"
+
+  (deftable proposals:{proposal-row})
+
+  (defschema signer-row
+    @doc "Row-level guard for a signer account, captured at enrollment."
+    guard:guard)
+
+  (deftable signer-guards:{signer-row})
+
+  (defconst CONFIG_KEY:string "config")
+
+  (defconst STATUS_PENDING:string "pending")
+  (defconst STATUS_EXECUTED:string "executed")
+  (defconst STATUS_CANCELLED:string "cancelled")
+
+  ;; -----------------------------
+  ;; Events
+  ;; -----------------------------
+
+  (defcap PROPOSED (id:string proposer:string recipient:string amount:decimal)
+    @event true)
+
+  (defcap APPROVED (id:string signer:string approvals:integer)
+    @event true)
+
+  (defcap EXECUTED (id:string recipient:string amount:decimal)
+    @event true)
+
+  (defcap CANCELLED (id:string)
+    @event true)
+
+  (defcap SIGNERS_ROTATED (signers:[string] threshold:integer)
+    @event true)
+
+  ;; -----------------------------
+  ;; Vault account (capability-guarded)
+  ;; -----------------------------
+  ;; The vault is a principal backed by a capability guard requiring SPEND.
+  ;; SPEND is acquired ONLY inside `execute`, after an on-chain threshold check.
+  ;; So coin can debit the vault only during a threshold-approved execution.
+
+  (defcap SPEND ()
+    @doc "Internal permission token gating vault debits. Weak body by design: \
+         \composed/acquired ONLY inside `execute` after the approval threshold \
+         \is verified, and required by the vault account guard. Not acquirable \
+         \from outside this module."
+    true)
+
+  (defun vault-guard-pred:bool ()
+    @doc "User-guard predicate for the vault: satisfied only when SPEND is in \
+         \scope (during a threshold-approved execute)."
+    (require-capability (SPEND)))
+
+  (defun create-vault-guard:guard ()
+    (create-user-guard (vault-guard-pred)))
+
+  (defconst VAULT:string
+    (create-principal (create-vault-guard))
+    "Vault principal account name.")
+
+  ;; -----------------------------
+  ;; Internal helpers
+  ;; -----------------------------
+
+  (defun get-config:object{config-row} ()
+    (read config CONFIG_KEY))
+
+  (defun is-signer:bool (account:string)
+    (contains account (at 'signers (get-config))))
+
+  (defcap SIGNER-AUTH (account:string)
+    @doc "Authenticate ACCOUNT as a current signer: it must be in the signer set \
+         \AND the caller must satisfy its enrolled guard. As a capability, a \
+         \signer can scope their signature to `(treasury.SIGNER-AUTH \"alice\")`, \
+         \so an approval signature does NOT also authorize other operations the \
+         \same key could satisfy in the transaction."
+    ; NODE-SAFETY: `is-signer` reads the config table. A table read inside an
+    ; `enforce` condition passes in the REPL but FAILS on the KDA-CE node
+    ; ('Operation is not allowed in read-only or system-only mode'). Bind the
+    ; read to a local FIRST, then enforce the local. (pact non-negotiable #4)
+    (let ((signer-ok (is-signer account)))
+      (enforce signer-ok "not an authorized signer"))
+    (with-read signer-guards account { 'guard := g }
+      (enforce-guard g)))
+
+  ;; -----------------------------
+  ;; Lifecycle & governance
+  ;; -----------------------------
+
+  (defun account-exists:bool (account:string)
+    @doc "True if ACCOUNT exists on coin. Uses coin's public API (get-balance \
+         \aborts on a missing account); we cannot read coin-table directly \
+         \(cross-module table access requires coin's admin)."
+    (try false (let ((_ (coin.get-balance account))) true)))
+
+  (defun ensure-vault-account:string ()
+    @doc "Create the vault coin account, tolerating a pre-existing one so init \
+         \cannot be front-run bricked. The vault guard is deterministic \
+         \(create-vault-guard); a pre-created vault necessarily carries it \
+         \because the principal name encodes that guard, and coin.create-account \
+         \enforces name==principal(guard). So a pre-existing vault is safe to \
+         \accept, and we only create when absent."
+    ; bind the existence check before branching (no read inside an enforce)
+    (let ((exists (account-exists VAULT)))
+      (if exists
+        "vault already exists"
+        (coin.create-account VAULT (create-vault-guard)))))
+
+  (defun enforce-valid-config:bool (signers:[string] threshold:integer guards:[guard])
+    @doc "Shared validation for the signer set. Rejects an empty set, a \
+         \non-positive or unreachable threshold, a signers/guards length \
+         \mismatch, and duplicate signers (which would silently make N-of-M \
+         \unreachable, since approvals are deduplicated per account)."
+    (enforce (> (length signers) 0) "at least one signer required")
+    (enforce (> threshold 0) "threshold must be positive")
+    (enforce (<= threshold (length signers)) "threshold exceeds signer count")
+    (enforce (= (length signers) (length guards)) "signers/guards length mismatch")
+    (enforce (= (length (distinct signers)) (length signers)) "duplicate signers"))
+
+  (defun init:string (signers:[string] threshold:integer guards:[guard])
+    @doc "One-time setup: configure the signer set + threshold, capture each \
+         \signer's guard, and create the vault coin account. GUARDS must align \
+         \positionally with SIGNERS. Idempotent w.r.t. a pre-created vault \
+         \account (front-run safe); the config insert still enforces one-time \
+         \setup."
+    (with-capability (GOV)
+      (enforce-valid-config signers threshold guards)
+      (insert config CONFIG_KEY { 'signers: signers, 'threshold: threshold })
+      (zip (lambda (s:string g:guard) (write signer-guards s { 'guard: g }))
+           signers guards)
+      (ensure-vault-account)
+      (emit-event (SIGNERS_ROTATED signers threshold))
+      "initialized"))
+
+  (defun rotate-signers:string (signers:[string] threshold:integer guards:[guard])
+    @doc "Governance: replace the signer set + threshold."
+    (with-capability (GOV)
+      (enforce-valid-config signers threshold guards)
+      (update config CONFIG_KEY { 'signers: signers, 'threshold: threshold })
+      (zip (lambda (s:string g:guard) (write signer-guards s { 'guard: g }))
+           signers guards)
+      (emit-event (SIGNERS_ROTATED signers threshold))
+      "rotated"))
+
+  ;; -----------------------------
+  ;; Proposal flow
+  ;; -----------------------------
+
+  (defun propose:string (id:string proposer:string recipient:string amount:decimal)
+    @doc "A signer proposes a spend. ID must be unique. The proposer is counted \
+         \as the first approval. The proposer signs scoped to SIGNER-AUTH."
+    (with-capability (SIGNER-AUTH proposer)
+      (enforce (> amount 0.0) "amount must be positive")
+      (coin.enforce-unit amount)
+      (enforce (!= recipient "") "recipient required")
+      (enforce (!= recipient VAULT) "recipient cannot be the vault")
+      ; reject a proposal that could never execute: the recipient account must
+      ; already exist on this chain. Bind the check before the enforce (node-safe).
+      ; A caller can create the recipient first (coin.create-account) if needed.
+      (let ((recipient-exists (account-exists recipient)))
+        (enforce recipient-exists
+          "recipient account does not exist; create it before proposing"))
+      (insert proposals id
+        { 'proposer: proposer
+        , 'recipient: recipient
+        , 'amount: amount
+        , 'approvals: [proposer]
+        , 'status: STATUS_PENDING })
+      (emit-event (PROPOSED id proposer recipient amount))
+      (emit-event (APPROVED id proposer 1))
+      id))
+
+  (defun approve:string (id:string signer:string)
+    @doc "A signer approves a pending proposal. Idempotent per signer: a repeat \
+         \approval by the same signer is rejected. The signer signs scoped to \
+         \SIGNER-AUTH."
+    (with-capability (SIGNER-AUTH signer)
+      (with-read proposals id
+        { 'approvals := approvals, 'status := status }
+        (enforce (= status STATUS_PENDING) "proposal is not pending")
+        (enforce (not (contains signer approvals)) "signer already approved")
+        (let ((new-approvals (+ approvals [signer])))
+          (update proposals id { 'approvals: new-approvals })
+          (emit-event (APPROVED id signer (length new-approvals)))
+          id))))
+
+  (defun execute:string (id:string)
+    @doc "Execute a proposal that has reached the approval threshold. Debits \
+         \the vault to the recipient exactly once. Callable by anyone once the \
+         \threshold is met (the approvals are the authorization)."
+    (with-read proposals id
+      { 'recipient := recipient
+      , 'amount := amount
+      , 'approvals := approvals
+      , 'status := status }
+      (enforce (= status STATUS_PENDING) "proposal is not pending")
+      ; Count only approvals from CURRENT signers. A signer rotated out (e.g. a
+      ; compromised key) must not have their stale approval count toward the
+      ; threshold. Bind the config read before the enforce (node-safe).
+      (let* ((cfg (get-config))
+             (current-signers (at 'signers cfg))
+             (threshold (at 'threshold cfg))
+             (valid-approvals (filter (lambda (a:string) (contains a current-signers)) approvals)))
+        (enforce (>= (length valid-approvals) threshold)
+          (format "valid approvals {} below threshold {}" [(length valid-approvals) threshold]))
+        ; mark settled BEFORE the transfer (guards against re-execution even if
+        ; coin.transfer re-entered; status is re-checked above on any re-entry)
+        (update proposals id { 'status: STATUS_EXECUTED })
+        (with-capability (SPEND)
+          (install-capability (coin.TRANSFER VAULT recipient amount))
+          (coin.transfer VAULT recipient amount))
+        (emit-event (EXECUTED id recipient amount))
+        id)))
+
+  (defun cancel:string (id:string)
+    @doc "Governance cancels a pending proposal."
+    (with-capability (GOV)
+      (with-read proposals id { 'status := status }
+        (enforce (= status STATUS_PENDING) "proposal is not pending")
+        (update proposals id { 'status: STATUS_CANCELLED })
+        (emit-event (CANCELLED id))
+        id)))
+
+  ;; -----------------------------
+  ;; Views
+  ;; -----------------------------
+
+  (defun get-proposal:object{proposal-row} (id:string)
+    (read proposals id))
+
+  (defun get-vault-account:string () VAULT)
+
+  (defun vault-balance:decimal ()
+    (coin.get-balance VAULT))
+)

--- a/docs/index.json
+++ b/docs/index.json
@@ -54,6 +54,36 @@
 }
 ,
 {
+  "name": "Multisig Treasury (M-of-N)",
+  "slug": "multisig-treasury",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "treasury",
+    "multisig",
+    "governance",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "multisig",
+    "m-of-n",
+    "treasury",
+    "capability-guard"
+  ]
+}
+,
+{
   "name": "Token (fungible-v2 + fungible-xchain-v1)",
   "slug": "token-fungible",
   "version": "0.2.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ _Generated from `contracts/**/metadata.yaml`._
 |------|------|---------|--------------|------|
 | Gas Station (drain-defended) | gas-station | 1.0.0 | self-reviewed | gas-station, gas-payer-v1, gasless, template, library |
 | Hello World | hello-world | 1.0.0 | self-reviewed | hello-world, tutorial, basic |
+| Multisig Treasury (M-of-N) | multisig-treasury | 1.0.0 | self-reviewed | treasury, multisig, governance, template, library |
 | Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
 
 ## Registry — KIP Standards (`registry/kip/`)


### PR DESCRIPTION
## Summary

Third WS3 flagship template: **threshold-controlled KDA custody** — the primitive every DAO, foundation, and company treasury needs. Funds live in a capability-guarded vault spendable **only** through an on-chain proposal that reaches an M-of-N approval threshold from an authenticated signer set. Async approval flow, governance rotate/cancel, an event on every step.

## Three audit passes, two fund-safety bugs caught before shipping

- **Pass 1 — HIGH (fixed).** `enforce-signer` read a table **inside an `enforce` condition** — passes in the REPL but **aborts on the KDA-CE node**. A funded vault could have accepted KDA and then been unable to ever spend it (funds locked). This is the read-in-enforce trap (a documented non-negotiable). Fixed by let-binding the read before the enforce; the whole module was swept (zero remain). Plus F2 (init front-run brick → tolerant `ensure-vault-account`), F3 (`enforce-unit` + recipient-exists), F4 (init event).
- **Pass 2 — MEDIUM (fixed).** Signer rotation didn't revoke stale approvals — a rotated-out (compromised) signer's approval still counted toward the threshold, breaking M-of-N in the exact scenario rotation exists for. `execute` now counts **only** approvals from **current** signers. Plus two LOWs: `SIGNER-AUTH` is now a capability (signers scope their signatures instead of signing unscoped), and duplicate signers are rejected.
- **Pass 3 — GO.** Zero CRITICAL/HIGH/MEDIUM; all prior findings verified closed (F2 confirmed down to the interpreter source). One residual LOW (re-keying a signer *in place* revives stale approvals) is documented with a compromise-response warning.

## Security model

- **Capability-guarded vault** — spendable only inside `execute`, under the internal `SPEND` cap, after the threshold check. Direct `coin.transfer` from the vault fails.
- **Authenticated signers** — `propose`/`approve` acquire `SIGNER-AUTH`, which enforces the signer's enrolled guard; signers scope their signature to it.
- **No double-spend** — status set `executed` before the transfer, re-checked on entry.
- **Threshold over the current set** — rotation drops stale approvals; a single compromised key cannot move funds below threshold.

## Tests + tooling

- **43-assertion self-contained suite** (loads `coin` + interfaces from `registry/`), including regressions for the stale-approval-after-rotation fix, scoped signatures, duplicate-signer rejection, front-run-safe init, and the double-spend / direct-vault-drain / self-dealing guards.
- Static gate: **PASS, 0 violations.** Entry passes the library quality gate. CI runs the suite as a blocking check.

## ⚠️ Important caveat

The read-in-enforce class (Pass 1) is **REPL-invisible** — a green suite cannot prove the on-chain path. The AUDIT and README flag a **devnet run of `propose`/`approve`/`execute` as MANDATORY** before any production use. This is the single most important gate for this entry.

## Verification

- `pact treasury-test.repl`: 43 assertions, 0 failures.
- `validate_contract.sh`: OK. Index regenerated.