### PR TITLE
feat(library): add escrowed vesting template (cliff + linear)

### DIFF
--- a/contracts/library/vesting/AUDIT.md
+++ b/contracts/library/vesting/AUDIT.md
@@ -1,0 +1,129 @@
+# AUDIT — library/vesting
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `vesting` (namespace: project-specific) |
+| **Version** | 1.0.0 |
+| **Audit Status** | self-reviewed |
+| **Category** | PCO Library Template |
+| **Source** | PCO-authored reference implementation |
+| **Last review** | 2026-07-05 |
+
+## Purpose
+
+Deployable template for KDA vesting with cliff + linear release, escrowed
+upfront: a grant locks its full amount in a capability-guarded vault at
+creation; the beneficiary claims the vested portion over time; a revocable
+grant lets the funder reclaim only the unvested remainder. Governance is
+upgrade-only — the deployed code gives it no path to escrowed funds.
+
+## Audit history: findings and fixes
+
+An independent `pact-auditor` pass returned **NO-GO** on the first version
+(zero CRITICAL/HIGH; one MEDIUM ship-stopper). All findings were fixed:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| F1 | **MEDIUM** | `revoke` computed `refund = total − vested(now)` without asserting `vested ≥ claimed`. Under a **non-monotonic block-time**, `vested(now)` could fall below `claimed`, making the refund exceed the grant's own remaining escrow. Because the vault is **shared across grants**, the excess was paid out of *other grants' escrow* — reproduced: a co-tenant grant was left unable to pay its beneficiary (`Insufficient funds`). | `revoke` now binds `claimed` and clamps `vested = max(vested-raw, claimed)`, so the refund is capped at `total − claimed` (this grant's own remaining escrow) and the frozen total stays ≥ claimed (no negative claimable after revoke). Regression-tested (`revoke-g6-clock-rollback`: claim 90 at day 90, revoke with the clock rolled back to day 40 → refund 10, not 60). The `claimable-amount` view is clamped at zero. |
+| F2 | LOW | The beneficiary name was not bound to the enrolled guard, so a **vanity-named** beneficiary could be squatted (account pre-created with a foreign guard), after which every claim failed coin's guard match — a permanent fund lock. | `create-grant` now enforces `(validate-principal beneficiary-guard beneficiary)`. Squatting a principal is impossible (coin's reserved-name protocol rejects a foreign guard) and principal accounts cannot be guard-rotated. Regression-tested (vanity rejection + coin-level squat impossibility). |
+| F3 | LOW | No exit path existed for a locked grant (no admin sweep — by design), so F2's squat-brick was a *permanent* loss state. | Structurally eliminated by the F2 fix: no third-party action can create a locked grant. Residual self-inflicted states are documented below. |
+| F4 | INFO | The header claim "governance has NO path to escrowed funds" was only true of the deployed bytecode — an upgrade can replace it. | Docs tightened: pin the audited module hash; put GOV under a multi-sig keyset. |
+| F5 | INFO | `start`/`cliff`/`end` magnitudes are unbounded (pathological far-future times can overflow time arithmetic). Impact confined to that single grant. | Accepted as-is for a trusted-funder template; documented. |
+
+A **second** independent pass verified F1–F5 closed with no regression —
+including targeted probes of the fix seams: the clamp's bounds were re-derived
+(`refund ∈ [0, total−claimed]` for all inputs), and the principal binding
+survived every self-referential-guard construction (a reconstructed vault
+guard canonicalizes to the vault's own principal, which is rejected by name;
+no alternate construction of the vault predicate yields a different
+principal). Verdict: **GO**, with two new low-impact items — both fixed:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| N1 | LOW | Doc/code mismatch: docs promised `k:/w:/r:` beneficiaries, but the code accepted **any** guard whose principal matched — including syntactically-valid but *unsatisfiable* `c:`/`u:` guards (reproduced: a `c:` capability-guard beneficiary creates fine and every claim fails forever). Funder-self-inflicted lock; no third-party exposure. | `create-grant` now enforces `typeof-principal ∈ {k:, w:, r:}` — the documented restriction is real. Regression-tested (`c:` beneficiary rejected). |
+| N2 | INFO | A claimer who also scopes their signature to the vault's `coin.TRANSFER` cap collides with the module's own `install-capability` and the tx fails (harmlessly, per-tx, user-recoverable). | README usage note: sign `claim`/`revoke` with only `CLAIM-AUTH`/`REVOKE-AUTH`. |
+
+**Residual accepted states (documented, not fixable without custodial power):**
+a beneficiary who loses their key loses access to vested funds — inherent to
+non-custodial escrow; there is deliberately no admin sweep. A grant id can be
+front-run squatted with a dust grant (victim's `create-grant` aborts on the
+insert collision, retries with a fresh id; no funds at risk) — use
+nonce-bearing ids.
+
+## Threat model & defenses
+
+| Vector | Defense | Test |
+|---|---|---|
+| Escrow created without funder consent | funder's own scoped `coin.TRANSFER` signature is the authorization; unscoped sig rejected | `create-grant-no-transfer-sig` |
+| Claim by a non-beneficiary | `CLAIM-AUTH` enforces the guard enrolled at creation | `claim-wrong-key` |
+| Claim signature reused across grants | `CLAIM-AUTH` is per-grant; sig scoped to another grant fails | `claim-sig-scoped-to-other-grant` |
+| Claim before cliff / beyond vested | schedule math + `nothing claimable` gate | `claim-before-cliff`, double-claim cases |
+| Over-claim via rounding | multiply-before-divide, floor to 12 dp, monotonic `claimed` | exact-amount asserts at days 90/182/end |
+| Revoke by a non-funder | `REVOKE-AUTH` enforces the funder's live coin guard | `revoke-wrong-key` |
+| Revoke stealing vested funds | refund = `total − max(vested, claimed)`; frozen remainder stays claimable | `revoke-g2`, `claim-after-revoke` |
+| Cross-grant drain via clock rollback | the F1 clamp caps refund at the grant's own remaining escrow | `revoke-g6-clock-rollback` |
+| Drain the vault directly | vault guard requires `SPEND`, acquired only inside `claim`/`revoke` | `vault-guard-denies` |
+| Squat the beneficiary account | beneficiary must be its guard's principal; coin rejects foreign guards on principals | `squat-impossible`, vanity rejection |
+| Unsatisfiable beneficiary guard (perma-lock) | only key-backed principals (`k:/w:/r:`) accepted | `c:` rejection case |
+| Self-dealing to the vault | `create-grant` rejects the vault as beneficiary | vault-as-beneficiary case |
+| Re-execute / double-pay | `claimed` settled before the transfer; status re-checked | `revoke-twice`, exhausted-grant cases |
+| Governance seizure | no function composes with `GOV`; upgrade-only | capability sweep (both passes) |
+| Value leak anywhere | conservation: suite ends with the vault at exactly `0.0` | `final-conservation` |
+
+## Capability model
+
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard GOV_KEYSET` | upgrade only; referenced by no function |
+| `CLAIM-AUTH (id)` | authentication | enrolled beneficiary guard (read let-bound, then enforced) | acquired by `claim`; signers scope per grant |
+| `REVOKE-AUTH (id)` | authentication | funder's **live** coin guard via `coin.details` | follows a funder key rotation; never revives an old key |
+| `SPEND` | weak-body | — | Safe: acquired ONLY inside `claim`/`revoke` after their guard + amount checks; required by the vault guard; not externally acquirable (verified: an externally reconstructed vault guard canonicalizes to the same rejected principal) |
+| `GRANT_CREATED` / `CLAIMED` / `REVOKED` | `@event` | — | emit-only audit trail |
+
+## Node-safety
+
+Every table read that feeds an `enforce` is bound first (`CLAIM-AUTH`,
+`REVOKE-AUTH`, the claim/revoke amount checks); the clamp code introduced no
+enforce-position reads. This class of bug is REPL-invisible on KDA-CE, so
+**devnet validation of a full `create-grant → claim → revoke` cycle is the
+required evidence** before production use — see the README deployment
+checklist.
+
+## Risk profile
+
+| Risk | Level | Notes |
+|---|---|---|
+| Unauthorized claim/revoke | Low | per-grant scoped caps over enrolled/live guards, regression-tested |
+| Over-payment / double-pay | Low | settle-before-transfer, monotonic `claimed`, floor-12 math |
+| Cross-grant contamination | Low | refund clamp (F1); conservation proven to vault `0.0` |
+| Direct vault drain | Low | capability-guarded principal; `SPEND` internal-only |
+| Permanent fund lock | Low | principal + key-backed enforcement close all third-party vectors; residual = beneficiary key loss (inherent) |
+| Governance dependency | Medium | upgrade power is ultimate power: pin the module hash, multi-sig the keyset |
+| Clock manipulation | Low | block-time is consensus-produced; even a regression only triggers the clamp |
+
+## Static analysis note
+
+`pact-static-check.sh` reports **PASS, 0 violations**. A bare `pact <file>`
+load cannot resolve the module's `coin` calls (missing-upstream-dependency
+class, WARN-scoped to the known allowlist); the authoritative evidence is the
+69-assertion `.repl` harness loading the real `coin`, plus the blocking CI
+test step. The three Tier-2 `enforce-guard` WARNs are dispositioned SAFE —
+all sit inside defcaps (`GOV`, `CLAIM-AUTH`, `REVOKE-AUTH`).
+
+## What self-reviewed means here
+
+Reviewed by the template's maintainers against the PCO checklist, with all
+authorization/schedule/conservation scenarios encoded as runnable regression
+tests, plus two independent `pact-auditor` passes (automated, fresh-context).
+**Not independent human review.** Promotion requires a second reviewer
+(`community-reviewed`) or a third-party report with a matching source hash
+(`independently-audited`) — see `docs/CONTRACT_POLICIES.md` §3.1.
+
+## Reproduce the review
+
+```bash
+cd contracts/library/vesting/examples
+pact vesting-test.repl   # 69 assertions
+```

--- a/contracts/library/vesting/README.md
+++ b/contracts/library/vesting/README.md
@@ -1,0 +1,71 @@
+# Token Vesting (cliff + linear)
+
+PCO library template: **KDA vesting with a cliff and linear release, escrowed upfront**. A grant locks its full amount in a capability-guarded vault the moment it is created, so the beneficiary never depends on the funder staying solvent or honest — and **governance has no path to escrowed funds** (upgrade authority only). This is the safe replacement for ad-hoc escrow/timelock contracts: team and advisor vesting, investor lockups, grant milestones, deferred payments.
+
+## How it works
+
+Funds sit in a **capability-guarded vault account** (a principal whose guard is satisfied only while the internal `SPEND` capability is in scope). `SPEND` is acquired only inside `claim` and `revoke`, after their checks — the vault cannot be debited any other way.
+
+1. **`create-grant id funder beneficiary beneficiary-guard total start cliff end revocable`** — escrows `total` from the funder into the vault. The funder authorizes by signing `coin.TRANSFER` for exactly that amount (they are spending their own funds; no module permission exists to move anyone else's). The beneficiary's guard is enrolled now and authorizes all future claims; **the beneficiary name must be that guard's principal** (`k:`/`w:`/`r:`) — enforced, see Security model. `start` may be in the past (e.g. an employment start date).
+2. **`claim id`** — pays the beneficiary everything vested and not yet claimed. Vesting is 0 before `cliff`, linear in elapsed time from `start` to `end`, and complete at `end`. The beneficiary signs scoped to `(vesting.CLAIM-AUTH "id")`. Payment uses `transfer-create` with the enrolled guard, so the beneficiary account is created on first claim if absent.
+3. **`revoke id`** — only if the grant was created `revocable`, and only by the funder (authenticated against the **current** guard of their coin account, so revoke authority follows a coin key rotation). The grant is frozen at its vested amount — still claimable by the beneficiary — and only the unvested remainder is refunded. Vested funds can never be clawed back.
+
+Every step emits an event (`GRANT_CREATED`, `CLAIMED`, `REVOKED`) for off-chain audit.
+
+## Security model
+
+- **Escrowed upfront.** The full grant moves into the vault at creation. There is no "funder tops up later" state and no way to create an underfunded grant.
+- **Beneficiary is a principal account — enforced.** `create-grant` requires `beneficiary` to be the principal of `beneficiary-guard` (`validate-principal`). This binds the payout name to the enrolled guard: the account can neither be squatted with a foreign guard (coin rejects it at the protocol level) nor guard-rotated out from under the grant (coin forbids rotating principal accounts). Without this, either would leave the escrow permanently unclaimable — there is deliberately no admin sweep.
+- **Refunds are clamped.** `revoke` never refunds more than the grant's own remaining escrow (`total − claimed`), even if `block-time` were ever non-monotonic — one grant's revoke can never be paid out of another grant's funds. `claimable-amount` is likewise clamped at zero.
+- **Non-custodial governance.** The `GOV` keyset can upgrade the module and nothing else — no function under `GOV` touches the vault. (Upgrade power is still absolute power over future code: pin the module hash you audited, and use a multi-sig keyset.)
+- **Vested is untouchable.** `revoke` refunds only `total − vested(now)`; the vested portion stays claimable by the beneficiary forever.
+- **Scoped signatures.** `CLAIM-AUTH` and `REVOKE-AUTH` are capabilities, so a signature authorizes exactly one action on exactly one grant — nothing else the same key could satisfy in the transaction.
+- **Precise math.** The linear schedule multiplies before dividing and floors to coin's 12-decimal precision, so every claim amount is transferable and claims are monotonic (no over-claim at schedule boundaries; the final claim pays the exact remainder, no dust left behind).
+
+## Deployment checklist
+
+1. Wrap the module in your namespace; replace the `"vesting-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig recommended**).
+2. Deploy and `create-table`. There is no init step — grants are self-contained.
+3. Validate the end-to-end flow on **devnet** before mainnet — **mandatory**, not optional (see Known limits; on-chain table-read behavior cannot be proven in the REPL).
+
+## Usage
+
+```pact
+;; funder creates a 1-year grant with a 90-day cliff, revocable
+;; (signs coin.TRANSFER for 365.0 to the vault — vesting.get-vault-account)
+(vesting.create-grant "alice-2026" "k:funder..." "k:alice..." (read-keyset "alice")
+  365.0 (time "2026-01-01T00:00:00Z") (time "2026-04-01T00:00:00Z")
+  (time "2027-01-01T00:00:00Z") true)
+
+;; beneficiary claims whatever has vested (signs scoped to CLAIM-AUTH)
+(vesting.claim "alice-2026")
+
+;; funder revokes the unvested remainder (signs scoped to REVOKE-AUTH)
+(vesting.revoke "alice-2026")
+```
+
+Sign `claim`/`revoke` with **only** the `CLAIM-AUTH`/`REVOKE-AUTH` capability. Do not also scope the signature to the vault's `coin.TRANSFER` — the module installs that capability itself, and a signature-installed duplicate makes the transaction fail (harmlessly; resubmit without it).
+
+## Testing
+
+`examples/vesting-test.repl` is self-contained (loads `coin` + interfaces from `registry/`):
+
+```bash
+cd contracts/library/vesting/examples && pact vesting-test.repl
+```
+
+The suite drives the full lifecycle on a controlled clock — escrow at creation, pre-cliff denial, exact linear amounts at the cliff / mid-schedule / after the end, revocation mid-schedule with the frozen remainder still claimable — plus every authorization attack: claiming with a foreign key, a signature scoped to another grant, revoking someone else's grant, revoking a non-revocable grant, direct vault drains, squatting a beneficiary principal, and a clock-rollback revoke (the refund clamp). It ends with the vault at exactly `0.0`: every escrowed KDA provably claimed or refunded. CI runs this suite as a blocking check.
+
+## Known limits
+
+- **Devnet validation is MANDATORY before mainnet — not optional.** The auth capabilities read on-chain tables; the template binds every read before its `enforce` (the node-safe pattern), but this class of bug is **invisible in the REPL**. Deploy to a devnet node and drive a full `create-grant → claim → revoke` cycle before trusting this with real funds.
+- **Vanity beneficiary names are rejected by design.** The beneficiary must be a principal account (`k:` single key, `w:` multi-key, `r:` keyset reference). This is what guarantees the escrow can always be claimed; see Security model.
+- **The suite's test keys are synthetic.** On a real chain, `k:` account keys are ED25519 public keys; the enforcement is coin's, not this module's.
+- **Grant `id`s are caller-supplied and must be unique** — `create-grant` uses `insert`, so a reused id aborts. Use a scheme like `"<beneficiary>-<purpose>-<nonce>"`.
+- **Revocation is all-or-nothing per grant and irreversible.** A revoked grant is frozen at its vested amount; there is no un-revoke and no partial revoke.
+- **Block time is the parent block's timestamp** (~one block behind wall clock) — irrelevant at vesting timescales, but do not build second-granularity schedules.
+- Governance holds upgrade power. It cannot touch escrowed funds through any function in this module, but an upgrade can change the module. Pin the deployed module hash you audited; use a multi-sig governance keyset.
+
+## License
+
+Apache-2.0

--- a/contracts/library/vesting/examples/vesting-test.repl
+++ b/contracts/library/vesting/examples/vesting-test.repl
@@ -1,0 +1,359 @@
+;; vesting-test.repl — PCO library template test suite
+;;
+;; Self-contained: loads coin + interfaces from this repo's registry tree.
+;;
+;; Drives the full grant lifecycle on a controlled clock (env-chain-data
+;; block-time): escrow-at-creation, cliff, linear claims, revocation of the
+;; unvested portion, and every authorization attack: claiming with the wrong
+;; key, a signature scoped to another grant, revoking someone else's grant,
+;; revoking a non-revocable grant, draining the vault directly, squatting a
+;; beneficiary principal, and a clock-rollback revoke (the refund clamp).
+;; The suite ends with the vault at exactly 0.0 — every escrowed KDA is
+;; either claimed by its beneficiary or refunded to the funder.
+;;
+;; Timeline (grant g1: 365.0 KDA over 365 days = 1 KDA/day, 90-day cliff):
+;;   2026-01-01 start | 2026-04-01 cliff (90) | 2026-07-02 (182) | 2027-01-01 end
+
+;; ---------------------------------------------------------------------------
+;; Setup: coin, keysets, module, table; fund the funder.
+;; Beneficiary accounts are k: principals (create-grant enforces the binding).
+;; ---------------------------------------------------------------------------
+(begin-tx "setup")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../../registry/core/coin/coin-v6.pact")
+(create-table coin-table)
+(env-data
+  { "vesting-gov": ["gov-key"]
+  , "funder": ["funder-key"]
+  , "ben1": ["b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"], "ben2": ["b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"], "ben3": ["b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3"]
+  , "dave": ["dave-key"] })
+(define-keyset "vesting-gov" (read-keyset "vesting-gov"))
+(load "../vesting.pact")
+(create-table grants)
+(coin.create-account "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1"))
+(coin.create-account "dave" (read-keyset "dave"))
+(test-capability (coin.CREDIT "funder"))
+(coin.credit "funder" (read-keyset "funder") 700.0)
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; create-grant parameter validation (no funds move on any of these).
+;; ---------------------------------------------------------------------------
+(begin-tx "create-grant-validation")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [])
+(expect-failure "zero total rejected" "total must be positive"
+  (vesting.create-grant "bad" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 0.0
+    (time "2026-01-01T00:00:00Z") (time "2026-01-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(expect-failure "sub-precision total rejected" "violates minimum precision"
+  (vesting.create-grant "bad" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 0.0000000000001
+    (time "2026-01-01T00:00:00Z") (time "2026-01-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(expect-failure "end before start rejected" "end must be after start"
+  (vesting.create-grant "bad" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 10.0
+    (time "2027-01-01T00:00:00Z") (time "2027-01-01T00:00:00Z")
+    (time "2026-01-01T00:00:00Z") false))
+(expect-failure "cliff before start rejected" "cliff cannot precede start"
+  (vesting.create-grant "bad" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 10.0
+    (time "2026-01-01T00:00:00Z") (time "2025-01-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(expect-failure "cliff after end rejected" "cliff cannot exceed end"
+  (vesting.create-grant "bad" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 10.0
+    (time "2026-01-01T00:00:00Z") (time "2027-06-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(expect-failure "vault as beneficiary rejected" "beneficiary cannot be the vault"
+  (vesting.create-grant "bad" "funder" (vesting.get-vault-account)
+    (read-keyset "ben1") 10.0
+    (time "2026-01-01T00:00:00Z") (time "2026-01-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(expect-failure "vanity beneficiary name rejected"
+  "beneficiary must be the principal of its guard"
+  (vesting.create-grant "bad" "funder" "ben3-vanity" (read-keyset "ben3") 10.0
+    (time "2026-01-01T00:00:00Z") (time "2026-01-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+;; a c: capability-guard principal is valid but unsatisfiable as a payout
+;; target (SPEND is never in scope when CLAIM-AUTH runs) — must be rejected,
+;; or the escrow would be locked forever
+(expect-failure "non-key-backed (c:) beneficiary principal rejected"
+  "beneficiary must be a key-backed principal"
+  (vesting.create-grant "bad" "funder"
+    (create-principal (create-capability-guard (vesting.SPEND)))
+    (create-capability-guard (vesting.SPEND)) 10.0
+    (time "2026-01-01T00:00:00Z") (time "2026-01-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Escrow authorization: without the funder's coin.TRANSFER signature the
+;; grant cannot be created (an unscoped signature does NOT install a managed
+;; capability — the funder must consent explicitly to the exact amount).
+;; ---------------------------------------------------------------------------
+(begin-tx "create-grant-no-transfer-sig")
+(env-sigs [{"key": "funder-key", "caps": []}])
+(expect-failure "create-grant without TRANSFER cap sig fails" "not installed"
+  (vesting.create-grant "g1" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 365.0
+    (time "2026-01-01T00:00:00Z") (time "2026-04-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; g1: 365 KDA / 365 days, 90-day cliff, NON-revocable. Escrowed upfront.
+;; ---------------------------------------------------------------------------
+(begin-tx "create-g1")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [{"key": "funder-key"
+          , "caps": [(coin.TRANSFER "funder" (vesting.get-vault-account) 365.0)]}])
+(expect "g1 created" "g1"
+  (vesting.create-grant "g1" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 365.0
+    (time "2026-01-01T00:00:00Z") (time "2026-04-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(expect "GRANT_CREATED emitted" true
+  (contains "vesting.GRANT_CREATED" (map (at 'name) (env-events true))))
+(expect "escrow moved into the vault" 365.0 (vesting.vault-balance))
+(expect "funder debited upfront" 335.0 (coin.get-balance "funder"))
+(expect "nothing vested at start" 0.0 (vesting.claimable-amount "g1"))
+(commit-tx)
+
+(begin-tx "duplicate-grant-id")
+(env-sigs [{"key": "funder-key"
+          , "caps": [(coin.TRANSFER "funder" (vesting.get-vault-account) 365.0)]}])
+(expect-failure "reused grant id rejected" "already found while in Insert mode"
+  (vesting.create-grant "g1" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 365.0
+    (time "2026-01-01T00:00:00Z") (time "2026-04-01T00:00:00Z")
+    (time "2027-01-01T00:00:00Z") false))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; g2 (revocable, no cliff, 100/100d) and g3 (past schedule = fully vested).
+;; ---------------------------------------------------------------------------
+(begin-tx "create-g2-g3")
+(env-sigs [{"key": "funder-key"
+          , "caps": [(coin.TRANSFER "funder" (vesting.get-vault-account) 150.0)]}])
+(expect "g2 created (revocable)" "g2"
+  (vesting.create-grant "g2" "funder" "k:b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2" (read-keyset "ben2") 100.0
+    (time "2026-01-01T00:00:00Z") (time "2026-01-01T00:00:00Z")
+    (time "2026-04-11T00:00:00Z") true))
+(expect "g3 created (past schedule = instantly vested)" "g3"
+  (vesting.create-grant "g3" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 50.0
+    (time "2025-01-01T00:00:00Z") (time "2025-01-01T00:00:00Z")
+    (time "2025-12-31T00:00:00Z") true))
+(expect "vault holds all escrows" 515.0 (vesting.vault-balance))
+(expect "funder debited for all grants" 185.0 (coin.get-balance "funder"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; A k: beneficiary principal cannot be squatted: coin itself rejects a
+;; foreign guard on a reserved single-key name, so the payout account can
+;; only ever exist with the enrolled guard.
+;; ---------------------------------------------------------------------------
+(begin-tx "squat-impossible")
+(expect-failure "k: principal cannot be squatted with a foreign guard"
+  "Single-key account protocol violation"
+  (coin.create-account "k:b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3" (read-keyset "dave")))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; g3 is past its end: fully claimable immediately.
+;; ---------------------------------------------------------------------------
+(begin-tx "claim-instant")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [{"key": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1", "caps": [(vesting.CLAIM-AUTH "g3")]}])
+(expect "g3 fully vested" 50.0 (vesting.claimable-amount "g3"))
+(expect "g3 claim succeeds" "g3" (vesting.claim "g3"))
+(expect "CLAIMED emitted" true
+  (contains "vesting.CLAIMED" (map (at 'name) (env-events true))))
+(expect "ben1 paid in full" 50.0 (coin.get-balance "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"))
+(expect "vault conservation after g3" 465.0 (vesting.vault-balance))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Before the cliff nothing is claimable.
+;; ---------------------------------------------------------------------------
+(begin-tx "claim-before-cliff")
+(env-chain-data { "block-time": (time "2026-02-01T00:00:00Z") })
+(env-sigs [{"key": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1", "caps": [(vesting.CLAIM-AUTH "g1")]}])
+(expect "pre-cliff claimable is zero" 0.0 (vesting.claimable-amount "g1"))
+(expect-failure "pre-cliff claim fails" "nothing claimable"
+  (vesting.claim "g1"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Claim authorization: only the enrolled beneficiary guard.
+;; ---------------------------------------------------------------------------
+(begin-tx "claim-wrong-key")
+(env-chain-data { "block-time": (time "2026-04-01T00:00:00Z") })
+(env-sigs [{"key": "dave-key", "caps": [(vesting.CLAIM-AUTH "g1")]}])
+(expect-failure "claim with a foreign key fails" "Keyset failure"
+  (vesting.claim "g1"))
+(rollback-tx)
+
+(begin-tx "claim-sig-scoped-to-other-grant")
+(env-chain-data { "block-time": (time "2026-04-01T00:00:00Z") })
+;; ben1's key, but scoped to g3 only — must not authorize a g1 claim
+(env-sigs [{"key": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1", "caps": [(vesting.CLAIM-AUTH "g3")]}])
+(expect-failure "sig scoped to another grant fails" "Keyset failure"
+  (vesting.claim "g1"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Revocation window (2026-02-10 = day 40 of g2's 100-day schedule).
+;; ---------------------------------------------------------------------------
+(begin-tx "revoke-wrong-key")
+(env-chain-data { "block-time": (time "2026-02-10T00:00:00Z") })
+(env-sigs [{"key": "dave-key", "caps": [(vesting.REVOKE-AUTH "g2")]}])
+(expect-failure "non-funder cannot revoke" "Keyset failure"
+  (vesting.revoke "g2"))
+(rollback-tx)
+
+(begin-tx "revoke-non-revocable")
+(env-chain-data { "block-time": (time "2026-02-10T00:00:00Z") })
+(env-sigs [{"key": "funder-key", "caps": [(vesting.REVOKE-AUTH "g1")]}])
+(expect-failure "non-revocable grant cannot be revoked" "grant is not revocable"
+  (vesting.revoke "g1"))
+(rollback-tx)
+
+(begin-tx "revoke-g2")
+(env-chain-data { "block-time": (time "2026-02-10T00:00:00Z") })
+(env-sigs [{"key": "funder-key", "caps": [(vesting.REVOKE-AUTH "g2")]}])
+(expect "g2 revoked" "g2" (vesting.revoke "g2"))
+(expect "REVOKED emitted" true
+  (contains "vesting.REVOKED" (map (at 'name) (env-events true))))
+(expect "unvested 60 refunded to funder" 245.0 (coin.get-balance "funder"))
+(expect "vault conservation after revoke" 405.0 (vesting.vault-balance))
+(expect "g2 frozen at vested amount" 40.0 (at 'total (vesting.get-grant "g2")))
+(expect "g2 status revoked" "revoked" (at 'status (vesting.get-grant "g2")))
+(commit-tx)
+
+(begin-tx "revoke-twice")
+(env-sigs [{"key": "funder-key", "caps": [(vesting.REVOKE-AUTH "g2")]}])
+(expect-failure "already-revoked grant cannot be revoked again" "grant is not active"
+  (vesting.revoke "g2"))
+(rollback-tx)
+
+(begin-tx "revoke-fully-vested")
+(env-chain-data { "block-time": (time "2026-02-10T00:00:00Z") })
+(env-sigs [{"key": "funder-key", "caps": [(vesting.REVOKE-AUTH "g3")]}])
+(expect-failure "fully vested grant has nothing to revoke"
+  "nothing to revoke; grant fully vested"
+  (vesting.revoke "g3"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; A revoked grant still owes its vested remainder — and nothing more.
+;; ben2 has NO coin account yet: the first claim creates it with the
+;; enrolled guard (transfer-create).
+;; ---------------------------------------------------------------------------
+(begin-tx "claim-after-revoke")
+(env-chain-data { "block-time": (time "2026-02-10T00:00:00Z") })
+(env-sigs [{"key": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2", "caps": [(vesting.CLAIM-AUTH "g2")]}])
+(expect "revoked grant owes its vested part" 40.0 (vesting.claimable-amount "g2"))
+(expect "vested remainder claimable after revoke" "g2" (vesting.claim "g2"))
+(expect "ben2 account auto-created and paid" 40.0 (coin.get-balance "k:b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"))
+(commit-tx)
+
+(begin-tx "revoked-grant-stops-vesting")
+;; months later: a revoked grant must NOT keep accruing
+(env-chain-data { "block-time": (time "2026-07-02T00:00:00Z") })
+(env-sigs [{"key": "b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2", "caps": [(vesting.CLAIM-AUTH "g2")]}])
+(expect "no further accrual after revoke" 0.0 (vesting.claimable-amount "g2"))
+(expect-failure "nothing further to claim on a revoked grant" "nothing claimable"
+  (vesting.claim "g2"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; g1 linear schedule: claim at the cliff (day 90), mid-way (day 182), and
+;; after the end; a repeat claim at the same block yields nothing.
+;; ---------------------------------------------------------------------------
+(begin-tx "claim-at-cliff")
+(env-chain-data { "block-time": (time "2026-04-01T00:00:00Z") })
+(env-sigs [{"key": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1", "caps": [(vesting.CLAIM-AUTH "g1")]}])
+(expect "day-90 vesting = 90" 90.0 (vesting.claimable-amount "g1"))
+(expect "cliff claim succeeds" "g1" (vesting.claim "g1"))
+(expect "ben1 balance after cliff claim" 140.0 (coin.get-balance "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"))
+(expect-failure "double claim in the same block yields nothing" "nothing claimable"
+  (vesting.claim "g1"))
+(commit-tx)
+
+(begin-tx "claim-mid-schedule")
+(env-chain-data { "block-time": (time "2026-07-02T00:00:00Z") })
+(env-sigs [{"key": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1", "caps": [(vesting.CLAIM-AUTH "g1")]}])
+(expect "day-182 claimable = 92 (182 vested - 90 claimed)" 92.0
+  (vesting.claimable-amount "g1"))
+(expect "mid-schedule claim succeeds" "g1" (vesting.claim "g1"))
+(expect "ben1 balance after mid claim" 232.0 (coin.get-balance "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"))
+(commit-tx)
+
+(begin-tx "claim-after-end")
+(env-chain-data { "block-time": (time "2027-06-01T00:00:00Z") })
+(env-sigs [{"key": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1", "caps": [(vesting.CLAIM-AUTH "g1")]}])
+(expect "post-end claimable = full remainder" 183.0 (vesting.claimable-amount "g1"))
+(expect "final claim succeeds" "g1" (vesting.claim "g1"))
+(expect "ben1 received the full grant" 415.0 (coin.get-balance "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"))
+(expect-failure "exhausted grant yields nothing" "nothing claimable"
+  (vesting.claim "g1"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Vault cannot be drained outside claim/revoke.
+;; ---------------------------------------------------------------------------
+(begin-tx "vault-guard-denies")
+(env-sigs [{"key": "dave-key"
+          , "caps": [(coin.TRANSFER (vesting.get-vault-account) "dave" 10.0)]}])
+(expect-failure "direct vault debit denied (SPEND not in scope)"
+  "not granted: (vesting.SPEND)"
+  (coin.transfer (vesting.get-vault-account) "dave" 10.0))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Clock-rollback regression: block-time is the parent block's timestamp and
+;; is assumed monotonic, but the refund math must not depend on that. After
+;; the beneficiary has claimed 90, a revoke evaluated at an EARLIER
+;; block-time (vested-raw 40 < claimed 90) must clamp: refund is capped at
+;; the grant's own remaining escrow (10), never paid from other grants.
+;; ---------------------------------------------------------------------------
+(begin-tx "create-g6")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [{"key": "funder-key"
+          , "caps": [(coin.TRANSFER "funder" (vesting.get-vault-account) 100.0)]}])
+(expect "g6 created (revocable, 100/100d)" "g6"
+  (vesting.create-grant "g6" "funder" "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1" (read-keyset "ben1") 100.0
+    (time "2026-01-01T00:00:00Z") (time "2026-01-01T00:00:00Z")
+    (time "2026-04-11T00:00:00Z") true))
+(commit-tx)
+
+(begin-tx "claim-g6-day90")
+(env-chain-data { "block-time": (time "2026-04-01T00:00:00Z") })
+(env-sigs [{"key": "b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1", "caps": [(vesting.CLAIM-AUTH "g6")]}])
+(expect "g6 day-90 claim = 90" 90.0 (vesting.claimable-amount "g6"))
+(expect "g6 claim succeeds" "g6" (vesting.claim "g6"))
+(expect "ben1 balance after g6 claim" 505.0 (coin.get-balance "k:b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1"))
+(commit-tx)
+
+(begin-tx "revoke-g6-clock-rollback")
+;; the clock REGRESSES to day 40: raw vested (40) < already claimed (90)
+(env-chain-data { "block-time": (time "2026-02-10T00:00:00Z") })
+(env-sigs [{"key": "funder-key", "caps": [(vesting.REVOKE-AUTH "g6")]}])
+(expect "claimable view clamped at zero under clock rollback" 0.0
+  (vesting.claimable-amount "g6"))
+(expect "rollback revoke succeeds" "g6" (vesting.revoke "g6"))
+(expect "refund clamped to g6's remaining escrow (10, not 60)" 155.0
+  (coin.get-balance "funder"))
+(expect "g6 frozen at claimed (clamp), not at raw vested" 90.0
+  (at 'total (vesting.get-grant "g6")))
+(expect "no negative claimable on the revoked grant" 0.0
+  (vesting.claimable-amount "g6"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Conservation: every escrowed KDA is accounted for. All grants settled;
+;; the vault ends EMPTY — nothing stranded, nothing over-paid.
+;; ---------------------------------------------------------------------------
+(begin-tx "final-conservation")
+(expect "vault fully settled" 0.0 (vesting.vault-balance))
+(expect "g1 fully claimed" 365.0 (at 'claimed (vesting.get-grant "g1")))
+(expect "g2 claimed equals frozen total" 40.0 (at 'claimed (vesting.get-grant "g2")))
+(expect "funder net = 700 - 365 (g1) - 40 (g2 vested) - 50 (g3) - 90 (g6 vested)" 155.0
+  (coin.get-balance "funder"))
+(commit-tx)

--- a/contracts/library/vesting/metadata.yaml
+++ b/contracts/library/vesting/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'Token Vesting (cliff + linear)'
+slug: 'vesting'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['vesting', 'escrow', 'timelock', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'vesting', 'cliff', 'linear-release', 'escrow', 'capability-guard']

--- a/contracts/library/vesting/vesting.pact
+++ b/contracts/library/vesting/vesting.pact
@@ -1,0 +1,297 @@
+(module vesting GOV
+
+  @doc "PCO library template: KDA vesting with cliff + linear release,           \
+  \escrowed upfront.                                                             \
+  \                                                                              \
+  \A grant locks its FULL amount in a module-owned (capability-guarded) vault    \
+  \at creation - the beneficiary never depends on the funder staying solvent    \
+  \or honest. The beneficiary claims the vested portion over time; if the       \
+  \grant is revocable, the funder can revoke the UNVESTED portion back, but     \
+  \never what has already vested.                                               \
+  \                                                                              \
+  \Model:                                                                        \
+  \  - `create-grant` escrows TOTAL from the funder into the vault (the         \
+  \    funder's own coin.TRANSFER signature is the authorization).              \
+  \  - vested(t): 0 before CLIFF; linear from START to END; TOTAL after END.    \
+  \  - `claim` pays (vested - claimed) to the beneficiary account, guarded by   \
+  \    the guard enrolled at grant creation.                                    \
+  \  - `revoke` (only if the grant was created revocable) freezes the grant at  \
+  \    its vested amount and refunds the rest to the funder.                    \
+  \  - The DEPLOYED code gives governance NO path to escrowed funds (upgrade    \
+  \    authority only). An upgrade can change that code: pin the module hash    \
+  \    you audited and put GOV under a multi-sig keyset.                        \
+  \                                                                              \
+  \Deployment checklist (see README.md):                                         \
+  \  1. Wrap in your namespace; replace the 'vesting-gov' keyset.                \
+  \  2. Deploy; no init step - grants are self-contained.                        \
+  \  3. Validate on devnet before mainnet."
+
+  ;; -----------------------------
+  ;; Governance
+  ;; -----------------------------
+
+  (defconst GOV_KEYSET:string "vesting-gov"
+    @doc "Governance keyset name. Replace with your deployed, namespace- \
+         \qualified keyset (multi-sig recommended). In the deployed code \
+         \governance can upgrade the module and nothing else - no function \
+         \under GOV touches escrowed funds - but upgrade power IS ultimate \
+         \power over future code, so treat this keyset accordingly.")
+
+  (defcap GOV ()
+    @doc "Module governance: upgrade only. No fund paths."
+    (enforce-guard (keyset-ref-guard GOV_KEYSET)))
+
+  ;; -----------------------------
+  ;; Schema & table
+  ;; -----------------------------
+
+  (defschema grant-row
+    @doc "One vesting grant. TOTAL is frozen to the vested amount on revoke."
+    funder:string             ;; coin account that escrowed the funds (refund target)
+    beneficiary:string        ;; coin account paid on claim
+    beneficiary-guard:guard   ;; guard enrolled at creation; authorizes claims
+    total:decimal             ;; total granted (frozen at vested-at-revoke on revoke)
+    claimed:decimal           ;; amount already claimed
+    start:time                ;; vesting start (may be in the past)
+    cliff:time                ;; nothing is claimable before this (start <= cliff <= end)
+    end:time                  ;; fully vested at/after this (end > start)
+    revocable:bool            ;; whether the funder may revoke the unvested part
+    status:string)            ;; "active" | "revoked"
+
+  (deftable grants:{grant-row})
+
+  (defconst STATUS_ACTIVE:string "active")
+  (defconst STATUS_REVOKED:string "revoked")
+
+  (defconst COIN_PRECISION:integer 12
+    @doc "coin's minimum-precision unit; vested amounts are floored to it so \
+         \claim transfers always satisfy coin.enforce-unit.")
+
+  ;; -----------------------------
+  ;; Events
+  ;; -----------------------------
+
+  (defcap GRANT_CREATED (id:string funder:string beneficiary:string total:decimal
+                         start:time cliff:time end:time revocable:bool)
+    @event true)
+
+  (defcap CLAIMED (id:string beneficiary:string amount:decimal)
+    @event true)
+
+  (defcap REVOKED (id:string funder:string refund:decimal vested:decimal)
+    @event true)
+
+  ;; -----------------------------
+  ;; Vault account (capability-guarded)
+  ;; -----------------------------
+  ;; The vault is a principal backed by a capability guard requiring SPEND.
+  ;; SPEND is acquired ONLY inside `claim` and `revoke`, after their checks.
+  ;; So coin can debit the vault only through those two audited paths.
+
+  (defcap SPEND ()
+    @doc "Internal permission token gating vault debits. Weak body by design: \
+         \composed/acquired ONLY inside `claim` (after the beneficiary-guard + \
+         \claimable checks) and `revoke` (after the funder-guard + revocable \
+         \checks), and required by the vault account guard. Not acquirable \
+         \from outside this module."
+    true)
+
+  (defun vault-guard-pred:bool ()
+    @doc "User-guard predicate for the vault: satisfied only while SPEND is in \
+         \scope (during a claim or revoke)."
+    (require-capability (SPEND)))
+
+  (defun create-vault-guard:guard ()
+    (create-user-guard (vault-guard-pred)))
+
+  (defconst VAULT:string
+    (create-principal (create-vault-guard))
+    "Vault principal account name.")
+
+  ;; -----------------------------
+  ;; Authentication capabilities
+  ;; -----------------------------
+
+  (defcap CLAIM-AUTH (id:string)
+    @doc "Authenticate the beneficiary of grant ID via the guard enrolled at \
+         \grant creation. As a capability, the beneficiary scopes their \
+         \signature to `(vesting.CLAIM-AUTH \"my-grant\")`, so it does not also \
+         \authorize other operations their key could satisfy in the transaction."
+    ; NODE-SAFETY: bind the table read to a local FIRST, then enforce - a table
+    ; read evaluated inside an enforce condition passes in the REPL but FAILS
+    ; on the KDA-CE node. (pact non-negotiable #4)
+    (let ((g (at 'beneficiary-guard (read grants id))))
+      (enforce-guard g)))
+
+  (defcap REVOKE-AUTH (id:string)
+    @doc "Authenticate the funder of grant ID via the CURRENT guard of their \
+         \coin account (looked up live, so revoke authority follows a coin \
+         \key rotation instead of reviving a compromised old key)."
+    (let* ((funder (at 'funder (read grants id)))
+           (fg (at 'guard (coin.details funder))))
+      (enforce-guard fg)))
+
+  ;; -----------------------------
+  ;; Vesting math
+  ;; -----------------------------
+
+  (defun chain-time:time ()
+    @doc "Current block time (the PARENT block's timestamp on Chainweb - about \
+         \one block behind wall-clock, irrelevant at vesting timescales)."
+    (at 'block-time (chain-data)))
+
+  (defun compute-vested:decimal (total:decimal start:time cliff:time end:time at-time:time)
+    @doc "Schedule function: 0 before CLIFF; TOTAL at/after END; otherwise \
+         \linear in elapsed time since START, floored to coin precision so the \
+         \result is always transferable. Multiplies BEFORE dividing: decimal \
+         \division is the only lossy step, so it must come last (dividing \
+         \first, e.g. total * (elapsed/duration), loses precision and can \
+         \understate exact schedule points)."
+    (if (< at-time cliff)
+      0.0
+      (if (>= at-time end)
+        total
+        (floor (/ (* total (diff-time at-time start)) (diff-time end start))
+               COIN_PRECISION))))
+
+  (defun vested-amount:decimal (id:string)
+    @doc "Amount vested for grant ID as of now. A revoked grant is frozen: its \
+         \TOTAL was set to the vested amount at revoke time."
+    (with-read grants id
+      { 'total := total, 'start := start, 'cliff := cliff
+      , 'end := end, 'status := status }
+      (if (= status STATUS_REVOKED)
+        total
+        (compute-vested total start cliff end (chain-time)))))
+
+  (defun claimable-amount:decimal (id:string)
+    @doc "Amount the beneficiary of grant ID could claim right now. Clamped \
+         \to zero: under a regressed block-time the raw difference could be \
+         \negative, and integrators should never see a negative claimable."
+    (with-read grants id { 'claimed := claimed }
+      (let ((raw (- (vested-amount id) claimed)))
+        (if (> raw 0.0) raw 0.0))))
+
+  ;; -----------------------------
+  ;; Grant lifecycle
+  ;; -----------------------------
+
+  (defun create-grant:string (id:string funder:string beneficiary:string
+                              beneficiary-guard:guard total:decimal
+                              start:time cliff:time end:time revocable:bool)
+    @doc "Create grant ID and escrow TOTAL from FUNDER into the vault. The \
+         \funder authorizes by signing coin.TRANSFER (they are spending their \
+         \own funds); no module-level permission is required. ID must be \
+         \unique. BENEFICIARY-GUARD is enrolled now and authorizes all claims. \
+         \BENEFICIARY must be the principal of that guard (k:/w:/r:): this \
+         \binds the payout name to the enrolled guard, so the account can \
+         \neither be squatted with a foreign guard (coin rejects it) nor \
+         \guard-rotated out from under the grant (coin forbids rotating \
+         \principal accounts) - without it, either would leave the escrow \
+         \permanently unclaimable. START may be in the past (e.g. an \
+         \employment start date)."
+    (enforce (> total 0.0) "total must be positive")
+    (coin.enforce-unit total)
+    (enforce (!= beneficiary VAULT) "beneficiary cannot be the vault")
+    (enforce (validate-principal beneficiary-guard beneficiary)
+      "beneficiary must be the principal of its guard")
+    ; key-backed principals only: a u:/c: guard can be syntactically valid yet
+    ; unsatisfiable (e.g. a capability guard no one can ever bring into scope),
+    ; which would lock the escrow forever - and there is no admin sweep.
+    (let ((protocol (typeof-principal beneficiary)))
+      (enforce (contains protocol ["k:" "w:" "r:"])
+        "beneficiary must be a key-backed principal (k:/w:/r:)"))
+    (enforce (< start end) "end must be after start")
+    (enforce (>= cliff start) "cliff cannot precede start")
+    (enforce (<= cliff end) "cliff cannot exceed end")
+    (insert grants id
+      { 'funder: funder
+      , 'beneficiary: beneficiary
+      , 'beneficiary-guard: beneficiary-guard
+      , 'total: total
+      , 'claimed: 0.0
+      , 'start: start
+      , 'cliff: cliff
+      , 'end: end
+      , 'revocable: revocable
+      , 'status: STATUS_ACTIVE })
+    ; escrow upfront: the funder's coin.TRANSFER signature authorizes this.
+    ; transfer-create binds the vault to its deterministic capability guard,
+    ; so a pre-created vault account with the right guard is tolerated and a
+    ; squatted one with a different guard aborts (front-run safe).
+    (coin.transfer-create funder VAULT (create-vault-guard) total)
+    (emit-event (GRANT_CREATED id funder beneficiary total start cliff end revocable))
+    id)
+
+  (defun claim:string (id:string)
+    @doc "Pay the beneficiary everything vested and not yet claimed. Requires \
+         \the beneficiary's signature scoped to (CLAIM-AUTH id). Pays via \
+         \transfer-create with the enrolled guard, so the beneficiary account \
+         \is created on first claim if absent, and a squatted account with a \
+         \different guard cannot receive the funds. Works on both active and \
+         \revoked grants (a revoked grant still owes its vested remainder)."
+    (with-capability (CLAIM-AUTH id)
+      (with-read grants id
+        { 'beneficiary := beneficiary
+        , 'beneficiary-guard := beneficiary-guard
+        , 'claimed := claimed }
+        (let* ((vested (vested-amount id))
+               (claimable (- vested claimed)))
+          (enforce (> claimable 0.0) "nothing claimable")
+          ; settle BEFORE the transfer (defends re-entry; claimed only grows)
+          (update grants id { 'claimed: (+ claimed claimable) })
+          (with-capability (SPEND)
+            (install-capability (coin.TRANSFER VAULT beneficiary claimable))
+            (coin.transfer-create VAULT beneficiary beneficiary-guard claimable))
+          (emit-event (CLAIMED id beneficiary claimable))
+          id))))
+
+  (defun revoke:string (id:string)
+    @doc "Funder revokes the UNVESTED portion of a revocable grant: the grant \
+         \is frozen at its vested amount (still claimable by the beneficiary) \
+         \and the rest is refunded to the funder. Requires the funder's \
+         \signature scoped to (REVOKE-AUTH id). Fails if the grant is not \
+         \revocable, already revoked, or already fully vested."
+    (with-capability (REVOKE-AUTH id)
+      (with-read grants id
+        { 'funder := funder
+        , 'total := total
+        , 'claimed := claimed
+        , 'start := start
+        , 'cliff := cliff
+        , 'end := end
+        , 'revocable := revocable
+        , 'status := status }
+        (enforce revocable "grant is not revocable")
+        (enforce (= status STATUS_ACTIVE) "grant is not active")
+        ; Clamp vested to at least CLAIMED. The vault is shared across grants:
+        ; if block-time ever regressed (non-monotonic clock), an unclamped
+        ; vested below claimed would make refund exceed this grant's remaining
+        ; escrow (total - claimed) and pay the excess out of OTHER grants'
+        ; funds. The clamp also keeps the frozen total >= claimed, so the
+        ; revoked grant's claimable can never go negative.
+        (let* ((vested-raw (compute-vested total start cliff end (chain-time)))
+               (vested (if (> vested-raw claimed) vested-raw claimed))
+               (refund (- total vested)))
+          (enforce (> refund 0.0) "nothing to revoke; grant fully vested")
+          ; freeze BEFORE the transfer: total := vested, so future claims can
+          ; pay out exactly the earned remainder and nothing more
+          (update grants id { 'total: vested, 'status: STATUS_REVOKED })
+          (with-capability (SPEND)
+            (install-capability (coin.TRANSFER VAULT funder refund))
+            (coin.transfer VAULT funder refund))
+          (emit-event (REVOKED id funder refund vested))
+          id))))
+
+  ;; -----------------------------
+  ;; Views
+  ;; -----------------------------
+
+  (defun get-grant:object{grant-row} (id:string)
+    (read grants id))
+
+  (defun get-vault-account:string () VAULT)
+
+  (defun vault-balance:decimal ()
+    (coin.get-balance VAULT))
+)

--- a/docs/index.json
+++ b/docs/index.json
@@ -112,6 +112,37 @@
 }
 ,
 {
+  "name": "Token Vesting (cliff + linear)",
+  "slug": "vesting",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "vesting",
+    "escrow",
+    "timelock",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "vesting",
+    "cliff",
+    "linear-release",
+    "escrow",
+    "capability-guard"
+  ]
+}
+,
+{
   "name": "free.cyberfly_node",
   "namespace": "free",
   "module": "cyberfly_node",

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ _Generated from `contracts/**/metadata.yaml`._
 | Hello World | hello-world | 1.0.0 | self-reviewed | hello-world, tutorial, basic |
 | Multisig Treasury (M-of-N) | multisig-treasury | 1.0.0 | self-reviewed | treasury, multisig, governance, template, library |
 | Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
+| Token Vesting (cliff + linear) | vesting | 1.0.0 | self-reviewed | vesting, escrow, timelock, template, library |
 
 ## Registry — KIP Standards (`registry/kip/`)
 


### PR DESCRIPTION
## What

New PCO library template: `contracts/library/vesting` — KDA vesting with cliff + linear release, **escrowed upfront**. This is the library's safe answer to the escrow/timelock use case; the registry's `p2p-escrow` snapshot (ungoverned upgrade, `unaudited`) stays as an observatory entry, but the catalog now offers a hardened alternative.

- Full grant amount locked in a **capability-guarded vault** at creation — the funder's own scoped `coin.TRANSFER` signature is the authorization; no underfunded grants, no rug.
- vested(t): 0 before cliff, linear start→end (multiply-before-divide, floor-12), total after end.
- `claim` pays the guard **enrolled at creation** via `transfer-create`; beneficiary must be a key-backed principal (`k:`/`w:`/`r:`) — enforced, which makes squatting and guard-rotation locks impossible.
- `revoke` (per-grant opt-in, funder-only, authenticated against the funder's **live** coin guard) freezes the grant at its vested amount and refunds only the unvested remainder — clamped so a refund can never exceed the grant's own remaining escrow.
- **Governance is upgrade-only**: no function in the deployed code composes with `GOV`; docs mandate hash-pinning + multi-sig.

## Review process

Two independent `pact-auditor` passes (fresh context each):

- **Pass 1 — NO-GO**: MEDIUM — revoke refund unclamped: under a non-monotonic block-time the refund exceeded the grant's remaining escrow and was paid out of *other grants'* escrow (reproduced; co-tenant grant bricked). Fixed with the `max(vested, claimed)` clamp. LOW ×2 — beneficiary name/guard binding (fixed with `validate-principal`) and the resulting permanent-lock state (structurally eliminated by the same fix). INFO ×2 — doc tightening (upgrade power), unbounded time magnitudes (accepted, documented).
- **Pass 2 — GO**: all Pass-1 findings verified closed (clamp bounds re-derived; principal binding survived every self-referential-guard probe). Its N1 (docs promised k:/w:/r: but code accepted unsatisfiable `c:`/`u:` guards) fixed by enforcing `typeof-principal`; N2 integration note added to README.

## Evidence

- `examples/vesting-test.repl`: **69 assertions**, self-contained (loads coin + interfaces from `registry/`), driven on a controlled clock; ends with the vault at exactly **0.0** — every escrowed KDA provably claimed or refunded. Runs as a blocking CI step.
- Static gate: PASS, 0 violations.
- `AUDIT.md` documents both passes, threat model, capability model, and the node-safety caveat: **devnet validation of create→claim→revoke is mandatory before mainnet** (read-in-enforce class is REPL-invisible; the code is written to the node-safe pattern, devnet is the only proof).
- Index regenerated; entry validates under the library quality gate at `self-reviewed`.