### PR TITLE
feat(library): add marmalade-v2 NFT collection policy template

### DIFF
--- a/contracts/library/nft-collection-policy/AUDIT.md
+++ b/contracts/library/nft-collection-policy/AUDIT.md
@@ -1,0 +1,134 @@
+# AUDIT — library/nft-collection-policy
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `nft-collection-policy` (namespace: project-specific) |
+| **Version** | 1.0.0 |
+| **Audit Status** | self-reviewed |
+| **Category** | PCO Library Template (marmalade-v2 concrete policy) |
+| **Source** | PCO-authored reference implementation |
+| **Last review** | 2026-07-06 |
+
+## Purpose
+
+Deployable marmalade-v2 concrete policy (implements `kip.token-policy-v2`) for
+NFT collections: creator-gated token creation and minting, a collection size
+cap, strict one-of-one NFT shape, opt-in burning. Custodies nothing — the
+marmalade ledger holds tokens; this policy only decides what is allowed.
+
+## Audit history
+
+An independent `pact-auditor` pass returned **GO** — zero
+CRITICAL/HIGH/MEDIUM/LOW findings; three INFO items, dispositioned below. The
+review drove the policy through the **real** marmalade-v2 registry stack and
+included two adversarial probe suites (hook reachability, state corruption),
+both passing.
+
+**The core security claim was empirically proven:** every one of the seven
+policy hooks is gated by `require-capability` on the policy-manager's
+corresponding `*-CALL` capability. External/top-level acquisition of those
+caps is refused by Pact (`Module admin necessary`), signature-scoping to them
+does not grant them, and the policy's rendered `POLICY` name matches what the
+policy-manager passes under any namespace. Hooks are unreachable outside the
+genuine ledger → policy-manager flow.
+
+**All seven hooks' `require-capability` argument lists were verified against
+the policy-manager source** — including `BUY-CALL`, whose path the REPL suite
+cannot exercise (quote/escrow machinery). An argument-order mistake there
+would brick every sale at the buy step invisibly; the order is confirmed
+correct (id, seller, buyer, amount, sale-id, policy).
+
+| # | Severity | Finding | Disposition |
+|---|----------|---------|-------------|
+| 1 | INFO | The creator's `enforce-guard` runs in the hook defuns (the standard marmalade concrete-policy pattern), so an **unscoped** creator signature authorizes their guard for the whole transaction. Not exploitable by others (proven: non-creators fail the guard). | Documented: README instructs creators to scope create-token/mint signatures to the ledger's `INIT-CALL`/`MINT-CALL`; the suite demonstrates the exact shape. |
+| 2 | INFO | `size` counts tokens **created** and never decrements on burn — a max-N collection can only ever contain N distinct token ids, even if some are burned. | Intended; documented explicitly in the README security model. |
+| 3 | INFO | Mint/burn emit no policy-level event (only `TOKEN-ADDED` at init). The ledger's `RECONCILE`/`TOKEN` events fully cover the audit trail. | Accepted — duplicating ledger events adds gas for no new information. Indexers should key off ledger events. |
+
+## Probe results (auditor artifacts, reproduced then removed from the tree)
+
+- **Hook reachability**: `POLICY` const == manager's rendering under any
+  namespace; top-level `with-capability` of a `*-CALL` cap refused;
+  a signature scoped to `INIT-CALL` still fails the hook's
+  `require-capability`. No bypass.
+- **State corruption**: collection `size` shows no phantom drift when a
+  create-token aborts mid-transaction (atomicity); listing this policy twice
+  in a token's policy list fails cleanly with size unchanged; a mint cannot
+  re-home a token to another collection (`collection_id` tx data is only read
+  at init — mint uses the stored binding).
+
+## Threat model & defenses
+
+| Vector | Defense | Test |
+|---|---|---|
+| Direct call to any policy hook | `require-capability` on the policy-manager's `*-CALL` caps | `direct-hook-calls-blocked` (all 7) |
+| Fake ledger / hostile module drives hooks | `*-CALL` caps acquirable only inside the genuine policy-manager | auditor reachability probe |
+| Non-creator adds tokens to a collection | `enforce-guard` on the enrolled creator guard at init | `create-token-non-creator` |
+| Non-creator mints | creator guard enforced at mint | `mint-non-creator` |
+| Supply > 1 (fractional, re-mint, mint-after-burn) | precision 0 at init; amount exactly 1.0; one-way minted flag | `mint-bad-amount`, double-mint, `burn-burnable-then-no-remint` |
+| Collection cap bypass | `size` incremented transactionally at init; `max-size` checked on bound locals | `collection-full`, auditor abort-atomicity probe |
+| Cross-collection contamination | token→collection binding stored at init; mint/burn use the stored binding | auditor cross-collection probe |
+| Non-owner transfer / burn | ledger's managed `TRANSFER` / `BURN`→`DEBIT` guard enforcement | `transfer-t1`, burn cases |
+| Burning where not intended | per-collection `burnable` opt-in | `burn-non-burnable` |
+| Governance seizure of collections | `GOV` is upgrade-only; touches no collection/token state | capability sweep |
+
+## Capability model
+
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard GOV_KEYSET` | upgrade only |
+| `CREATOR-AUTH (guard)` | authentication | `enforce-guard` on the supplied guard | acquired by `create-collection`; scoped-sig friendly |
+| `COLLECTION` / `TOKEN-ADDED` | `@event` | — | emit-only |
+| (external) `marmalade-v2.policy-manager.*-CALL` | gate | acquirable only inside the policy-manager | the hooks' only entry path |
+
+## Node-safety
+
+Every table read feeding an `enforce` is let/with-read-bound first
+(`enforce-init`, `enforce-mint`, `enforce-burn`); `read-msg "collection_id"`
+is env-data, not a table read. Swept clean by both the author and the
+auditor. This class is REPL-invisible on KDA-CE, so **devnet validation
+against the real marmalade-v2 deployment is required evidence** — including
+specifically an on-chain **buy** (the REPL suite exercises offer/withdraw
+positively but cannot cover the quote/escrow buy path).
+
+## Risk profile
+
+| Risk | Level | Notes |
+|---|---|---|
+| Unauthorized mint/creation | Low | creator guard + `*-CALL` gates, probe-verified |
+| Supply inflation | Low | one-way minted flag + amount/precision invariants |
+| Policy-state corruption | Low | module-scoped tables; tx atomicity probe-verified |
+| Sale-path defect | Medium→Low | buy arg-order statically verified; devnet buy exercise mandated before relying on sales |
+| Governance dependency | Medium | upgrade power: pin the module hash, multi-sig the keyset |
+
+## Static analysis note
+
+`pact-static-check.sh` reports **PASS, 0 violations**. WARNs dispositioned:
+bare-load env-data warnings are the namespace/`read-msg` load ceremony
+(the full harness is authoritative); the `enforce-guard` warnings sit either
+in defcaps (`GOV`, `CREATOR-AUTH`) or inside `require-capability`-gated hooks
+(Finding 1 above).
+
+The suite loads real registry snapshots plus two **test-support interface
+stubs** (`examples/support/`) for kip interfaces pre-deployed on-chain but not
+yet snapshotted; the auditor confirmed both are pure interfaces (no state, no
+executable bodies) whose signatures match the registry sources' usage — they
+cannot alter behavior under test.
+
+## What self-reviewed means here
+
+Reviewed by the template's maintainers against the PCO checklist, driven
+through the genuine marmalade-v2 stack with attack scenarios as runnable
+regression tests, plus an independent `pact-auditor` pass (automated,
+fresh-context) returning GO. **Not independent human review.** Promotion
+requires a second reviewer (`community-reviewed`) or a third-party report with
+a matching source hash (`independently-audited`) — see
+`docs/CONTRACT_POLICIES.md` §3.1.
+
+## Reproduce the review
+
+```bash
+cd contracts/library/nft-collection-policy/examples
+pact nft-collection-policy-test.repl   # 38 assertions against the real marmalade-v2 stack
+```

--- a/contracts/library/nft-collection-policy/README.md
+++ b/contracts/library/nft-collection-policy/README.md
@@ -1,0 +1,66 @@
+# NFT Collection Policy (marmalade-v2)
+
+PCO library template: a **marmalade-v2 concrete policy** for NFT collections — creator-gated token creation and minting, a collection size cap, strict one-of-one NFT shape, and opt-in burning. This is the artifact an NFT project on Kadena actually writes: a module implementing `kip.token-policy-v2`, attached to tokens at `create-token` time and driven by the marmalade ledger through the policy-manager. It custodies nothing — the marmalade ledger holds the tokens; this policy only decides what is allowed.
+
+## How it works
+
+1. **`create-collection id name max-size burnable creator-guard`** — self-serve; the caller must satisfy `creator-guard` (signs scoped to `CREATOR-AUTH`). `max-size 0` = unbounded.
+2. **`marmalade-v2.ledger.create-token …`** with this policy in the token's policies list and `"collection_id"` in tx data — the policy's `enforce-init` admits the token: only the collection creator may add tokens, the collection must have room, and precision must be 0.
+3. **`marmalade-v2.ledger.mint token-id account guard 1.0`** — `enforce-mint`: creator-authorized, exactly once per token **ever**, amount exactly 1.0. The recipient may be anyone.
+4. **Transfers and sales** are permitted by this policy — the ledger enforces ownership (managed `TRANSFER`/`OFFER` capabilities). Stack marmalade's royalty policy for economics.
+5. **Burning** is a per-collection opt-in; the ledger additionally enforces the owner's guard. A burned NFT can never be re-minted.
+
+## Security model
+
+- **Hooks are unreachable outside the real flow.** Every one of the seven `kip.token-policy-v2` hooks is gated by `require-capability` on the policy-manager's corresponding `*-CALL` capability (with this policy's rendered name as argument). Direct calls — from users or hostile modules — always fail; the only path to policy state runs through the genuine ledger → policy-manager flow.
+- **Collections belong to their creators.** Adding tokens and minting both enforce the guard enrolled at collection creation, inside the policy-manager-granted scope. Governance (`nft-collection-gov` keyset) can upgrade the module and nothing else.
+- **One-of-one shape is a hard invariant.** Precision 0 at init; mint exactly once per token with amount exactly 1.0; the minted flag is one-way, so burn → re-mint is impossible. Supply for any token is 0 or 1, forever.
+- **Size caps count created tokens — burned tokens still count.** `max-size` bounds tokens ever admitted to the collection (minted or not, burned or not): a max-N collection can only ever contain N distinct token ids. Accounting updates are transactional with the ledger's `create-token`, so an abort anywhere rolls back everything.
+- **Scope your signatures.** The creator's guard is enforced inside the policy-manager's `INIT-CALL`/`MINT-CALL` scope, so creators can (and should) scope their create-token and mint signatures to those ledger capabilities instead of signing unscoped — the suite demonstrates the exact shape.
+
+## Deployment checklist
+
+1. Wrap the module in your namespace; replace the `"nft-collection-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig recommended**).
+2. Deploy and `create-table` (`collections`, `tokens`). No init step — collections are self-serve.
+3. Validate on **devnet against the real marmalade-v2 deployment** before mainnet — **mandatory**, not optional (see Known limits: the buy step of sales is not exercised in the REPL suite).
+
+## Usage
+
+```pact
+;; create a collection (sign scoped to CREATOR-AUTH)
+(free.nft-collection-policy.create-collection "my-art" "My Art" 100 false
+  (read-keyset "creator"))
+
+;; create a token in it (tx data: {"collection_id": "my-art"}; creator signs)
+(marmalade-v2.ledger.create-token
+  (marmalade-v2.ledger.create-token-id
+    { 'uri: "ipfs://…", 'precision: 0, 'policies: [free.nft-collection-policy] }
+    (read-keyset "creator"))
+  0 "ipfs://…" [free.nft-collection-policy] (read-keyset "creator"))
+
+;; mint it (creator signs scoped to the ledger's MINT-CALL + managed MINT)
+(marmalade-v2.ledger.mint token-id "collector" (read-keyset "collector") 1.0)
+```
+
+## Testing
+
+`examples/nft-collection-policy-test.repl` loads the **real marmalade-v2 stack** from this repo's `registry/` tree (verbatim chain snapshots — ledger, policy-manager, kip interfaces, `util.fungible-util`) plus two clearly-labeled interface stubs (`examples/support/`) for kip interfaces not yet snapshotted:
+
+```bash
+cd contracts/library/nft-collection-policy/examples && pact nft-collection-policy-test.repl
+```
+
+38 assertions: direct-call attacks on all seven hooks, creator gating on create-token and mint, precision/amount/once-only NFT shape, collection size cap, non-owner transfer denial, per-collection burn opt-in with the no-re-mint invariant, and the sale defpact's offer + withdraw steps exercised positively through the genuine ledger. CI runs this suite as a blocking check.
+
+## Known limits
+
+- **The sale BUY step is not exercised in the REPL suite** (it needs the quote/escrow machinery). `enforce-buy`'s capability arguments are verified against the policy-manager source, but **devnet validation of a full sale (offer → buy) against the real marmalade-v2 deployment is mandatory** before relying on sales.
+- **`collection_id` comes from tx data at create-token time** — one collection per transaction when creating tokens.
+- **Minting is creator-only by design.** For public/paid mint drops, front this policy with a sale contract or extend it — that is deliberately out of scope for the template.
+- **No royalty logic.** Stack marmalade's concrete royalty policy alongside this one in the token's policies list.
+- The two files under `examples/support/` are **REPL test support only** (interface signatures for `kip.account-protocols-v1` and `kip.updatable-uri-policy-v1`, which are pre-deployed on-chain but not yet snapshotted in the registry). Never deploy them.
+- Governance holds upgrade power. Pin the deployed module hash you audited; use a multi-sig governance keyset.
+
+## License
+
+Apache-2.0

--- a/contracts/library/nft-collection-policy/examples/nft-collection-policy-test.repl
+++ b/contracts/library/nft-collection-policy/examples/nft-collection-policy-test.repl
@@ -1,0 +1,290 @@
+;; nft-collection-policy-test.repl — PCO library template test suite
+;;
+;; Loads the REAL marmalade-v2 stack from this repo's registry tree (see
+;; setup-marmalade.repl) and drives this policy through the genuine ledger:
+;; create-token, mint, transfer, burn, and the sale defpact's offer/withdraw
+;; steps — plus direct-call attacks on every policy hook (all must be
+;; unreachable outside the ledger flow).
+;;
+;; Actors: carol = collection creator; alice = collector; dave = attacker/buyer.
+
+(load "setup-marmalade.repl")
+
+;; ---------------------------------------------------------------------------
+;; Load the policy under test.
+;; ---------------------------------------------------------------------------
+(begin-tx "load-policy")
+(env-data
+  { "nft-collection-gov": ["gov-key"]
+  , "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(define-keyset "nft-collection-gov" (read-keyset "nft-collection-gov"))
+(load "../nft-collection-policy.pact")
+(create-table collections)
+(create-table tokens)
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; create-collection: validated, creator-authenticated (scoped sig), unique.
+;; ---------------------------------------------------------------------------
+(begin-tx "create-collection-validation")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect-failure "empty collection id rejected" "collection id required"
+  (nft-collection-policy.create-collection "" "Art" 2 false (read-keyset "carol")))
+(expect-failure "empty collection name rejected" "collection name required"
+  (nft-collection-policy.create-collection "col1" "" 2 false (read-keyset "carol")))
+(expect-failure "negative max-size rejected" "max-size must be >= 0"
+  (nft-collection-policy.create-collection "col1" "Art" -1 false (read-keyset "carol")))
+(rollback-tx)
+
+(begin-tx "create-collection-wrong-key")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(env-sigs [{"key": "dave-key", "caps": []}])
+(expect-failure "cannot enroll a guard you cannot satisfy" "Keyset failure"
+  (nft-collection-policy.create-collection "col1" "Art" 2 false (read-keyset "carol")))
+(rollback-tx)
+
+(begin-tx "create-collections")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+;; carol signs SCOPED to CREATOR-AUTH — a collection signature authorizes
+;; nothing else her key could satisfy in the transaction
+(env-sigs [{"key": "carol-key"
+          , "caps": [(nft-collection-policy.CREATOR-AUTH (read-keyset "carol"))]}])
+(expect "col1 created (max 2, non-burnable)" "col1"
+  (nft-collection-policy.create-collection "col1" "Art Editions" 2 false
+    (read-keyset "carol")))
+(expect "COLLECTION emitted" true
+  (contains "nft-collection-policy.COLLECTION" (map (at 'name) (env-events true))))
+(expect "col2 created (unbounded, burnable)" "col2"
+  (nft-collection-policy.create-collection "col2" "Burn Club" 0 true
+    (read-keyset "carol")))
+(commit-tx)
+
+(begin-tx "duplicate-collection-id")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect-failure "reused collection id rejected" "already found while in Insert mode"
+  (nft-collection-policy.create-collection "col1" "Again" 2 false
+    (read-keyset "carol")))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Direct-call attacks: every policy hook must be unreachable outside the
+;; ledger -> policy-manager flow (require-capability on *-CALL).
+;; ---------------------------------------------------------------------------
+(begin-tx "direct-hook-calls-blocked")
+(env-sigs [{"key": "carol-key", "caps": []}])
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"], "collection_id": "col1" })
+(let ((fake:object{kip.token-policy-v2.token-info}
+        { 'id: "t:fake", 'supply: 0.0, 'precision: 0, 'uri: "ipfs://fake"
+        , 'policies: [nft-collection-policy] }))
+  (expect-failure "direct enforce-init blocked" "not granted"
+    (nft-collection-policy.enforce-init fake))
+  (expect-failure "direct enforce-mint blocked" "not granted"
+    (nft-collection-policy.enforce-mint fake "dave" (read-keyset "dave") 1.0))
+  (expect-failure "direct enforce-burn blocked" "not granted"
+    (nft-collection-policy.enforce-burn fake "dave" 1.0))
+  (expect-failure "direct enforce-offer blocked" "not granted"
+    (nft-collection-policy.enforce-offer fake "dave" 1.0 0 "sale"))
+  (expect-failure "direct enforce-withdraw blocked" "not granted"
+    (nft-collection-policy.enforce-withdraw fake "dave" 1.0 0 "sale"))
+  (expect-failure "direct enforce-buy blocked" "not granted"
+    (nft-collection-policy.enforce-buy fake "dave" "dave" (read-keyset "dave") 1.0 "sale"))
+  (expect-failure "direct enforce-transfer blocked" "not granted"
+    (nft-collection-policy.enforce-transfer fake "alice" (read-keyset "dave") "dave" 1.0)))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; create-token through the real ledger: creator-gated, collection cap,
+;; NFT shape (precision 0).
+;; ---------------------------------------------------------------------------
+(begin-tx "create-token-non-creator")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"], "collection_id": "col1" })
+(env-sigs [{"key": "dave-key", "caps": []}])
+(expect-failure "non-creator cannot add a token to the collection" "Keyset failure"
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-x", 'precision: 0
+               , 'policies: [nft-collection-policy] } (read-keyset "dave"))))
+    (marmalade-v2.ledger.create-token tid 0 "ipfs://col1-x"
+      [nft-collection-policy] (read-keyset "dave"))))
+(rollback-tx)
+
+(begin-tx "create-token-bad-precision")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"], "collection_id": "col1" })
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect-failure "precision must be 0 for NFTs" "NFT precision must be 0"
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-x", 'precision: 12
+               , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+    (marmalade-v2.ledger.create-token tid 12 "ipfs://col1-x"
+      [nft-collection-policy] (read-keyset "carol"))))
+(rollback-tx)
+
+(begin-tx "create-token-unknown-collection")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"], "collection_id": "nope" })
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect-failure "unknown collection rejected" "nope"
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-x", 'precision: 0
+               , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+    (marmalade-v2.ledger.create-token tid 0 "ipfs://col1-x"
+      [nft-collection-policy] (read-keyset "carol"))))
+(rollback-tx)
+
+(begin-tx "create-t1-t2")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"], "collection_id": "col1" })
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect "t1 created in col1" true
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-1", 'precision: 0
+               , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+    (marmalade-v2.ledger.create-token tid 0 "ipfs://col1-1"
+      [nft-collection-policy] (read-keyset "carol"))))
+(expect "TOKEN-ADDED emitted" true
+  (contains "nft-collection-policy.TOKEN-ADDED" (map (at 'name) (env-events true))))
+(expect "t2 created in col1" true
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-2", 'precision: 0
+               , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+    (marmalade-v2.ledger.create-token tid 0 "ipfs://col1-2"
+      [nft-collection-policy] (read-keyset "carol"))))
+(expect "col1 size is 2" 2
+  (at 'size (nft-collection-policy.get-collection "col1")))
+(commit-tx)
+
+(begin-tx "collection-full")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"], "collection_id": "col1" })
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect-failure "col1 is at max-size 2" "collection is full"
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-3", 'precision: 0
+               , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+    (marmalade-v2.ledger.create-token tid 0 "ipfs://col1-3"
+      [nft-collection-policy] (read-keyset "carol"))))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; mint through the real ledger: creator-gated, once per token, amount 1.0.
+;; ---------------------------------------------------------------------------
+(begin-tx "mint-non-creator")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(env-sigs [{"key": "dave-key", "caps": []}])
+(expect-failure "non-creator cannot mint" "Keyset failure"
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-1", 'precision: 0
+               , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+    (marmalade-v2.ledger.mint tid "dave" (read-keyset "dave") 1.0)))
+(rollback-tx)
+
+(begin-tx "mint-bad-amount")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(env-sigs [{"key": "carol-key", "caps": []}])
+(expect-failure "mint amount must be exactly 1.0" "NFT mint amount must be exactly 1.0"
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-1", 'precision: 0
+               , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+    (marmalade-v2.ledger.mint tid "alice" (read-keyset "alice") 2.0)))
+(rollback-tx)
+
+(begin-tx "mint-t1-to-alice")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(let ((tid (marmalade-v2.ledger.create-token-id
+             { 'uri: "ipfs://col1-1", 'precision: 0
+             , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+  ;; the creator scopes to MINT-CALL (in scope when the policy checks her
+  ;; guard) and to the ledger's one-shot managed MINT cap
+  (env-sigs [{"key": "carol-key"
+            , "caps": [(marmalade-v2.ledger.MINT-CALL tid "alice" 1.0)
+                      ,(marmalade-v2.ledger.MINT tid "alice" 1.0)]}])
+  (expect "t1 minted to alice" true
+    (marmalade-v2.ledger.mint tid "alice" (read-keyset "alice") 1.0))
+  (expect "alice owns t1" 1.0 (marmalade-v2.ledger.get-balance tid "alice"))
+  (expect "t1 marked minted" true (nft-collection-policy.is-minted tid))
+  (expect-failure "t1 cannot be minted twice" "NFT already minted"
+    (marmalade-v2.ledger.mint tid "dave" (read-keyset "dave") 1.0)))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; transfer through the real ledger: owner-guarded (managed TRANSFER cap),
+;; permitted by this policy.
+;; ---------------------------------------------------------------------------
+(begin-tx "transfer-t1")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(let ((tid (marmalade-v2.ledger.create-token-id
+             { 'uri: "ipfs://col1-1", 'precision: 0
+             , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+  (env-sigs [{"key": "dave-key"
+            , "caps": [(marmalade-v2.ledger.TRANSFER tid "alice" "dave" 1.0)]}])
+  (expect-failure "non-owner cannot transfer" "Keyset failure"
+    (marmalade-v2.ledger.transfer-create tid "alice" "dave" (read-keyset "dave") 1.0))
+  (env-sigs [{"key": "alice-key"
+            , "caps": [(marmalade-v2.ledger.TRANSFER tid "alice" "dave" 1.0)]}])
+  (expect "alice transfers t1 to dave" true
+    (marmalade-v2.ledger.transfer-create tid "alice" "dave" (read-keyset "dave") 1.0))
+  (expect "dave owns t1" 1.0 (marmalade-v2.ledger.get-balance tid "dave")))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; burn: per-collection opt-in; a burned NFT cannot be re-minted.
+;; ---------------------------------------------------------------------------
+(begin-tx "burn-non-burnable")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(env-sigs [{"key": "dave-key", "caps": []}])
+(expect-failure "col1 does not allow burning" "collection does not allow burning"
+  (let ((tid (marmalade-v2.ledger.create-token-id
+               { 'uri: "ipfs://col1-1", 'precision: 0
+               , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+    (marmalade-v2.ledger.burn tid "dave" 1.0)))
+(rollback-tx)
+
+(begin-tx "burn-burnable-then-no-remint")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"], "collection_id": "col2" })
+(env-sigs [{"key": "carol-key", "caps": []}])
+(let ((tid (marmalade-v2.ledger.create-token-id
+             { 'uri: "ipfs://col2-1", 'precision: 0
+             , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+  (marmalade-v2.ledger.create-token tid 0 "ipfs://col2-1"
+    [nft-collection-policy] (read-keyset "carol"))
+  (env-sigs [{"key": "carol-key"
+            , "caps": [(marmalade-v2.ledger.MINT-CALL tid "alice" 1.0)
+                      ,(marmalade-v2.ledger.MINT tid "alice" 1.0)]}])
+  (marmalade-v2.ledger.mint tid "alice" (read-keyset "alice") 1.0)
+  (env-sigs [{"key": "alice-key"
+            , "caps": [(marmalade-v2.ledger.BURN tid "alice" 1.0)]}])
+  (expect "alice burns her col2 token" true
+    (marmalade-v2.ledger.burn tid "alice" 1.0))
+  (expect "supply back to zero" 0.0 (marmalade-v2.ledger.total-supply tid))
+  (env-sigs [{"key": "carol-key", "caps": []}])
+  (expect-failure "burned NFT cannot be re-minted" "NFT already minted"
+    (marmalade-v2.ledger.mint tid "alice" (read-keyset "alice") 1.0)))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; sale defpact: step 0 (offer) escrows the token and exercises
+;; enforce-offer positively; the rollback (withdraw) returns it and
+;; exercises enforce-withdraw positively. The buy step needs the
+;; quote/escrow machinery — devnet-mandated (see README).
+;; ---------------------------------------------------------------------------
+(begin-tx "sale-offer")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(env-hash (hash "sale-1"))
+(let ((tid (marmalade-v2.ledger.create-token-id
+             { 'uri: "ipfs://col1-1", 'precision: 0
+             , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+  (env-sigs [{"key": "dave-key"
+            , "caps": [(marmalade-v2.ledger.OFFER tid "dave" 1.0 0)]}])
+  (marmalade-v2.ledger.sale tid "dave" 1.0 0)
+  (expect "t1 escrowed for sale" 0.0 (marmalade-v2.ledger.get-balance tid "dave")))
+(commit-tx)
+
+(begin-tx "sale-withdraw")
+(env-data { "nft-collection-gov": ["gov-key"], "carol": ["carol-key"], "alice": ["alice-key"], "dave": ["dave-key"] })
+(let ((tid (marmalade-v2.ledger.create-token-id
+             { 'uri: "ipfs://col1-1", 'precision: 0
+             , 'policies: [nft-collection-policy] } (read-keyset "carol"))))
+  (env-sigs [{"key": "dave-key"
+            , "caps": [(marmalade-v2.ledger.WITHDRAW tid "dave" 1.0 0 (hash "sale-1"))]}])
+  (continue-pact 0 true (hash "sale-1"))
+  (expect "t1 returned to dave after withdraw" 1.0
+    (marmalade-v2.ledger.get-balance tid "dave")))
+(commit-tx)

--- a/contracts/library/nft-collection-policy/examples/setup-marmalade.repl
+++ b/contracts/library/nft-collection-policy/examples/setup-marmalade.repl
@@ -1,0 +1,47 @@
+;; setup-marmalade.repl — loads the REAL marmalade-v2 stack from this repo's
+;; registry tree (verbatim chain snapshots), plus one test-support interface
+;; stub (support/kip-account-protocols-v1.pact — see its header).
+;;
+;; Loaded by vesting-style suites via (load "setup-marmalade.repl").
+
+(begin-tx "namespaces-and-keysets")
+(env-data { "ns-admin": ["ns-admin-key"] })
+(env-sigs [{"key": "ns-admin-key", "caps": []}])
+(define-namespace 'kip (read-keyset "ns-admin") (read-keyset "ns-admin"))
+(define-namespace 'util (read-keyset "ns-admin") (read-keyset "ns-admin"))
+(define-namespace 'marmalade-v2 (read-keyset "ns-admin") (read-keyset "ns-admin"))
+(define-keyset "util-ns-admin" (read-keyset "ns-admin"))
+(namespace 'marmalade-v2)
+(define-keyset "marmalade-v2.marmalade-contract-admin" (read-keyset "ns-admin"))
+(commit-tx)
+
+(begin-tx "load-kip")
+(env-data { "ns": "kip" })
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../../registry/kip/token-manifest/kip-token-manifest.pact")
+(load "../../../registry/kip/token-manifest/kip-poly-fungible-v3.pact")
+(load "../../../registry/kip/token-policy-v2/kip-token-policy-v2.pact")
+(load "support/kip-account-protocols-v1.pact")
+(load "support/kip-updatable-uri-policy-v1.pact")
+(commit-tx)
+
+(begin-tx "load-util")
+(env-sigs [{"key": "ns-admin-key", "caps": []}])
+;; the verbatim snapshot has no namespace directive; enter it here
+(namespace 'util)
+(load "../../../registry/core/fungible-util/fungible-util.pact")
+(commit-tx)
+
+(begin-tx "load-marmalade")
+(env-data { "ns": "marmalade-v2", "upgrade": false, "upgrade_version_1": false })
+(env-sigs [{"key": "ns-admin-key", "caps": []}])
+(load "../../../registry/marmalade/ledger/ledger-interface.pact")
+(load "../../../registry/marmalade/ledger/ledger-v2-interface.pact")
+(load "../../../registry/marmalade/policy-manager/sale-interface.pact")
+(load "../../../registry/marmalade/policy-manager/policy-manager.pact")
+(load "../../../registry/marmalade/ledger/marmalade-v2-ledger.pact")
+;; the verbatim snapshot's fresh-deploy branch predates the `versions` table
+;; (added on-chain in the version-1 upgrade); create it explicitly
+(create-table marmalade-v2.ledger.versions)
+(marmalade-v2.policy-manager.init marmalade-v2.ledger)
+(commit-tx)

--- a/contracts/library/nft-collection-policy/examples/support/kip-account-protocols-v1.pact
+++ b/contracts/library/nft-collection-policy/examples/support/kip-account-protocols-v1.pact
@@ -1,0 +1,31 @@
+;; REPL TEST SUPPORT ONLY — NOT a registry snapshot.
+;;
+;; On-chain, `kip.account-protocols-v1` is pre-deployed; this repo's registry
+;; holds only verbatim chain snapshots, and this interface has not been
+;; snapshotted yet. The member signatures below are derived mechanically from
+;; the registry's `util.fungible-util` (which implements this interface), so
+;; the real module loads against it unchanged. Do not deploy this file.
+
+(namespace (read-string 'ns))
+
+(interface account-protocols-v1
+
+  (defun enforce-valid-amount (precision:integer amount:decimal)
+    @doc "Enforce positive AMOUNT at PRECISION.")
+
+  (defun enforce-valid-account (account:string)
+    @doc "Enforce minimum account-name validity.")
+
+  (defun enforce-precision (precision:integer amount:decimal)
+    @doc "Enforce AMOUNT respects PRECISION.")
+
+  (defun enforce-valid-transfer
+    (sender:string receiver:string precision:integer amount:decimal)
+    @doc "Enforce transfer validity of AMOUNT from SENDER to RECEIVER.")
+
+  (defun check-reserved:string (account:string)
+    @doc "Return the reserved-name protocol prefix of ACCOUNT, or empty.")
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account-name protocols for ACCOUNT/GUARD.")
+)

--- a/contracts/library/nft-collection-policy/examples/support/kip-updatable-uri-policy-v1.pact
+++ b/contracts/library/nft-collection-policy/examples/support/kip-updatable-uri-policy-v1.pact
@@ -1,0 +1,16 @@
+;; REPL TEST SUPPORT ONLY — NOT a registry snapshot.
+;;
+;; On-chain, `kip.updatable-uri-policy-v1` is pre-deployed; the registry has
+;; not snapshotted it yet. The single member signature below is derived from
+;; its call site in the registry's marmalade-v2 policy-manager
+;; (`(policy::enforce-update-uri token new-uri)`). Do not deploy this file.
+
+(namespace (read-string 'ns))
+
+(interface updatable-uri-policy-v1
+
+  (defun enforce-update-uri:bool
+    ( token:object{kip.token-policy-v2.token-info}
+      new-uri:string )
+    @doc "Policy hook for updating a token's URI.")
+)

--- a/contracts/library/nft-collection-policy/metadata.yaml
+++ b/contracts/library/nft-collection-policy/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'NFT Collection Policy (marmalade-v2)'
+slug: 'nft-collection-policy'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['nft', 'marmalade', 'collection', 'token-policy', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'nft', 'marmalade-v2', 'token-policy-v2', 'collection', 'mint']

--- a/contracts/library/nft-collection-policy/nft-collection-policy.pact
+++ b/contracts/library/nft-collection-policy/nft-collection-policy.pact
@@ -1,0 +1,221 @@
+(module nft-collection-policy GOV
+
+  @doc "PCO library template: a marmalade-v2 CONCRETE POLICY for NFT            \
+  \collections with creator-gated creation/minting, a collection size cap,     \
+  \one-of-one NFT shape, and opt-in burning.                                   \
+  \                                                                              \
+  \This is the artifact an NFT project on Kadena actually writes: a module     \
+  \implementing kip.token-policy-v2, attached to tokens at create-token time   \
+  \and driven by the marmalade-v2 ledger through the policy-manager. It does   \
+  \NOT custody tokens or funds - the marmalade ledger does; this policy only   \
+  \decides what is allowed.                                                    \
+  \                                                                              \
+  \Rules enforced:                                                              \
+  \  - Tokens join a COLLECTION (created here) at create-token time via the    \
+  \    'collection_id' field in tx data. Only the collection creator (its      \
+  \    enrolled guard) can add tokens, up to max-size (0 = unbounded).         \
+  \  - NFT shape: precision 0, minted exactly once, amount exactly 1.0.        \
+  \    A burned NFT cannot be re-minted (mint is once per token, ever).        \
+  \  - Burning is a per-collection opt-in (the ledger additionally enforces    \
+  \    the owner's guard).                                                     \
+  \  - Transfers and sales are permitted by this policy (the ledger enforces   \
+  \    ownership); stack marmalade concrete policies (e.g. royalty) for        \
+  \    economics.                                                              \
+  \                                                                              \
+  \SECURITY: every policy hook is gated by require-capability on the           \
+  \policy-manager's *-CALL capability, so hooks CANNOT be called directly -    \
+  \only through the real ledger flow.                                          \
+  \                                                                              \
+  \Deployment checklist (see README.md):                                        \
+  \  1. Wrap in your namespace; replace the 'nft-collection-gov' keyset.        \
+  \  2. Deploy and create-table; no init step - collections are self-serve.    \
+  \  3. Validate on devnet against the real marmalade-v2 deployment before     \
+  \     mainnet."
+
+  (implements kip.token-policy-v2)
+  (use kip.token-policy-v2 [token-info])
+
+  ;; -----------------------------
+  ;; Governance
+  ;; -----------------------------
+
+  (defconst GOV_KEYSET:string "nft-collection-gov"
+    @doc "Governance keyset name. Replace with your deployed, namespace- \
+         \qualified keyset (multi-sig recommended). Governance can upgrade \
+         \the module and nothing else: collections belong to their creators, \
+         \and no function under GOV touches collection or token state.")
+
+  (defcap GOV ()
+    @doc "Module governance: upgrade only."
+    (enforce-guard (keyset-ref-guard GOV_KEYSET)))
+
+  ;; -----------------------------
+  ;; Identity of this policy (for the policy-manager's *-CALL caps)
+  ;; -----------------------------
+
+  (defconst POLICY:string (format "{}" [nft-collection-policy])
+    @doc "This policy's fully-qualified name as the policy-manager renders it \
+         \in its *-CALL capabilities.")
+
+  ;; -----------------------------
+  ;; Schemas & tables
+  ;; -----------------------------
+
+  (defschema collection-row
+    @doc "A creator-owned NFT collection."
+    name:string
+    creator-guard:guard   ;; authorizes create-token and mint for this collection
+    max-size:integer      ;; max tokens in the collection; 0 = unbounded
+    size:integer          ;; tokens created so far
+    burnable:bool)        ;; whether owners may burn tokens of this collection
+
+  (deftable collections:{collection-row})
+
+  (defschema token-row
+    @doc "Per-token policy state. MINTED is one-way: a burned NFT cannot be \
+         \re-minted."
+    collection-id:string
+    minted:bool)
+
+  (deftable tokens:{token-row})
+
+  ;; -----------------------------
+  ;; Events & auth
+  ;; -----------------------------
+
+  (defcap COLLECTION (id:string name:string max-size:integer burnable:bool)
+    @event true)
+
+  (defcap TOKEN-ADDED (collection-id:string token-id:string)
+    @event true)
+
+  (defcap CREATOR-AUTH (guard:guard)
+    @doc "Authenticate a collection creator. As a capability, a creator can \
+         \scope their create-collection signature to it."
+    (enforce-guard guard))
+
+  ;; -----------------------------
+  ;; Collections (self-serve, creator-owned)
+  ;; -----------------------------
+
+  (defun create-collection:string (id:string name:string max-size:integer
+                                   burnable:bool creator-guard:guard)
+    @doc "Create a collection owned by CREATOR-GUARD. The caller must satisfy \
+         \that guard (proves control of the enrolled authority). MAX-SIZE 0 \
+         \means unbounded. ID must be unique."
+    (enforce (!= id "") "collection id required")
+    (enforce (!= name "") "collection name required")
+    (enforce (>= max-size 0) "max-size must be >= 0 (0 = unbounded)")
+    (with-capability (CREATOR-AUTH creator-guard)
+      (insert collections id
+        { 'name: name
+        , 'creator-guard: creator-guard
+        , 'max-size: max-size
+        , 'size: 0
+        , 'burnable: burnable })
+      (emit-event (COLLECTION id name max-size burnable))
+      id))
+
+  ;; -----------------------------
+  ;; kip.token-policy-v2 hooks
+  ;; -----------------------------
+  ;; Every hook is gated by require-capability on the policy-manager's
+  ;; *-CALL capability: acquirable only inside the policy-manager, which is
+  ;; itself gated by the ledger's own *-CALL capabilities. Direct calls to
+  ;; these hooks always fail.
+
+  (defun enforce-init:bool (token:object{token-info})
+    @doc "Token creation: the tx data field 'collection_id' names the target \
+         \collection; only the collection creator may add tokens; the \
+         \collection must have room; NFT precision must be 0."
+    (require-capability
+      (marmalade-v2.policy-manager.INIT-CALL
+        (at 'id token) (at 'precision token) (at 'uri token) POLICY))
+    (enforce (= 0 (at 'precision token)) "NFT precision must be 0")
+    (let* ((collection-id:string (read-msg "collection_id"))
+           (col (read collections collection-id))
+           (creator-guard (at 'creator-guard col))
+           (max-size (at 'max-size col))
+           (new-size (+ 1 (at 'size col)))
+           (within-cap (or (= 0 max-size) (<= new-size max-size))))
+      (enforce-guard creator-guard)
+      (enforce within-cap "collection is full")
+      (update collections collection-id { 'size: new-size })
+      (insert tokens (at 'id token)
+        { 'collection-id: collection-id, 'minted: false })
+      (emit-event (TOKEN-ADDED collection-id (at 'id token)))
+      true))
+
+  (defun enforce-mint:bool (token:object{token-info} account:string
+                            guard:guard amount:decimal)
+    @doc "Minting: creator-authorized, exactly once per token, amount exactly \
+         \1.0. The recipient (ACCOUNT/GUARD) may be anyone - the creator's \
+         \guard authorizes the mint itself."
+    (require-capability
+      (marmalade-v2.policy-manager.MINT-CALL (at 'id token) account amount POLICY))
+    (enforce (= amount 1.0) "NFT mint amount must be exactly 1.0")
+    (with-read tokens (at 'id token)
+      { 'collection-id := collection-id, 'minted := minted }
+      (enforce (not minted) "NFT already minted")
+      (let ((creator-guard (at 'creator-guard (read collections collection-id))))
+        (enforce-guard creator-guard))
+      (update tokens (at 'id token) { 'minted: true })
+      true))
+
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal)
+    @doc "Burning: allowed only if the token's collection opted in. The \
+         \ledger separately enforces the owner's guard (DEBIT). A burned \
+         \NFT cannot be re-minted."
+    (require-capability
+      (marmalade-v2.policy-manager.BURN-CALL (at 'id token) account amount POLICY))
+    (let* ((collection-id (at 'collection-id (read tokens (at 'id token))))
+           (burnable (at 'burnable (read collections collection-id))))
+      (enforce burnable "collection does not allow burning"))
+    true)
+
+  (defun enforce-offer:bool (token:object{token-info} seller:string
+                             amount:decimal timeout:integer sale-id:string)
+    @doc "Sales are permitted by this policy; the ledger/policy-manager \
+         \enforce seller ownership and sale mechanics. Stack a royalty \
+         \policy for economics."
+    (require-capability
+      (marmalade-v2.policy-manager.OFFER-CALL
+        (at 'id token) seller amount sale-id timeout POLICY))
+    true)
+
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string
+                                amount:decimal timeout:integer sale-id:string)
+    (require-capability
+      (marmalade-v2.policy-manager.WITHDRAW-CALL
+        (at 'id token) seller amount sale-id timeout POLICY))
+    true)
+
+  (defun enforce-buy:bool (token:object{token-info} seller:string buyer:string
+                           buyer-guard:guard amount:decimal sale-id:string)
+    (require-capability
+      (marmalade-v2.policy-manager.BUY-CALL
+        (at 'id token) seller buyer amount sale-id POLICY))
+    true)
+
+  (defun enforce-transfer:bool (token:object{token-info} sender:string
+                                guard:guard receiver:string amount:decimal)
+    @doc "Transfers are permitted by this policy (the ledger enforces the \
+         \sender's guard). Also covers the ledger's rotate case (amount 0.0)."
+    (require-capability
+      (marmalade-v2.policy-manager.TRANSFER-CALL
+        (at 'id token) sender receiver amount POLICY))
+    true)
+
+  ;; -----------------------------
+  ;; Views
+  ;; -----------------------------
+
+  (defun get-collection:object{collection-row} (id:string)
+    (read collections id))
+
+  (defun get-token-collection:string (token-id:string)
+    (at 'collection-id (read tokens token-id)))
+
+  (defun is-minted:bool (token-id:string)
+    (at 'minted (read tokens token-id)))
+)

--- a/docs/index.json
+++ b/docs/index.json
@@ -115,6 +115,38 @@
 }
 ,
 {
+  "name": "NFT Collection Policy (marmalade-v2)",
+  "slug": "nft-collection-policy",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "nft",
+    "marmalade",
+    "collection",
+    "token-policy",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "nft",
+    "marmalade-v2",
+    "token-policy-v2",
+    "collection",
+    "mint"
+  ]
+}
+,
+{
   "name": "Token (fungible-v2 + fungible-xchain-v1)",
   "slug": "token-fungible",
   "version": "0.2.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ _Generated from `contracts/**/metadata.yaml`._
 | Gas Station (drain-defended) | gas-station | 1.0.0 | self-reviewed | gas-station, gas-payer-v1, gasless, template, library |
 | Hello World | hello-world | 1.0.0 | self-reviewed | hello-world, tutorial, basic |
 | Multisig Treasury (M-of-N) | multisig-treasury | 1.0.0 | self-reviewed | treasury, multisig, governance, template, library |
+| NFT Collection Policy (marmalade-v2) | nft-collection-policy | 1.0.0 | self-reviewed | nft, marmalade, collection, token-policy, template, library |
 | Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
 | Token Vesting (cliff + linear) | vesting | 1.0.0 | self-reviewed | vesting, escrow, timelock, template, library |
 


### PR DESCRIPTION
## What

New PCO library template: `contracts/library/nft-collection-policy` — a **marmalade-v2 concrete policy** (implements `kip.token-policy-v2`), the artifact an NFT project on Kadena actually writes. Creator-owned collections with size caps, strict one-of-one NFT shape, opt-in burning; the marmalade ledger custodies the tokens, this policy only decides what's allowed.

- **Hooks unreachable outside the real flow**: all seven policy hooks are `require-capability`-gated on the policy-manager's `*-CALL` capabilities — direct calls, hostile modules, and signature-scoping tricks all fail (empirically probed).
- **1-of-1 invariant**: precision 0 at init, mint exactly once **ever** (burn → no re-mint), amount exactly 1.0 — supply is 0 or 1, permanently.
- **Creator-gated**: adding tokens and minting enforce the guard enrolled at collection creation; governance is upgrade-only.
- **Tested against the genuine stack**: the suite loads the real marmalade-v2 ledger + policy-manager + kip interfaces + `util.fungible-util` from the registry's verbatim snapshots and drives create-token / mint / transfer / burn / sale offer+withdraw through the actual ledger. Two clearly-labeled interface-only stubs (`examples/support/`) cover kip interfaces not yet snapshotted (auditor-confirmed: pure interfaces, cannot alter behavior under test).

## Review process

Independent `pact-auditor` pass: **GO — zero findings above INFO**. Highlights:

- Hook-gating claim empirically proven: top-level acquisition of `*-CALL` caps is refused by Pact, sig-scoping grants nothing, and the policy's rendered name matches the manager's under any namespace.
- **All seven `require-capability` argument orders verified against the policy-manager source — including `BUY-CALL`**, whose path a REPL suite cannot exercise (an arg-order mistake there would brick every sale at the buy step, invisibly). Verified correct.
- State-corruption probes: no size drift under mid-tx aborts, duplicate-policy listing fails cleanly, mint cannot re-home a token to another collection.
- Three INFO items (scoped-sig guidance, burned-tokens-still-count-toward-cap, no policy-level mint/burn events) — all documented/dispositioned in AUDIT.md.

## Evidence

- `examples/nft-collection-policy-test.repl`: **38 assertions** against the real marmalade-v2 stack, including direct-call attacks on all seven hooks. Runs as a blocking CI step (the setup harness is also CI-run and load-clean).
- Static gate: PASS, 0 violations.
- `AUDIT.md` documents the probes, threat model, and the standing caveat: **devnet validation against the real marmalade-v2 deployment — specifically an on-chain buy — is mandatory before relying on sales.**
- Index regenerated; entry validates under the library quality gate at `self-reviewed`.