### PR TITLE
feat(library): add DAO voting template (membership, quorum + threshold)

### DIFF
--- a/contracts/library/dao-voting/AUDIT.md
+++ b/contracts/library/dao-voting/AUDIT.md
@@ -1,0 +1,119 @@
+# AUDIT — library/dao-voting
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `dao-voting` (namespace: project-specific) |
+| **Version** | 1.0.0 |
+| **Audit Status** | self-reviewed |
+| **Category** | PCO Library Template |
+| **Source** | PCO-authored reference implementation |
+| **Last review** | 2026-07-05 |
+
+## Purpose
+
+Deployable template for membership-based on-chain voting: a governed member
+set votes yes/no/abstain on deadline-bounded proposals; settlement checks a
+quorum (participation vs. current members) and an approval threshold (yes vs.
+yes+no). Custodies no funds — it produces an auditable decision record,
+intended to pair with the multisig-treasury template.
+
+## Audit history: findings and fixes
+
+An independent `pact-auditor` pass returned **GO with required dispositions**
+(zero CRITICAL/HIGH; one MEDIUM, two LOW, three INFO). All required items
+were implemented:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| M-1 | **MEDIUM** | `close` read quorum/threshold from **live config**, so governance could rotate the percentages after votes were cast on an open proposal and move the passage bar — including **force-passing a motion the members rejected** (reproduced: 1-yes/2-no at threshold 60 → governance drops threshold to 1 → close returns "passed"). Especially serious because this module's output is meant to authorize treasury actions. | Quorum/threshold are now **snapshotted into the proposal row at propose time**; `close` settles against the snapshot. The member *set* deliberately stays live (that is what lets rotation revoke a compromised member's votes); the residual governance influence via the member list is documented and event-audited. Regression-tested (`close-p8-snapshot-holds`: governance lowering the bar to 1/1 does not flip an open proposal; `new-proposal-uses-new-bar`: future proposals use the new bar). |
+| L-1 | LOW | No upper bound on the member count. `close` is O(members × voters); the docs claimed "bounded by member count" with no tested ceiling. | `MAX_MEMBERS = 200` enforced in the shared config validation, backed by the auditor's gas measurements (344 / 858 / 2,693 gas at 50 / 100 / 200 all-voting members — quadratic, but ~2 orders of magnitude under the 150k ceiling at the cap). Regression-tested (201 members rejected). |
+| L-2 | LOW | Coverage gaps: the shipped suite did not exercise the M-1 vector, the in-place re-key sharp edge, exact-at-threshold boundaries, or single-member edges. | All folded into the shipped suite: snapshot regression, re-key revival (documented sharp edge, asserted), inclusive quorum+threshold exact boundaries, single-member 100/100 (sole-yes passes, silence fails quorum). |
+
+**Informational (confirmed, accepted):**
+
+- **Re-key revival.** Re-enrolling a compromised member under the *same name*
+  with a new guard revives the old key's votes on still-open proposals — the
+  unavoidable dual of keying votes by name (which is what makes
+  rotation-revocation work). The compromise response is to **remove the
+  name**; documented in module doc + README and *proven* in the suite
+  (`close-p10-rekey-revives`).
+- **MEMBER-AUTH scope.** The capability is per-account (not per-proposal): one
+  scoped signature lets a member act on multiple proposals in one transaction,
+  but cannot double-vote any single proposal and cannot authorize anything
+  outside this module. Sound design, verified by probe.
+- **Proposal-id squatting.** A member can front-run another member's intended
+  id (insert collision; retry with a fresh id). Member-gated griefing only.
+
+## Threat model & defenses
+
+| Vector | Defense | Test |
+|---|---|---|
+| Non-member proposes/votes | `MEMBER-AUTH` checks current membership | `propose-non-member`, `vote-non-member` |
+| Impersonate a member by name | `MEMBER-AUTH` enforces the enrolled guard | `propose-wrong-key`, `vote-wrong-key` |
+| Vote twice (any choice combination) | member checked against all three choice lists | `vote-p1` double-vote case |
+| Alter/remove a cast vote | append-only lists; no mutation path exists | capability sweep |
+| Vote after the deadline / on settled | strict `< deadline` + `status = open` gates | `vote-at-deadline`, `close-settled`, `cancelled-is-dead` |
+| Settle early / re-settle | `>= deadline` + `status = open`; status settles before event | `close-before-deadline`, re-close case |
+| Governance moves the bar on an open proposal | per-proposal quorum/threshold snapshot | `close-p8-snapshot-holds` |
+| Rotated-out member's vote counts | `close` filters votes to current members | `close-p6-stale-vote-dropped` |
+| Zero-yes passage (all-abstain quorum) | `yes > 0` required to pass | `close-outcome-matrix` p4 |
+| Quorum/threshold math manipulation | integer-only products (no division/rounding) | `exact-boundaries`, `single-member-dao` |
+| Gas-exhaustion via giant member set | `MAX_MEMBERS = 200` (measured ~2.7k gas at cap) | `member-cap` |
+| Governance votes or flips outcomes | `GOV` has no vote path; settled proposals immutable | capability sweep + re-close case |
+
+## Capability model
+
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard GOV_KEYSET` | init / rotate-members / cancel / upgrade; cannot vote |
+| `MEMBER-AUTH (account)` | authentication | current membership + enrolled guard (reads let-bound, then enforced) | acquired by `propose`/`vote`; members sign scoped |
+| `PROPOSED`/`VOTED`/`CLOSED`/`CANCELLED`/`MEMBERS_ROTATED` | `@event` | — | emit-only audit trail |
+
+`close` and the views take no capability: settlement is deterministic from
+recorded state, and the recorded votes are the authorization. There are no
+managed caps, no weak-body caps on any public path, and no external module
+calls anywhere (not even coin).
+
+## Node-safety
+
+Every `enforce` operates on arguments or let/with-read-bound locals;
+`MEMBER-AUTH` uses the bind-before-enforce pattern for both the membership
+read and the guard read. This class is REPL-invisible on KDA-CE, so **devnet
+validation of a full `propose → vote → close` cycle is the required
+evidence** before production use — see the README deployment checklist.
+
+## Risk profile
+
+| Risk | Level | Notes |
+|---|---|---|
+| Unauthorized/duplicate voting | Low | scoped caps over enrolled guards + counts-once, regression-tested |
+| Outcome manipulation | Low | snapshot bar + integer math + zero-yes rule; settled proposals immutable |
+| Rotation abuse | Medium | member list stays live by design (revocation feature); governance influence over open proposals is inherent and event-audited — use a multi-sig |
+| Denial of service | Low | O(1) transactional paths; close bounded by `MAX_MEMBERS`; id-squat is member-gated griefing |
+| Governance dependency | Medium | upgrade power is ultimate power: pin the module hash, multi-sig the keyset |
+
+## Static analysis note
+
+`pact-static-check.sh` reports **PASS, 0 violations** — including a clean
+Tier-1 standalone load (this module has no upstream dependencies). The two
+Tier-2 `enforce-guard` WARNs are dispositioned SAFE — both sit inside defcaps
+(`GOV`, `MEMBER-AUTH`).
+
+## What self-reviewed means here
+
+Reviewed by the template's maintainers against the PCO checklist, with the
+decision-integrity model encoded as runnable regression tests, plus an
+independent `pact-auditor` pass (automated, fresh-context) whose required
+dispositions are all implemented. **Not independent human review.** Promotion
+requires a second reviewer (`community-reviewed`) or a third-party report with
+a matching source hash (`independently-audited`) — see
+`docs/CONTRACT_POLICIES.md` §3.1.
+
+## Reproduce the review
+
+```bash
+cd contracts/library/dao-voting/examples
+pact dao-voting-test.repl   # 60 assertions
+```

--- a/contracts/library/dao-voting/README.md
+++ b/contracts/library/dao-voting/README.md
@@ -1,0 +1,71 @@
+# DAO Voting (membership, quorum + threshold)
+
+PCO library template: **membership-based on-chain voting** — a governed member set votes yes/no/abstain on proposals, one member one vote, immutable once cast. A proposal passes when participation meets a **quorum** percentage of the current member set and yes-votes meet an approval **threshold**. The module custodies **no funds**: it produces an auditable, replayable on-chain decision record. Pair it with the [multisig-treasury](../multisig-treasury/) template to act on passed proposals — together they are the complete DAO primitive stack.
+
+## How it works
+
+1. **`init members guards quorum-pct threshold-pct`** (governance) — enroll the member accounts with their authenticating guards (positionally aligned) and set the integer percentages (both in `[1,100]`).
+2. **`propose id proposer title deadline`** — any member opens a proposal with a future voting deadline. The proposer does not auto-vote. `id` must be unique.
+3. **`vote id member choice`** — a member casts `"yes"`, `"no"`, or `"abstain"`, strictly before the deadline. One immutable vote per member per proposal — no vote changes.
+4. **`close id`** — at or after the deadline, **anyone** may close (settlement is deterministic; the recorded votes are the authorization). Close counts **only votes from members current at close time**, records the filtered tallies, and settles:
+   - **quorum**: `participation × 100 ≥ quorum-pct × member-count` — abstains count toward participation;
+   - **passed**: quorum **and** `yes > 0` **and** `yes × 100 ≥ threshold-pct × (yes + no)` — abstains do not dilute the threshold.
+5. **`cancel id`** (governance) — cancel an open proposal.
+6. **`rotate-members members guards quorum-pct threshold-pct`** (governance) — replace the member set and percentages.
+
+Every step emits an event (`PROPOSED`, `VOTED`, `CLOSED`, `CANCELLED`, `MEMBERS_ROTATED`) for off-chain audit.
+
+## Security model
+
+- **Authenticated, scoped voting.** `propose`/`vote` acquire the `MEMBER-AUTH` capability, which checks current membership **and** enforces the member's enrolled guard. Members scope their signature to `(dao-voting.MEMBER-AUTH "alice")`, so a voting signature does not also authorize other operations their key could satisfy in the transaction.
+- **Counts-once, immutable.** A member appears in at most one choice list per proposal; there is no vote-change and no vote-removal — the record is append-only until settlement.
+- **Rotation revokes in-flight votes.** `close` counts only current members' votes, so rotating a compromised member out drops their votes on every open proposal. Respond to a key compromise by **removing the member's name** — re-enrolling the same name with a new guard revives votes the old key cast on still-open proposals.
+- **Integer-only math.** All quorum/threshold comparisons are integer products (counts × 100) — no decimal division, no rounding surface.
+- **Zero-yes proposals never pass.** An all-abstain turnout can meet quorum but is rejected (`yes > 0` is required), so a proposal cannot pass without a single affirmative vote.
+- **The passage bar is locked at propose time.** Each proposal snapshots the quorum and threshold percentages when it is opened — governance cannot move the bar on an open proposal after votes are cast (rotating the percentages affects only future proposals). Membership is deliberately *not* snapshotted: that is what lets rotation revoke a compromised member's votes, and it means governance retains influence over open proposals through the member list itself — every rotation emits `MEMBERS_ROTATED` for audit.
+- **Governance cannot vote.** It configures the member set, cancels open proposals, and upgrades the module; it cannot cast, alter, or remove votes, and settled proposals are immutable.
+
+## Deployment checklist
+
+1. Wrap the module in your namespace; replace the `"dao-voting-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig recommended** — governance can rotate the member set and cancel proposals).
+2. Deploy and `create-table`, then call `(init members guards quorum-pct threshold-pct)` **once**.
+3. Validate the end-to-end flow on **devnet** before mainnet — **mandatory**, not optional (see Known limits).
+
+## Usage
+
+```pact
+;; a member proposes (signs scoped to MEMBER-AUTH)
+(dao-voting.propose "grants-2026-q3" "alice" "Fund the grants program"
+  (time "2026-08-01T00:00:00Z"))
+
+;; members vote (each signs scoped to their own MEMBER-AUTH)
+(dao-voting.vote "grants-2026-q3" "alice" "yes")
+(dao-voting.vote "grants-2026-q3" "bob" "no")
+
+;; after the deadline, anyone settles it
+(dao-voting.close "grants-2026-q3")
+```
+
+## Testing
+
+`examples/dao-voting-test.repl` is fully standalone (this module depends on nothing — not even coin):
+
+```bash
+cd contracts/library/dao-voting/examples && pact dao-voting-test.repl
+```
+
+60 assertions on a controlled clock: the full pass/quorum-fail/threshold-fail/all-abstain outcome matrix, deadline boundaries (vote strictly before, close at-or-after), counts-once voting, every authorization attack (non-member, wrong key, signature scoped to another member, governance bypass), the rotation regression (a rotated-out member's in-flight vote is dropped at close, flipping the outcome), the snapshot regression (governance lowering the bar cannot flip an open proposal), the documented in-place re-key sharp edge, inclusive quorum/threshold boundaries, the single-member 100/100 edge, and the 200-member cap. CI runs this suite as a blocking check.
+
+## Known limits
+
+- **Devnet validation is MANDATORY before mainnet — not optional.** The auth capability reads on-chain tables; the template binds every read before its `enforce` (the node-safe pattern), but this class of bug is **invisible in the REPL**. Deploy to a devnet node and drive a full `propose → vote → close` cycle before relying on outcomes.
+- **Member sets are capped at 200 (`MAX_MEMBERS`).** Votes are stored as lists on the proposal row and `close` filters them against the member list (O(members × voters)); measured at ~2.7k gas for 200 all-voting members — generous headroom under the 150k per-transaction gas ceiling. For larger electorates you need per-vote rows and paginated tallying — a different design.
+- **Membership at close governs the tally.** Quorum/threshold are snapshotted per proposal, but the member *set* is read at `close` — rotating a member out drops their in-flight votes (by design), and rotating members in changes the quorum denominator for open proposals. Governance is trusted here; put it under a multi-sig.
+- **Proposal `id`s are caller-supplied and must be unique** — `propose` uses `insert`, so a reused id aborts (a front-runner squatting an id costs you nothing but a retry with a fresh id).
+- **No vote delegation, no weighting.** One enrolled member, one vote. Token-weighted voting needs snapshot mechanics that are chain-specific — out of scope for this template.
+- **Block time is the parent block's timestamp** (~one block behind wall clock) — do not build second-granularity deadlines.
+- Governance holds upgrade power. Pin the deployed module hash you audited; use a multi-sig governance keyset.
+
+## License
+
+Apache-2.0

--- a/contracts/library/dao-voting/dao-voting.pact
+++ b/contracts/library/dao-voting/dao-voting.pact
@@ -1,0 +1,326 @@
+(module dao-voting GOV
+
+  @doc "PCO library template: membership-based on-chain voting.                  \
+  \                                                                              \
+  \A governed set of MEMBER accounts votes on proposals - one member, one       \
+  \vote, immutable once cast. A proposal passes when, at close, participation   \
+  \meets a QUORUM percentage of the CURRENT member set and yes-votes meet a     \
+  \THRESHOLD percentage of the yes+no votes cast by CURRENT members. This      \
+  \module custodies NO funds: it produces an auditable, replayable on-chain    \
+  \decision record (pair it with the multisig-treasury template to act on      \
+  \passed proposals).                                                           \
+  \                                                                              \
+  \Model:                                                                        \
+  \  - Governance configures members (with their guards), quorum-pct and        \
+  \    threshold-pct at init, and may rotate them or cancel proposals.          \
+  \  - Any member may `propose` with a voting deadline. The quorum and          \
+  \    threshold percentages are SNAPSHOTTED into the proposal at propose       \
+  \    time - a later rotation cannot move the passage bar on an open           \
+  \    proposal. Membership stays dynamic (see close).                          \
+  \  - Members `vote` yes/no/abstain before the deadline; one immutable vote    \
+  \    per member per proposal.                                                 \
+  \  - After the deadline anyone may `close`, which counts ONLY votes from      \
+  \    members current at close time (rotating a member out revokes their       \
+  \    in-flight votes), checks quorum and threshold, and settles the           \
+  \    proposal as passed or rejected.                                          \
+  \                                                                              \
+  \All percentage math is integer-only (vote counts scaled by 100) - no        \
+  \decimal division anywhere.                                                   \
+  \                                                                              \
+  \Deployment checklist (see README.md):                                         \
+  \  1. Wrap in your namespace; replace the 'dao-voting-gov' keyset.             \
+  \  2. Deploy, then (init members guards quorum-pct threshold-pct) once.        \
+  \  3. Validate on devnet before mainnet."
+
+  ;; -----------------------------
+  ;; Governance
+  ;; -----------------------------
+
+  (defconst GOV_KEYSET:string "dao-voting-gov"
+    @doc "Governance keyset name. Replace with your deployed, namespace- \
+         \qualified keyset (multi-sig recommended). Governance rotates the \
+         \member set, cancels proposals, and upgrades the module. It cannot \
+         \vote or change a cast vote, and each proposal's quorum/threshold \
+         \are locked at propose time (rotating percentages affects only \
+         \future proposals). Membership is deliberately NOT locked: rotation \
+         \revokes in-flight votes (the compromise response), which also means \
+         \governance retains influence over open proposals through the member \
+         \list itself - every rotation emits MEMBERS_ROTATED for audit.")
+
+  (defcap GOV ()
+    @doc "Module governance: init/rotate members, cancel proposals, upgrade."
+    (enforce-guard (keyset-ref-guard GOV_KEYSET)))
+
+  ;; -----------------------------
+  ;; Schemas & tables
+  ;; -----------------------------
+
+  (defschema config-row
+    @doc "Singleton voting config. Percentages are integers in [1,100]."
+    members:[string]        ;; enrolled member account names
+    quorum-pct:integer      ;; min participation as % of current members
+    threshold-pct:integer)  ;; min yes as % of (yes+no) valid votes
+
+  (deftable config:{config-row})
+
+  (defschema member-row
+    @doc "Row-level guard for a member account, captured at enrollment."
+    guard:guard)
+
+  (deftable member-guards:{member-row})
+
+  (defschema proposal-row
+    @doc "A proposal and its recorded votes. quorum-pct/threshold-pct are \
+         \snapshotted from config at propose time, so a later rotation cannot \
+         \move the passage bar on an open proposal. Vote lists are bounded by \
+         \the member count. Final counts are the CURRENT-member-filtered \
+         \tallies recorded at close."
+    proposer:string
+    title:string
+    deadline:time
+    quorum-pct:integer
+    threshold-pct:integer
+    yes:[string]
+    no:[string]
+    abstain:[string]
+    status:string           ;; "open" | "passed" | "rejected" | "cancelled"
+    final-yes:integer
+    final-no:integer
+    final-abstain:integer)
+
+  (deftable proposals:{proposal-row})
+
+  (defconst CONFIG_KEY:string "config")
+
+  (defconst STATUS_OPEN:string "open")
+  (defconst STATUS_PASSED:string "passed")
+  (defconst STATUS_REJECTED:string "rejected")
+  (defconst STATUS_CANCELLED:string "cancelled")
+
+  (defconst CHOICE_YES:string "yes")
+  (defconst CHOICE_NO:string "no")
+  (defconst CHOICE_ABSTAIN:string "abstain")
+
+  (defconst MAX_MEMBERS:integer 200
+    @doc "Upper bound on the member set. `close` filters the vote lists \
+         \against the member list (O(members x voters)); measured at ~2.7k \
+         \gas for 200 all-voting members (REPL table gas model) - generous \
+         \headroom under the 150k per-tx ceiling while keeping settlement \
+         \costs predictable.")
+
+  ;; -----------------------------
+  ;; Events
+  ;; -----------------------------
+
+  (defcap PROPOSED (id:string proposer:string title:string deadline:time)
+    @event true)
+
+  (defcap VOTED (id:string member:string choice:string)
+    @event true)
+
+  (defcap CLOSED (id:string status:string yes:integer no:integer abstain:integer)
+    @event true)
+
+  (defcap CANCELLED (id:string)
+    @event true)
+
+  (defcap MEMBERS_ROTATED (members:[string] quorum-pct:integer threshold-pct:integer)
+    @event true)
+
+  ;; -----------------------------
+  ;; Internal helpers
+  ;; -----------------------------
+
+  (defun chain-time:time ()
+    @doc "Current block time (the PARENT block's timestamp on Chainweb - about \
+         \one block behind wall-clock; do not build second-granularity \
+         \deadlines)."
+    (at 'block-time (chain-data)))
+
+  (defun get-config:object{config-row} ()
+    (read config CONFIG_KEY))
+
+  (defun is-member:bool (account:string)
+    (contains account (at 'members (get-config))))
+
+  (defcap MEMBER-AUTH (account:string)
+    @doc "Authenticate ACCOUNT as a current member: it must be in the member \
+         \set AND the caller must satisfy its enrolled guard. As a capability, \
+         \a member scopes their signature to (dao-voting.MEMBER-AUTH \"alice\"), \
+         \so a voting signature does NOT also authorize other operations the \
+         \same key could satisfy in the transaction."
+    ; NODE-SAFETY: `is-member` reads the config table. A table read inside an
+    ; `enforce` condition passes in the REPL but FAILS on the KDA-CE node.
+    ; Bind the read to a local FIRST, then enforce the local.
+    (let ((member-ok (is-member account)))
+      (enforce member-ok "not a member"))
+    (with-read member-guards account { 'guard := g }
+      (enforce-guard g)))
+
+  (defun enforce-valid-config:bool (members:[string] guards:[guard]
+                                    quorum-pct:integer threshold-pct:integer)
+    @doc "Shared validation for the member set. Rejects an empty set, a \
+         \members/guards length mismatch, duplicate members (each member \
+         \votes at most once, so duplicates silently deflate quorum), and \
+         \percentages outside [1,100]."
+    (enforce (> (length members) 0) "at least one member required")
+    (enforce (<= (length members) MAX_MEMBERS)
+      (format "member count exceeds maximum of {}" [MAX_MEMBERS]))
+    (enforce (= (length members) (length guards)) "members/guards length mismatch")
+    (enforce (= (length (distinct members)) (length members)) "duplicate members")
+    (enforce (and (>= quorum-pct 1) (<= quorum-pct 100))
+      "quorum-pct must be in [1,100]")
+    (enforce (and (>= threshold-pct 1) (<= threshold-pct 100))
+      "threshold-pct must be in [1,100]"))
+
+  ;; -----------------------------
+  ;; Lifecycle & governance
+  ;; -----------------------------
+
+  (defun init:string (members:[string] guards:[guard]
+                      quorum-pct:integer threshold-pct:integer)
+    @doc "One-time setup: enroll the member set (guards align positionally) \
+         \and set quorum/threshold percentages. The config insert enforces \
+         \one-time setup."
+    (with-capability (GOV)
+      (enforce-valid-config members guards quorum-pct threshold-pct)
+      (insert config CONFIG_KEY
+        { 'members: members, 'quorum-pct: quorum-pct, 'threshold-pct: threshold-pct })
+      (zip (lambda (m:string g:guard) (write member-guards m { 'guard: g }))
+           members guards)
+      (emit-event (MEMBERS_ROTATED members quorum-pct threshold-pct))
+      "initialized"))
+
+  (defun rotate-members:string (members:[string] guards:[guard]
+                                quorum-pct:integer threshold-pct:integer)
+    @doc "Governance: replace the member set and percentages. Open proposals \
+         \are NOT cancelled, but `close` counts only votes from members \
+         \current at close time - rotating a member out revokes their \
+         \in-flight votes. Respond to a key compromise by REMOVING the \
+         \member's name: re-enrolling the same name with a new guard revives \
+         \votes the old key cast on still-open proposals."
+    (with-capability (GOV)
+      (enforce-valid-config members guards quorum-pct threshold-pct)
+      (update config CONFIG_KEY
+        { 'members: members, 'quorum-pct: quorum-pct, 'threshold-pct: threshold-pct })
+      (zip (lambda (m:string g:guard) (write member-guards m { 'guard: g }))
+           members guards)
+      (emit-event (MEMBERS_ROTATED members quorum-pct threshold-pct))
+      "rotated"))
+
+  ;; -----------------------------
+  ;; Proposal flow
+  ;; -----------------------------
+
+  (defun propose:string (id:string proposer:string title:string deadline:time)
+    @doc "A member opens a proposal. ID must be unique. DEADLINE must be in \
+         \the future; voting is possible strictly before it. The proposer \
+         \does NOT auto-vote (they may vote explicitly like any member). The \
+         \current quorum/threshold percentages are snapshotted into the \
+         \proposal, locking its passage bar. The proposer signs scoped to \
+         \MEMBER-AUTH."
+    (with-capability (MEMBER-AUTH proposer)
+      (enforce (!= title "") "title required")
+      (let ((now (chain-time)))
+        (enforce (< now deadline) "deadline must be in the future"))
+      (let ((cfg (get-config)))
+        (insert proposals id
+          { 'proposer: proposer
+          , 'title: title
+          , 'deadline: deadline
+          , 'quorum-pct: (at 'quorum-pct cfg)
+          , 'threshold-pct: (at 'threshold-pct cfg)
+          , 'yes: []
+          , 'no: []
+          , 'abstain: []
+          , 'status: STATUS_OPEN
+          , 'final-yes: 0
+          , 'final-no: 0
+          , 'final-abstain: 0 }))
+      (emit-event (PROPOSED id proposer title deadline))
+      id))
+
+  (defun vote:string (id:string member:string choice:string)
+    @doc "A member casts an immutable vote (yes | no | abstain) on an open \
+         \proposal, strictly before its deadline. One vote per member per \
+         \proposal; there is no vote-change (a member unsure at vote time \
+         \should wait - voting is possible until the deadline). The member \
+         \signs scoped to MEMBER-AUTH."
+    (with-capability (MEMBER-AUTH member)
+      (enforce (contains choice [CHOICE_YES CHOICE_NO CHOICE_ABSTAIN])
+        "choice must be yes, no, or abstain")
+      (with-read proposals id
+        { 'deadline := deadline, 'yes := yes, 'no := no
+        , 'abstain := abstain, 'status := status }
+        (enforce (= status STATUS_OPEN) "proposal is not open")
+        (let ((now (chain-time)))
+          (enforce (< now deadline) "voting deadline has passed"))
+        (let ((all-voters (+ yes (+ no abstain))))
+          (enforce (not (contains member all-voters)) "member already voted"))
+        (if (= choice CHOICE_YES)
+          (update proposals id { 'yes: (+ yes [member]) })
+          (if (= choice CHOICE_NO)
+            (update proposals id { 'no: (+ no [member]) })
+            (update proposals id { 'abstain: (+ abstain [member]) })))
+        (emit-event (VOTED id member choice))
+        id)))
+
+  (defun close:string (id:string)
+    @doc "Settle a proposal after its deadline. Callable by anyone: the \
+         \recorded votes are the authorization, and settlement is \
+         \deterministic. Uses the proposal's SNAPSHOTTED quorum/threshold \
+         \(locked at propose) over the CURRENT member set (so rotating a \
+         \member out revokes their in-flight votes), then:                    \
+         \quorum  = participation*100 >= quorum-pct * member-count           \
+         \passed  = quorum AND yes > 0 AND yes*100 >= threshold-pct*(yes+no). \
+         \Abstain votes count toward quorum but not toward the threshold. \
+         \Records the filtered tallies and emits CLOSED."
+    (with-read proposals id
+      { 'deadline := deadline, 'yes := yes, 'no := no
+      , 'abstain := abstain, 'status := status
+      , 'quorum-pct := quorum-pct, 'threshold-pct := threshold-pct }
+      (enforce (= status STATUS_OPEN) "proposal is not open")
+      (let ((now (chain-time)))
+        (enforce (>= now deadline) "voting deadline has not passed"))
+      (let* ((cfg (get-config))
+             (members (at 'members cfg))
+             (in-members (lambda (m:string) (contains m members)))
+             (valid-yes (length (filter in-members yes)))
+             (valid-no (length (filter in-members no)))
+             (valid-abstain (length (filter in-members abstain)))
+             (participation (+ valid-yes (+ valid-no valid-abstain)))
+             (quorum-met (>= (* participation 100) (* quorum-pct (length members))))
+             (threshold-met (and (> valid-yes 0)
+                                 (>= (* valid-yes 100)
+                                     (* threshold-pct (+ valid-yes valid-no)))))
+             (new-status (if (and quorum-met threshold-met)
+                           STATUS_PASSED
+                           STATUS_REJECTED)))
+        (update proposals id
+          { 'status: new-status
+          , 'final-yes: valid-yes
+          , 'final-no: valid-no
+          , 'final-abstain: valid-abstain })
+        (emit-event (CLOSED id new-status valid-yes valid-no valid-abstain))
+        new-status)))
+
+  (defun cancel:string (id:string)
+    @doc "Governance cancels an open proposal."
+    (with-capability (GOV)
+      (with-read proposals id { 'status := status }
+        (enforce (= status STATUS_OPEN) "proposal is not open")
+        (update proposals id { 'status: STATUS_CANCELLED })
+        (emit-event (CANCELLED id))
+        id)))
+
+  ;; -----------------------------
+  ;; Views
+  ;; -----------------------------
+
+  (defun get-proposal:object{proposal-row} (id:string)
+    (read proposals id))
+
+  (defun has-voted:bool (id:string member:string)
+    (with-read proposals id { 'yes := yes, 'no := no, 'abstain := abstain }
+      (contains member (+ yes (+ no abstain)))))
+)

--- a/contracts/library/dao-voting/examples/dao-voting-test.repl
+++ b/contracts/library/dao-voting/examples/dao-voting-test.repl
@@ -1,0 +1,457 @@
+;; dao-voting-test.repl — PCO library template test suite
+;;
+;; Fully standalone: this module custodies no funds and depends on no other
+;; module (not even coin), so nothing else is loaded.
+;;
+;; Drives the full proposal lifecycle on a controlled clock (env-chain-data
+;; block-time) with a 4-member set (alice/bob/carol/dan), quorum 50%,
+;; threshold 60%: pass, quorum-fail, threshold-fail, and all-abstain
+;; outcomes; deadline boundaries (vote strictly before, close at-or-after);
+;; every authorization attack (non-member, wrong key, sig scoped to another
+;; member, governance bypass); counts-once voting; and the rotation
+;; regression: rotating a member out revokes their in-flight votes at close.
+
+;; ---------------------------------------------------------------------------
+;; Setup: keyset, module, tables.
+;; ---------------------------------------------------------------------------
+(begin-tx "setup")
+(env-data
+  { "dao-voting-gov": ["gov-key"]
+  , "alice": ["alice-key"], "bob": ["bob-key"], "carol": ["carol-key"]
+  , "dan": ["dan-key"], "eve": ["eve-key"], "carol2": ["carol2-key"] })
+(define-keyset "dao-voting-gov" (read-keyset "dao-voting-gov"))
+(load "../dao-voting.pact")
+(create-table config)
+(create-table member-guards)
+(create-table proposals)
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; init: governance-gated, validated config.
+;; ---------------------------------------------------------------------------
+(begin-tx "init-requires-gov")
+(env-sigs [])
+(expect-failure "init without governance fails" "Keyset failure"
+  (dao-voting.init ["alice"] [(read-keyset "alice")] 50 60))
+(rollback-tx)
+
+(begin-tx "init-validation")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "empty member set rejected" "at least one member required"
+  (dao-voting.init [] [] 50 60))
+(expect-failure "members/guards mismatch rejected" "members/guards length mismatch"
+  (dao-voting.init ["alice" "bob"] [(read-keyset "alice")] 50 60))
+(expect-failure "duplicate members rejected" "duplicate members"
+  (dao-voting.init ["alice" "alice"]
+    [(read-keyset "alice") (read-keyset "alice")] 50 60))
+(expect-failure "zero quorum rejected" "quorum-pct must be in [1,100]"
+  (dao-voting.init ["alice"] [(read-keyset "alice")] 0 60))
+(expect-failure "quorum above 100 rejected" "quorum-pct must be in [1,100]"
+  (dao-voting.init ["alice"] [(read-keyset "alice")] 101 60))
+(expect-failure "zero threshold rejected" "threshold-pct must be in [1,100]"
+  (dao-voting.init ["alice"] [(read-keyset "alice")] 50 0))
+(expect-failure "threshold above 100 rejected" "threshold-pct must be in [1,100]"
+  (dao-voting.init ["alice"] [(read-keyset "alice")] 50 101))
+(rollback-tx)
+
+(begin-tx "init")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "init 4 members, quorum 50, threshold 60" "initialized"
+  (dao-voting.init ["alice" "bob" "carol" "dan"]
+    [(read-keyset "alice") (read-keyset "bob")
+     (read-keyset "carol") (read-keyset "dan")] 50 60))
+(expect "init emits MEMBERS_ROTATED" true
+  (contains "dao-voting.MEMBERS_ROTATED" (map (at 'name) (env-events true))))
+(commit-tx)
+
+(begin-tx "init-once")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "init cannot run twice" "already found while in Insert mode"
+  (dao-voting.init ["alice"] [(read-keyset "alice")] 50 60))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; propose: members only, authenticated, future deadline.
+;; ---------------------------------------------------------------------------
+(begin-tx "propose-non-member")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [{"key": "eve-key", "caps": [(dao-voting.MEMBER-AUTH "eve")]}])
+(expect-failure "non-member cannot propose" "not a member"
+  (dao-voting.propose "p1" "eve" "Fund the grants program"
+    (time "2026-01-10T00:00:00Z")))
+(rollback-tx)
+
+(begin-tx "propose-wrong-key")
+(env-sigs [{"key": "eve-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect-failure "proposing as a member without their key fails" "Keyset failure"
+  (dao-voting.propose "p1" "alice" "Fund the grants program"
+    (time "2026-01-10T00:00:00Z")))
+(rollback-tx)
+
+(begin-tx "propose-past-deadline")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect-failure "past deadline rejected" "deadline must be in the future"
+  (dao-voting.propose "p1" "alice" "Fund the grants program"
+    (time "2025-12-31T00:00:00Z")))
+(expect-failure "empty title rejected" "title required"
+  (dao-voting.propose "p1" "alice" "" (time "2026-01-10T00:00:00Z")))
+(rollback-tx)
+
+(begin-tx "propose-p1")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect "p1 proposed" "p1"
+  (dao-voting.propose "p1" "alice" "Fund the grants program"
+    (time "2026-01-10T00:00:00Z")))
+(expect "PROPOSED emitted" true
+  (contains "dao-voting.PROPOSED" (map (at 'name) (env-events true))))
+(expect "proposer did not auto-vote" false (dao-voting.has-voted "p1" "alice"))
+(commit-tx)
+
+(begin-tx "propose-duplicate-id")
+(env-sigs [{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}])
+(expect-failure "reused proposal id rejected" "already found while in Insert mode"
+  (dao-voting.propose "p1" "bob" "Something else" (time "2026-01-10T00:00:00Z")))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; vote: members only, one immutable vote each, strictly before the deadline.
+;; ---------------------------------------------------------------------------
+(begin-tx "vote-non-member")
+(env-chain-data { "block-time": (time "2026-01-05T00:00:00Z") })
+(env-sigs [{"key": "eve-key", "caps": [(dao-voting.MEMBER-AUTH "eve")]}])
+(expect-failure "non-member cannot vote" "not a member"
+  (dao-voting.vote "p1" "eve" "yes"))
+(rollback-tx)
+
+(begin-tx "vote-wrong-key")
+(env-sigs [{"key": "eve-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect-failure "voting as a member without their key fails" "Keyset failure"
+  (dao-voting.vote "p1" "alice" "yes"))
+(rollback-tx)
+
+(begin-tx "vote-bad-choice")
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect-failure "invalid choice rejected" "choice must be yes, no, or abstain"
+  (dao-voting.vote "p1" "alice" "maybe"))
+(rollback-tx)
+
+(begin-tx "vote-p1")
+(env-chain-data { "block-time": (time "2026-01-05T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect "alice votes yes" "p1" (dao-voting.vote "p1" "alice" "yes"))
+(expect "VOTED emitted" true
+  (contains "dao-voting.VOTED" (map (at 'name) (env-events true))))
+(expect "has-voted view reflects the vote" true (dao-voting.has-voted "p1" "alice"))
+(expect-failure "double vote rejected (even with a new choice)" "member already voted"
+  (dao-voting.vote "p1" "alice" "no"))
+(commit-tx)
+
+(begin-tx "vote-p1-rest")
+(env-chain-data { "block-time": (time "2026-01-05T00:00:00Z") })
+(env-sigs [{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}
+          ,{"key": "carol-key", "caps": [(dao-voting.MEMBER-AUTH "carol")]}
+          ,{"key": "dan-key", "caps": [(dao-voting.MEMBER-AUTH "dan")]}])
+(expect "bob votes yes" "p1" (dao-voting.vote "p1" "bob" "yes"))
+(expect "carol votes no" "p1" (dao-voting.vote "p1" "carol" "no"))
+(expect "dan abstains" "p1" (dao-voting.vote "p1" "dan" "abstain"))
+(commit-tx)
+
+(begin-tx "vote-at-deadline")
+;; the deadline itself is NOT votable (strictly before)
+(env-chain-data { "block-time": (time "2026-01-10T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect-failure "vote at the deadline rejected" "voting deadline has passed"
+  (dao-voting.vote "p1" "alice" "yes"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; close: at-or-after the deadline, anyone; abstain counts toward quorum but
+;; not the threshold. p1: 2 yes, 1 no, 1 abstain of 4 members —
+;; participation 4/4 >= 50%; yes 2/3 = 66% >= 60% → PASSED.
+;; ---------------------------------------------------------------------------
+(begin-tx "close-before-deadline")
+(env-chain-data { "block-time": (time "2026-01-09T23:59:59Z") })
+(env-sigs [])
+(expect-failure "close before the deadline rejected" "voting deadline has not passed"
+  (dao-voting.close "p1"))
+(rollback-tx)
+
+(begin-tx "close-p1")
+;; close AT the deadline is allowed (>=); no signature required
+(env-chain-data { "block-time": (time "2026-01-10T00:00:00Z") })
+(env-sigs [])
+(expect "p1 passes (66% yes of yes+no, full participation)" "passed"
+  (dao-voting.close "p1"))
+(expect "CLOSED emitted" true
+  (contains "dao-voting.CLOSED" (map (at 'name) (env-events true))))
+(expect "final tallies recorded" [2 1 1]
+  (let ((p (dao-voting.get-proposal "p1")))
+    [(at 'final-yes p) (at 'final-no p) (at 'final-abstain p)]))
+(commit-tx)
+
+(begin-tx "close-settled")
+(env-chain-data { "block-time": (time "2026-01-11T00:00:00Z") })
+(expect-failure "re-close rejected" "proposal is not open"
+  (dao-voting.close "p1"))
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect-failure "vote on a settled proposal rejected" "proposal is not open"
+  (dao-voting.vote "p1" "alice" "yes"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Outcome matrix on fresh proposals (same 4-member config).
+;; p2 quorum-fail: only alice votes (1/4 = 25% < 50%) despite 100% yes.
+;; p3 threshold-fail: 1 yes, 2 no (33% < 60%) with quorum met.
+;; p4 all-abstain: quorum met (2/4 = 50%) but zero yes → rejected.
+;; ---------------------------------------------------------------------------
+(begin-tx "outcome-matrix")
+(env-chain-data { "block-time": (time "2026-02-01T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}
+          ,{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}
+          ,{"key": "carol-key", "caps": [(dao-voting.MEMBER-AUTH "carol")]}])
+(dao-voting.propose "p2" "alice" "Quorum fail" (time "2026-02-10T00:00:00Z"))
+(dao-voting.propose "p3" "alice" "Threshold fail" (time "2026-02-10T00:00:00Z"))
+(dao-voting.propose "p4" "alice" "All abstain" (time "2026-02-10T00:00:00Z"))
+(dao-voting.vote "p2" "alice" "yes")
+(dao-voting.vote "p3" "alice" "yes")
+(dao-voting.vote "p3" "bob" "no")
+(dao-voting.vote "p3" "carol" "no")
+(dao-voting.vote "p4" "alice" "abstain")
+(dao-voting.vote "p4" "bob" "abstain")
+(commit-tx)
+
+(begin-tx "close-outcome-matrix")
+(env-chain-data { "block-time": (time "2026-02-10T00:00:00Z") })
+(env-sigs [])
+(expect "p2 rejected: 100% yes but quorum missed" "rejected"
+  (dao-voting.close "p2"))
+(expect "p3 rejected: quorum met, threshold missed" "rejected"
+  (dao-voting.close "p3"))
+(expect "p4 rejected: abstains meet quorum but zero yes" "rejected"
+  (dao-voting.close "p4"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; cancel: governance only, open proposals only.
+;; ---------------------------------------------------------------------------
+(begin-tx "cancel")
+(env-chain-data { "block-time": (time "2026-02-01T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(dao-voting.propose "p5" "alice" "To be cancelled" (time "2026-02-10T00:00:00Z"))
+(env-sigs [])
+(expect-failure "cancel without governance fails" "Keyset failure"
+  (dao-voting.cancel "p5"))
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "governance cancels p5" "p5" (dao-voting.cancel "p5"))
+(expect "CANCELLED emitted" true
+  (contains "dao-voting.CANCELLED" (map (at 'name) (env-events true))))
+(expect-failure "cancel a settled proposal rejected" "proposal is not open"
+  (dao-voting.cancel "p1"))
+(commit-tx)
+
+(begin-tx "cancelled-is-dead")
+(env-chain-data { "block-time": (time "2026-02-05T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect-failure "vote on a cancelled proposal rejected" "proposal is not open"
+  (dao-voting.vote "p5" "alice" "yes"))
+(env-chain-data { "block-time": (time "2026-02-10T00:00:00Z") })
+(expect-failure "close a cancelled proposal rejected" "proposal is not open"
+  (dao-voting.close "p5"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Rotation regression: rotating a member out revokes their in-flight votes.
+;; p6 collects alice yes + bob yes + carol no (would pass: 66% >= 60%).
+;; Alice is then rotated OUT (compromise response). At close only current
+;; members count: 1 yes, 1 no → 50% < 60% → REJECTED. The revocation
+;; flips the outcome — exactly what rotation is for.
+;; ---------------------------------------------------------------------------
+(begin-tx "propose-and-vote-p6")
+(env-chain-data { "block-time": (time "2026-03-01T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}
+          ,{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}
+          ,{"key": "carol-key", "caps": [(dao-voting.MEMBER-AUTH "carol")]}])
+(dao-voting.propose "p6" "bob" "Rotation regression" (time "2026-03-10T00:00:00Z"))
+(dao-voting.vote "p6" "alice" "yes")
+(dao-voting.vote "p6" "bob" "yes")
+(dao-voting.vote "p6" "carol" "no")
+(commit-tx)
+
+(begin-tx "rotate-alice-out")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "rotate with duplicate members rejected" "duplicate members"
+  (dao-voting.rotate-members ["bob" "bob"]
+    [(read-keyset "bob") (read-keyset "bob")] 50 60))
+(expect "alice rotated out (3 members remain)" "rotated"
+  (dao-voting.rotate-members ["bob" "carol" "dan"]
+    [(read-keyset "bob") (read-keyset "carol") (read-keyset "dan")] 50 60))
+(commit-tx)
+
+(begin-tx "rotated-out-member-cannot-vote")
+(env-chain-data { "block-time": (time "2026-03-05T00:00:00Z") })
+(env-sigs [{"key": "alice-key", "caps": [(dao-voting.MEMBER-AUTH "alice")]}])
+(expect-failure "rotated-out member cannot vote" "not a member"
+  (dao-voting.vote "p6" "alice" "yes"))
+(rollback-tx)
+
+(begin-tx "close-p6-stale-vote-dropped")
+(env-chain-data { "block-time": (time "2026-03-10T00:00:00Z") })
+(env-sigs [])
+(expect "p6 rejected: alice's stale yes no longer counts" "rejected"
+  (dao-voting.close "p6"))
+(expect "final tallies exclude the rotated-out member" [1 1 0]
+  (let ((p (dao-voting.get-proposal "p6")))
+    [(at 'final-yes p) (at 'final-no p) (at 'final-abstain p)]))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; A rotated-IN member can vote on a still-open proposal immediately.
+;; ---------------------------------------------------------------------------
+(begin-tx "rotate-eve-in")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(dao-voting.rotate-members ["bob" "carol" "dan" "eve"]
+  [(read-keyset "bob") (read-keyset "carol")
+   (read-keyset "dan") (read-keyset "eve")] 50 60)
+(commit-tx)
+
+(begin-tx "new-member-votes")
+(env-chain-data { "block-time": (time "2026-03-01T00:00:00Z") })
+(env-sigs [{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}])
+(dao-voting.propose "p7" "bob" "New member participates" (time "2026-03-10T00:00:00Z"))
+(env-sigs [{"key": "eve-key", "caps": [(dao-voting.MEMBER-AUTH "eve")]}])
+(expect "newly enrolled member votes" "p7" (dao-voting.vote "p7" "eve" "yes"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Snapshot regression: quorum/threshold are locked at propose time.
+;; p8 (1 yes, 2 no under threshold 60) must stay REJECTED even after
+;; governance drops the percentages to 1/1 — the bar cannot be moved on an
+;; open proposal. New proposals (p9) use the new percentages.
+;; ---------------------------------------------------------------------------
+(begin-tx "propose-and-vote-p8")
+(env-chain-data { "block-time": (time "2026-04-01T00:00:00Z") })
+(env-sigs [{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}
+          ,{"key": "carol-key", "caps": [(dao-voting.MEMBER-AUTH "carol")]}
+          ,{"key": "dan-key", "caps": [(dao-voting.MEMBER-AUTH "dan")]}])
+(dao-voting.propose "p8" "bob" "Snapshot regression" (time "2026-04-10T00:00:00Z"))
+(dao-voting.vote "p8" "bob" "yes")
+(dao-voting.vote "p8" "carol" "no")
+(dao-voting.vote "p8" "dan" "no")
+(commit-tx)
+
+(begin-tx "gov-lowers-bar")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(dao-voting.rotate-members ["bob" "carol" "dan" "eve"]
+  [(read-keyset "bob") (read-keyset "carol")
+   (read-keyset "dan") (read-keyset "eve")] 1 1)
+(commit-tx)
+
+(begin-tx "close-p8-snapshot-holds")
+(env-chain-data { "block-time": (time "2026-04-10T00:00:00Z") })
+(env-sigs [])
+(expect "p8 keeps its snapshotted threshold (60)" 60
+  (at 'threshold-pct (dao-voting.get-proposal "p8")))
+(expect "p8 rejected: governance cannot move the bar on an open proposal"
+  "rejected" (dao-voting.close "p8"))
+(commit-tx)
+
+(begin-tx "new-proposal-uses-new-bar")
+(env-chain-data { "block-time": (time "2026-04-11T00:00:00Z") })
+(env-sigs [{"key": "eve-key", "caps": [(dao-voting.MEMBER-AUTH "eve")]}])
+(dao-voting.propose "p9" "eve" "Post-rotation bar" (time "2026-04-20T00:00:00Z"))
+(dao-voting.vote "p9" "eve" "yes")
+(env-chain-data { "block-time": (time "2026-04-20T00:00:00Z") })
+(expect "p9 (proposed after rotation) passes under the 1/1 bar" "passed"
+  (dao-voting.close "p9"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Documented sharp edge: re-keying a member IN PLACE (same name, new guard)
+;; revives votes the old key cast on still-open proposals — this is WHY the
+;; compromise response is to REMOVE the name, never to re-key it.
+;; ---------------------------------------------------------------------------
+(begin-tx "restore-bar-and-propose-p10")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(dao-voting.rotate-members ["bob" "carol" "dan" "eve"]
+  [(read-keyset "bob") (read-keyset "carol")
+   (read-keyset "dan") (read-keyset "eve")] 50 60)
+(env-chain-data { "block-time": (time "2026-05-01T00:00:00Z") })
+(env-sigs [{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}
+          ,{"key": "carol-key", "caps": [(dao-voting.MEMBER-AUTH "carol")]}
+          ,{"key": "dan-key", "caps": [(dao-voting.MEMBER-AUTH "dan")]}])
+(dao-voting.propose "p10" "bob" "Re-key sharp edge" (time "2026-05-10T00:00:00Z"))
+(dao-voting.vote "p10" "bob" "yes")
+(dao-voting.vote "p10" "carol" "yes")
+(dao-voting.vote "p10" "dan" "no")
+(commit-tx)
+
+(begin-tx "rekey-carol-in-place")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(dao-voting.rotate-members ["bob" "carol" "dan" "eve"]
+  [(read-keyset "bob") (read-keyset "carol2")
+   (read-keyset "dan") (read-keyset "eve")] 50 60)
+(commit-tx)
+
+(begin-tx "close-p10-rekey-revives")
+(env-chain-data { "block-time": (time "2026-05-10T00:00:00Z") })
+(env-sigs [])
+;; carol's OLD-key vote still counts because the NAME is still a member:
+;; 2 yes / 1 no = 66% >= 60 → passed. Removal (not re-key) would have
+;; dropped it (see close-p6-stale-vote-dropped).
+(expect "in-place re-key revives the old key's vote (documented)" "passed"
+  (dao-voting.close "p10"))
+(expect "revived vote is in the final tally" [2 1 0]
+  (let ((p (dao-voting.get-proposal "p10")))
+    [(at 'final-yes p) (at 'final-no p) (at 'final-abstain p)]))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Math edges: inclusive boundaries and the single-member set.
+;; ---------------------------------------------------------------------------
+(begin-tx "exact-boundaries")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(dao-voting.rotate-members ["bob" "carol" "dan" "eve"]
+  [(read-keyset "bob") (read-keyset "carol2")
+   (read-keyset "dan") (read-keyset "eve")] 50 50)
+(env-chain-data { "block-time": (time "2026-06-01T00:00:00Z") })
+(env-sigs [{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}
+          ,{"key": "dan-key", "caps": [(dao-voting.MEMBER-AUTH "dan")]}])
+(dao-voting.propose "p11" "bob" "Exact boundaries" (time "2026-06-10T00:00:00Z"))
+(dao-voting.vote "p11" "bob" "yes")
+(dao-voting.vote "p11" "dan" "no")
+(env-chain-data { "block-time": (time "2026-06-10T00:00:00Z") })
+(env-sigs [])
+;; participation 2/4 = exactly 50% quorum; yes 1/2 = exactly 50% threshold:
+;; both boundaries are inclusive — strict majority needs threshold 51.
+(expect "exactly-at-quorum and exactly-at-threshold pass (inclusive)" "passed"
+  (dao-voting.close "p11"))
+(commit-tx)
+
+(begin-tx "single-member-dao")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(dao-voting.rotate-members ["bob"] [(read-keyset "bob")] 100 100)
+(env-chain-data { "block-time": (time "2026-07-01T00:00:00Z") })
+(env-sigs [{"key": "bob-key", "caps": [(dao-voting.MEMBER-AUTH "bob")]}])
+(dao-voting.propose "p12" "bob" "Sole member votes" (time "2026-07-10T00:00:00Z"))
+(dao-voting.vote "p12" "bob" "yes")
+(dao-voting.propose "p13" "bob" "Sole member silent" (time "2026-07-10T00:00:00Z"))
+(env-chain-data { "block-time": (time "2026-07-10T00:00:00Z") })
+(env-sigs [])
+(expect "1-member 100/100: sole yes passes" "passed" (dao-voting.close "p12"))
+(expect "1-member 100/100: no votes fails quorum" "rejected"
+  (dao-voting.close "p13"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Member-count ceiling (gas bound for close's O(members x voters) filter).
+;; ---------------------------------------------------------------------------
+(begin-tx "member-cap")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "member set above MAX_MEMBERS rejected"
+  "member count exceeds maximum of 200"
+  (dao-voting.rotate-members
+    (map (lambda (i:integer) (format "m{}" [i])) (enumerate 1 201))
+    (make-list 201 (read-keyset "bob")) 50 60))
+(rollback-tx)

--- a/contracts/library/dao-voting/metadata.yaml
+++ b/contracts/library/dao-voting/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'DAO Voting (membership, quorum + threshold)'
+slug: 'dao-voting'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['dao', 'voting', 'governance', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'dao', 'voting', 'quorum', 'threshold', 'proposal']

--- a/docs/index.json
+++ b/docs/index.json
@@ -1,5 +1,36 @@
 [
 {
+  "name": "DAO Voting (membership, quorum + threshold)",
+  "slug": "dao-voting",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "dao",
+    "voting",
+    "governance",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "dao",
+    "voting",
+    "quorum",
+    "threshold",
+    "proposal"
+  ]
+}
+,
+{
   "name": "Gas Station (drain-defended)",
   "slug": "gas-station",
   "version": "1.0.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ _Generated from `contracts/**/metadata.yaml`._
 
 | Name | Slug | Version | Audit Status | Tags |
 |------|------|---------|--------------|------|
+| DAO Voting (membership, quorum + threshold) | dao-voting | 1.0.0 | self-reviewed | dao, voting, governance, template, library |
 | Gas Station (drain-defended) | gas-station | 1.0.0 | self-reviewed | gas-station, gas-payer-v1, gasless, template, library |
 | Hello World | hello-world | 1.0.0 | self-reviewed | hello-world, tutorial, basic |
 | Multisig Treasury (M-of-N) | multisig-treasury | 1.0.0 | self-reviewed | treasury, multisig, governance, template, library |


### PR DESCRIPTION
## What

New PCO library template: `contracts/library/dao-voting` — **membership-based on-chain voting** with quorum + approval-threshold settlement. A governed member set votes yes/no/abstain on deadline-bounded proposals; one member one vote, immutable once cast. The module custodies **no funds** and depends on **no other module** (not even coin): its output is an auditable decision record. Paired with `library/multisig-treasury`, it completes the DAO primitive stack (decide → execute).

- **Authenticated, scoped voting**: `MEMBER-AUTH` capability checks current membership and enforces the enrolled guard; a voting signature authorizes nothing else in the transaction.
- **Passage bar locked at propose time**: each proposal snapshots quorum/threshold, so governance cannot move the bar on an open proposal. Membership stays live by design — rotating a compromised member out revokes their in-flight votes (regression-tested both ways).
- **Integer-only math** (counts × 100, no division), inclusive boundaries, and a `yes > 0` rule so an all-abstain quorum can never pass a proposal.
- **`MAX_MEMBERS = 200`** enforced, backed by gas measurements (~2.7k gas to settle 200 all-voting members vs the 150k ceiling).
- Governance (keyset, multi-sig recommended) can init/rotate members, cancel open proposals, and upgrade — it cannot vote or alter cast votes.

## Review process

Independent `pact-auditor` pass (fresh context): **GO with required dispositions** — zero CRITICAL/HIGH, node-safety sweep clean. All dispositions implemented:

- **MEDIUM**: `close` read *live* config, so governance could rotate percentages after votes were cast and force-pass a motion the members rejected (auditor reproduced it) — fixed with the per-proposal snapshot; regression `close-p8-snapshot-holds` proves a bar lowered to 1/1 cannot flip an open proposal.
- **LOW**: member-count ceiling now enforced + tested; **LOW**: all auditor probe scenarios (snapshot flip, in-place re-key revival sharp edge, exact boundaries, single-member edges) folded into the shipped suite.

## Evidence

- `examples/dao-voting-test.repl`: **60 assertions**, fully standalone, controlled clock — outcome matrix (pass / quorum-fail / threshold-fail / all-abstain), deadline boundary semantics, counts-once, every authorization attack, rotation + snapshot regressions, and the documented re-key sharp edge. Runs as a blocking CI step.
- Static gate: PASS, 0 violations — including a clean Tier-1 standalone load (a library first: no dependency stub warnings).
- `AUDIT.md` documents the findings/fixes, threat model, capability model, and the standing caveat: **devnet validation of propose → vote → close is mandatory before mainnet** (the read-in-enforce class is REPL-invisible).
- Index regenerated; entry validates under the library quality gate at `self-reviewed`.