### PR TITLE
feat(library): add median oracle feed template (staleness-guarded)

### DIFF
--- a/contracts/library/oracle-feed/AUDIT.md
+++ b/contracts/library/oracle-feed/AUDIT.md
@@ -1,0 +1,121 @@
+# AUDIT — library/oracle-feed
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `oracle-feed` (namespace: project-specific) |
+| **Version** | 1.0.0 |
+| **Audit Status** | self-reviewed |
+| **Category** | PCO Library Template |
+| **Source** | PCO-authored reference implementation |
+| **Last review** | 2026-07-06 |
+
+## Purpose
+
+Deployable median data/price feed with fail-closed consumption: a governed
+publisher set posts chain-timestamped observations; consumers read the median
+of fresh, currently-enrolled publishers' values, aborting below a per-feed
+quorum. Custodies no funds.
+
+## Audit history: findings and fixes
+
+An independent `pact-auditor` pass returned **GO conditional on two LOW
+dispositions** (zero CRITICAL/HIGH/MEDIUM). Both were implemented, plus the
+INFO recommendations:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| F1 | LOW | `obs-key` (`"{feed}:{publisher}"`) was **not injective** when names contain `":"` — reproduced: `obs-key("A:B","n1") == obs-key("A","B:n1")`, letting two distinct (feed, publisher) pairs silently alias one observation row and corrupt the median. Especially dangerous for a template, since `"KDA:USD"` is a natural feed-id choice. | `":"` (and empty publisher names) are now **rejected** at `create-feed`, `init`, and `rotate-publishers`, making the key injective by construction. Regression-tested (both rejection paths). |
+| F2 | LOW | The module doc claimed median robustness **unconditionally**, but the guarantee needs `n ≥ 2f+1`: a 1-answer read is one publisher's word, and a 2-answer read *averages* — either publisher has unbounded pull (reproduced: honest 1.00 + malicious 1,000,000 → answer 500,000.5). | Docs corrected everywhere the claim appears (module doc, `create-feed` doc, README): the median bounds a minority only at `n ≥ 3`; `min-answers ≥ 3` recommended for adversarial robustness; 1- and 2-answer semantics stated plainly. |
+
+**INFO items (confirmed, dispositioned):**
+
+- **Re-key revival** — re-enrolling a rotated-out publisher *name* revives its
+  last posted (possibly poisoned) observation under its old timestamp. Docs
+  now instruct: respond to a compromise with a **fresh name**, never an
+  in-place re-key (observation rows are never deleted).
+- **Non-monotonic block-time** — a future-dated observation counts as fresh
+  (`diff-time` negative). Safe direction (very-recent data); publishers cannot
+  manipulate freshness either way since timestamps are chain-assigned.
+- **Even-median precision** — averaging can carry one extra decimal place;
+  documented (consumers round to token precision before money math).
+- **`PUBLISH-AUTH` scope** — per-publisher, not per-feed (one signature covers
+  posts to multiple feeds in a transaction); now stated in the cap's doc.
+- **Unbounded `min-answers`** — a quorum above the publisher count makes the
+  feed unreadable; that is the documented fail-closed behavior.
+- **`median []`** — aborts on an out-of-bounds index if called directly with
+  an empty list; unreachable via `get-price` (quorum ≥ 1 checked first).
+- **Suite gap** — the outlier test only proved a *high* outlier; a
+  low-outlier regression was added (the auditor verified both directions and
+  unsorted inputs independently).
+
+## Threat model & defenses
+
+| Vector | Defense | Test |
+|---|---|---|
+| Non-publisher posts | `PUBLISH-AUTH` checks enrollment | `post-non-publisher` |
+| Impersonate a publisher by name | `PUBLISH-AUTH` enforces the enrolled guard | `post-wrong-key` |
+| Backdate/forward-date an observation | timestamps assigned from chain block-time only | `post-node1-node2` timestamp assert |
+| Minority manipulation of the answer | median over ≥3 fresh answers bounds any minority | high + low outlier regressions |
+| Stale data served | caller's `max-age` excludes old observations; below-quorum reads abort | `staleness`, `quorum-fail-closed` |
+| Rotated-out publisher still counts | reads aggregate current publishers only | `rotate-out-revokes-observation` |
+| Observation-row aliasing via `":"` names | `":"` banned in feed ids and publisher names (F1) | colon-rejection cases |
+| Zero/negative values (incl. sentinel collision) | `value > 0` enforced at post; nothing else writes observations | `post-validation` |
+| Feed spoofing / rogue feed creation | `create-feed` is governance-gated, ids unique | `create-feed-requires-gov`, dup case |
+| Whole-set repointing (majority/market event) | consumer-side deviation breaker (worked example shipped) | `consumer-rejects-jump` / `consumer-accepts-drift` |
+| Governance posts or alters data | no such path; governance = enrollment + feeds + upgrade | capability sweep |
+
+## Capability model
+
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard GOV_KEYSET` | init / rotate / create-feed / upgrade; **cannot post** — but enrollment is the feed's root of trust (operationally trusted; multi-sig it) |
+| `PUBLISH-AUTH (account)` | authentication | enrollment + enrolled guard (reads let-bound, then enforced) | per-publisher scope (module-wide, all feeds) |
+| `FEED_CREATED` / `POSTED` / `PUBLISHERS_ROTATED` | `@event` | — | emit-only; `POSTED` stream is the feed's full history |
+
+Reads (`get-price`, `fresh-values`, `answer-count`, views) take no capability:
+they are deterministic aggregations of recorded state.
+
+## Node-safety
+
+Every `enforce` operates on arguments or let/with-read-bound locals
+(`PUBLISH-AUTH` binds the enrollment read; `get-price` enforces a bound
+count). The whole read pipeline (`map`/`with-default-read`/`filter`/`sort`)
+runs outside any enforce. Swept clean by author and auditor. This class is
+REPL-invisible on KDA-CE, so **devnet validation of enroll → post → read is
+the required evidence** before production use.
+
+## Risk profile
+
+| Risk | Level | Notes |
+|---|---|---|
+| Unauthorized posting | Low | scoped cap over enrolled guards, regression-tested |
+| Answer manipulation | Low at `min-answers ≥ 3` | median bounds minorities; 1–2 answer feeds documented as single-opinion |
+| Stale/thin reads | Low | fail-closed quorum + caller staleness window |
+| State corruption | Low | injective keys (F1 fix); only `post` writes observations |
+| Publisher-set capture | **Inherent** | whoever controls enrollment controls the feed — multi-sig governance mandatory in spirit |
+| Governance dependency | Medium | upgrade power: pin the module hash, multi-sig the keyset |
+
+## Static analysis note
+
+`pact-static-check.sh` reports **PASS, 0 violations** — including a clean
+Tier-1 standalone load (no dependencies). The three Tier-2 `enforce-guard`
+WARNs are dispositioned SAFE — all sit inside defcaps (`GOV`, `PUBLISH-AUTH`,
+and the suite consumer's governance cap).
+
+## What self-reviewed means here
+
+Reviewed by the template's maintainers against the PCO checklist, with the
+data-integrity model encoded as runnable regression tests, plus an independent
+`pact-auditor` pass (automated, fresh-context) whose required dispositions are
+implemented. **Not independent human review.** Promotion requires a second
+reviewer (`community-reviewed`) or a third-party report with a matching source
+hash (`independently-audited`) — see `docs/CONTRACT_POLICIES.md` §3.1.
+
+## Reproduce the review
+
+```bash
+cd contracts/library/oracle-feed/examples
+pact oracle-feed-test.repl   # 51 assertions
+```

--- a/contracts/library/oracle-feed/README.md
+++ b/contracts/library/oracle-feed/README.md
@@ -1,0 +1,69 @@
+# Oracle Feed (median, staleness-guarded)
+
+PCO library template: an on-chain **median data feed** with fail-closed consumption. A governed set of publishers posts observations; consumers read a median that only counts **fresh** observations (against their own staleness tolerance) from **currently enrolled** publishers, and aborts below a per-feed quorum. Prices are the obvious use, but any positive-decimal observation works.
+
+## How it works
+
+1. **`init publishers guards`** (governance) — enroll the publisher accounts with their authenticating guards (max 20).
+2. **`create-feed id description min-answers`** (governance) — create a feed with a read quorum.
+3. **`post feed publisher value`** — an enrolled publisher upserts their latest observation (positive decimals only), signing scoped to `(oracle-feed.PUBLISH-AUTH "node-1")`. **The timestamp is assigned from chain block-time** — publishers cannot backdate or forward-date.
+4. **`get-price feed max-age`** — the consumer's read: the **median** of observations no older than `max-age` seconds, from current publishers only. Aborts (fails closed) unless at least `min-answers` such observations exist. `answer-count` previews the same filter.
+5. **`rotate-publishers publishers guards`** (governance) — replace the set; a rotated-out publisher's standing observation stops counting **immediately**.
+
+Every step emits an event (`FEED_CREATED`, `POSTED`, `PUBLISHERS_ROTATED`) — the `POSTED` stream is the feed's full history (state keeps only each publisher's latest).
+
+## Security model
+
+- **Median aggregation — at a real quorum.** With `n ≥ 3` fresh answers, fewer than `n/2` rogue publishers cannot move the answer beyond the honest range (`n ≥ 2f+1`). Below that the guarantee does not exist: one answer is a single publisher's word, and **two answers are averaged, giving either publisher unbounded pull**. Set `min-answers ≥ 3` for adversarial robustness, and size the publisher set so staleness can't thin reads below it.
+- **Fail closed, never stale.** Consumers pick `max-age`; observations older than that are excluded, and a read below the quorum aborts. There is no path that returns a stale or thin answer.
+- **Chain-assigned time.** `post` stamps observations with block-time. A publisher controls only the value, never the freshness bookkeeping.
+- **Rotation is revocation.** Reads aggregate only current publishers, so rotating a compromised publisher out instantly removes their influence. Respond to a key compromise by enrolling a **fresh name** — re-enrolling the same name (even with a new guard) instantly revives that name's last posted, possibly poisoned, observation under its old timestamp.
+- **Names are separator-safe.** Feed ids and publisher names must not contain `":"` (the observation-key separator) — enforced, so distinct (feed, publisher) pairs can never alias one storage row.
+- **Scoped publishing.** `PUBLISH-AUTH` is a capability; a posting signature authorizes nothing else the same key could satisfy in the transaction.
+- **Governance cannot post.** It curates publishers and creates feeds. Note the trust honestly: whoever controls enrollment controls the feed's long-run integrity — an oracle's governance is **operationally trusted**, unlike this library's custody templates. Multi-sig it.
+
+## Consuming a feed safely
+
+The suite ships a worked consumer (`price-consumer` in the test file) demonstrating the pattern every integrator should copy:
+
+```pact
+(let* ((p (oracle-feed.get-price "KDA/USD" 900.0))       ;; staleness: fail closed
+       (prev (get-last-accepted))
+       (dev-ok (or (= prev 0.0)
+                   (<= (abs (- p prev)) (* prev 0.10)))))  ;; deviation breaker
+  (enforce dev-ok "price deviates too far from last accepted")
+  ...)
+```
+
+- **Choose `max-age` for your use case** — a lending protocol wants minutes, a weekly settlement can take hours. Remember block-time is the parent block's timestamp (~30s lag).
+- **Add a deviation circuit-breaker** against your last accepted value: the feed defends against minority manipulation, but a majority repointing (or a real market crash) passes quorum and freshness — the consumer decides whether a sudden move is acceptable.
+- **Round before money math.** An even answer count averages the two middle values, which can carry one more decimal place than the inputs; round/floor to your token's precision before transferring.
+
+## Deployment checklist
+
+1. Wrap the module in your namespace; replace the `"oracle-feed-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig mandatory in spirit** — enrollment is the feed's root of trust).
+2. Deploy, `create-table` (all four), `init`, `create-feed`.
+3. Validate the end-to-end flow on **devnet** before mainnet — **mandatory**, not optional (the auth path reads on-chain tables; that class of bug is invisible in the REPL).
+
+## Testing
+
+`examples/oracle-feed-test.repl` is fully standalone:
+
+```bash
+cd contracts/library/oracle-feed/examples && pact oracle-feed-test.repl
+```
+
+51 assertions on a controlled clock: publisher authorization attacks (non-publisher, wrong key, signature scoped to another publisher), chain-assigned timestamps, even-count and odd-count medians (an outlier is provably swallowed), staleness windows thinning the answer set until the quorum fails closed, the rotation regression (a rotated-out publisher's standing observation stops counting immediately, flipping the price), re-post upserts, and the consumer deviation-breaker pattern accepting drift and rejecting a >10% jump. CI runs this suite as a blocking check.
+
+## Known limits
+
+- **The feed is only as good as its publisher set.** The median bounds *minority* manipulation; a colluding majority of fresh answers controls the price. Enrollment (governance) is the root of trust — this is inherent to oracles, not fixable in Pact.
+- **`min-answers 1` means single-publisher truth, and `2` means an average either publisher controls.** Legitimate for a feed you run yourself; understand what each value buys before pointing money at it. `≥ 3` is where the median guarantee starts.
+- **A quorum above the publisher count makes the feed unreadable** (fail closed) until enough publishers exist and post — by design.
+- **Publishers are per-module, not per-feed.** Every enrolled publisher may post to every feed. Segment by deploying separate instances if feeds need disjoint publisher sets.
+- **State holds only each publisher's latest observation** per feed (bounded: publishers × feeds rows). History lives in the `POSTED` event stream — index it off-chain if you need TWAPs or archives.
+- Governance holds upgrade power. Pin the deployed module hash you audited; use a multi-sig governance keyset.
+
+## License
+
+Apache-2.0

--- a/contracts/library/oracle-feed/examples/oracle-feed-test.repl
+++ b/contracts/library/oracle-feed/examples/oracle-feed-test.repl
@@ -1,0 +1,306 @@
+;; oracle-feed-test.repl — PCO library template test suite
+;;
+;; Fully standalone (no dependencies). Drives the feed on a controlled clock:
+;; publisher authorization attacks, chain-assigned timestamps, median
+;; aggregation (odd count swallows an outlier; even count averages),
+;; staleness exclusion at the caller's max-age, the min-answers fail-closed
+;; quorum, the rotation regression (a rotated-out publisher's standing
+;; observation stops counting immediately), and a consumer module showing
+;; the deviation-guard consumption pattern.
+;;
+;; Actors: node1/node2/node3 publishers (node4 rotated in later); eve attacker.
+
+;; ---------------------------------------------------------------------------
+;; Setup: keyset, module, tables.
+;; ---------------------------------------------------------------------------
+(begin-tx "setup")
+(env-data
+  { "oracle-feed-gov": ["gov-key"]
+  , "node1": ["node1-key"], "node2": ["node2-key"], "node3": ["node3-key"]
+  , "node4": ["node4-key"], "eve": ["eve-key"] })
+(define-keyset "oracle-feed-gov" (read-keyset "oracle-feed-gov"))
+(load "../oracle-feed.pact")
+(create-table config)
+(create-table publisher-guards)
+(create-table feeds)
+(create-table observations)
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; init: governance-gated, validated publisher set.
+;; ---------------------------------------------------------------------------
+(begin-tx "init-requires-gov")
+(env-sigs [])
+(expect-failure "init without governance fails" "Keyset failure"
+  (oracle-feed.init ["node1"] [(read-keyset "node1")]))
+(rollback-tx)
+
+(begin-tx "init-validation")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "empty publisher set rejected" "at least one publisher required"
+  (oracle-feed.init [] []))
+(expect-failure "publishers/guards mismatch rejected" "publishers/guards length mismatch"
+  (oracle-feed.init ["node1" "node2"] [(read-keyset "node1")]))
+(expect-failure "duplicate publishers rejected" "duplicate publishers"
+  (oracle-feed.init ["node1" "node1"]
+    [(read-keyset "node1") (read-keyset "node1")]))
+(expect-failure "publisher name with ':' rejected (obs-key injectivity)"
+  "must not contain ':'"
+  (oracle-feed.init ["node:1"] [(read-keyset "node1")]))
+(expect-failure "publisher set above MAX_PUBLISHERS rejected"
+  "publisher count exceeds maximum of 20"
+  (oracle-feed.init
+    (map (lambda (i:integer) (format "n{}" [i])) (enumerate 1 21))
+    (make-list 21 (read-keyset "node1"))))
+(rollback-tx)
+
+(begin-tx "init")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "init 3 publishers" "initialized"
+  (oracle-feed.init ["node1" "node2" "node3"]
+    [(read-keyset "node1") (read-keyset "node2") (read-keyset "node3")]))
+(expect "init emits PUBLISHERS_ROTATED" true
+  (contains "oracle-feed.PUBLISHERS_ROTATED" (map (at 'name) (env-events true))))
+(commit-tx)
+
+(begin-tx "init-once")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "init cannot run twice" "already found while in Insert mode"
+  (oracle-feed.init ["node1"] [(read-keyset "node1")]))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; create-feed: governance only, validated, unique.
+;; ---------------------------------------------------------------------------
+(begin-tx "create-feed-requires-gov")
+(env-sigs [{"key": "eve-key", "caps": []}])
+(expect-failure "non-governance cannot create a feed" "Keyset failure"
+  (oracle-feed.create-feed "KDA/USD" "KDA spot price in USD" 2))
+(rollback-tx)
+
+(begin-tx "create-feed")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect-failure "empty feed id rejected" "feed id required"
+  (oracle-feed.create-feed "" "x" 2))
+(expect-failure "zero min-answers rejected" "min-answers must be >= 1"
+  (oracle-feed.create-feed "KDA/USD" "x" 0))
+(expect-failure "feed id with ':' rejected (obs-key injectivity)"
+  "feed id must not contain ':'"
+  (oracle-feed.create-feed "KDA:USD" "x" 2))
+(expect "KDA/USD feed created (quorum 2)" "KDA/USD"
+  (oracle-feed.create-feed "KDA/USD" "KDA spot price in USD" 2))
+(expect "FEED_CREATED emitted" true
+  (contains "oracle-feed.FEED_CREATED" (map (at 'name) (env-events true))))
+(expect-failure "duplicate feed id rejected" "already found while in Insert mode"
+  (oracle-feed.create-feed "KDA/USD" "again" 2))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; post: enrolled publishers only, authenticated, positive values, real feed,
+;; chain-assigned timestamps.
+;; ---------------------------------------------------------------------------
+(begin-tx "post-non-publisher")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [{"key": "eve-key", "caps": [(oracle-feed.PUBLISH-AUTH "eve")]}])
+(expect-failure "non-publisher cannot post" "not an enrolled publisher"
+  (oracle-feed.post "KDA/USD" "eve" 1.0))
+(rollback-tx)
+
+(begin-tx "post-wrong-key")
+(env-sigs [{"key": "eve-key", "caps": [(oracle-feed.PUBLISH-AUTH "node1")]}])
+(expect-failure "posting as a publisher without their key fails" "Keyset failure"
+  (oracle-feed.post "KDA/USD" "node1" 1.0))
+(rollback-tx)
+
+(begin-tx "post-validation")
+(env-sigs [{"key": "node1-key", "caps": [(oracle-feed.PUBLISH-AUTH "node1")]}])
+(expect-failure "zero value rejected" "value must be positive"
+  (oracle-feed.post "KDA/USD" "node1" 0.0))
+(expect-failure "negative value rejected" "value must be positive"
+  (oracle-feed.post "KDA/USD" "node1" -1.0))
+(expect-failure "unknown feed rejected" "KDA/EUR"
+  (oracle-feed.post "KDA/EUR" "node1" 1.0))
+(rollback-tx)
+
+(begin-tx "post-node1-node2")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-sigs [{"key": "node1-key", "caps": [(oracle-feed.PUBLISH-AUTH "node1")]}
+          ,{"key": "node2-key", "caps": [(oracle-feed.PUBLISH-AUTH "node2")]}])
+(expect "node1 posts 1.00" "KDA/USD" (oracle-feed.post "KDA/USD" "node1" 1.00))
+(expect "POSTED emitted" true
+  (contains "oracle-feed.POSTED" (map (at 'name) (env-events true))))
+(expect "node2 posts 1.10" "KDA/USD" (oracle-feed.post "KDA/USD" "node2" 1.10))
+(expect "timestamp is chain-assigned" (time "2026-01-01T00:00:00Z")
+  (at 'updated (oracle-feed.get-observation "KDA/USD" "node1")))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; get-price: quorum fail-closed, even-count median.
+;; ---------------------------------------------------------------------------
+(begin-tx "read-basics")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(expect-failure "non-positive max-age rejected" "max-age must be positive"
+  (oracle-feed.get-price "KDA/USD" 0.0))
+(expect-failure "unknown feed read rejected" "KDA/EUR"
+  (oracle-feed.get-price "KDA/EUR" 60.0))
+(expect "two fresh answers" 2 (oracle-feed.answer-count "KDA/USD" 60.0))
+(expect "even-count median averages the middle pair" 1.05
+  (oracle-feed.get-price "KDA/USD" 60.0))
+(commit-tx)
+
+(begin-tx "quorum-fail-closed")
+;; a second feed with quorum 2 and only one post: read must abort
+(env-sigs [{"key": "gov-key", "caps": []}])
+(oracle-feed.create-feed "BTC/USD" "BTC spot" 2)
+(env-sigs [{"key": "node1-key", "caps": [(oracle-feed.PUBLISH-AUTH "node1")]}])
+(oracle-feed.post "BTC/USD" "node1" 100000.0)
+(expect-failure "below-quorum read fails closed" "insufficient fresh answers"
+  (oracle-feed.get-price "BTC/USD" 60.0))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Odd-count median swallows an outlier: node3 posts a wild value 30s later.
+;; ---------------------------------------------------------------------------
+(begin-tx "outlier-resistance")
+(env-chain-data { "block-time": (time "2026-01-01T00:00:30Z") })
+(env-sigs [{"key": "node3-key", "caps": [(oracle-feed.PUBLISH-AUTH "node3")]}])
+(oracle-feed.post "KDA/USD" "node3" 99.9)
+(expect "three fresh answers" 3 (oracle-feed.answer-count "KDA/USD" 60.0))
+(expect "median ignores the high outlier" 1.10
+  (oracle-feed.get-price "KDA/USD" 60.0))
+(commit-tx)
+
+(begin-tx "low-outlier-resistance")
+;; the outlier direction must not matter: node3 repoints far BELOW
+(env-chain-data { "block-time": (time "2026-01-01T00:00:30Z") })
+(env-sigs [{"key": "node3-key", "caps": [(oracle-feed.PUBLISH-AUTH "node3")]}])
+(oracle-feed.post "KDA/USD" "node3" 0.0001)
+(expect "median ignores the low outlier" 1.00
+  (oracle-feed.get-price "KDA/USD" 60.0))
+;; restore the high outlier for the staleness/rotation scenes below
+(oracle-feed.post "KDA/USD" "node3" 99.9)
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Staleness: at T0+100s, a 60s max-age excludes everything; 90s keeps only
+;; node3 (1 < quorum 2); 120s keeps all three.
+;; ---------------------------------------------------------------------------
+(begin-tx "staleness")
+(env-chain-data { "block-time": (time "2026-01-01T00:01:40Z") })
+(expect "no answers within 60s" 0 (oracle-feed.answer-count "KDA/USD" 60.0))
+(expect-failure "all-stale read fails closed" "insufficient fresh answers"
+  (oracle-feed.get-price "KDA/USD" 60.0))
+(expect "only node3 within 90s" 1 (oracle-feed.answer-count "KDA/USD" 90.0))
+(expect-failure "below-quorum (stale-thinned) read fails closed"
+  "insufficient fresh answers"
+  (oracle-feed.get-price "KDA/USD" 90.0))
+(expect "all three within 120s" 3 (oracle-feed.answer-count "KDA/USD" 120.0))
+(expect "median over the full window" 1.10
+  (oracle-feed.get-price "KDA/USD" 120.0))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Rotation regression: rotating node3 out revokes its standing observation
+;; IMMEDIATELY — the price flips back to the two-answer median. A rotated-out
+;; publisher can no longer post; a rotated-in one counts at once.
+;; ---------------------------------------------------------------------------
+(begin-tx "rotate-out-revokes-observation")
+(env-chain-data { "block-time": (time "2026-01-01T00:01:40Z") })
+(env-sigs [{"key": "gov-key", "caps": []}])
+(expect "node3 rotated out" "rotated"
+  (oracle-feed.rotate-publishers ["node1" "node2"]
+    [(read-keyset "node1") (read-keyset "node2")]))
+(expect "outlier's observation no longer counts" 2
+  (oracle-feed.answer-count "KDA/USD" 120.0))
+(expect "median without the rotated-out publisher" 1.05
+  (oracle-feed.get-price "KDA/USD" 120.0))
+(env-sigs [{"key": "node3-key", "caps": [(oracle-feed.PUBLISH-AUTH "node3")]}])
+(expect-failure "rotated-out publisher cannot post" "not an enrolled publisher"
+  (oracle-feed.post "KDA/USD" "node3" 1.0))
+(commit-tx)
+
+(begin-tx "rotate-in-counts-at-once")
+(env-chain-data { "block-time": (time "2026-01-01T00:01:40Z") })
+(env-sigs [{"key": "gov-key", "caps": []}])
+(oracle-feed.rotate-publishers ["node1" "node2" "node4"]
+  [(read-keyset "node1") (read-keyset "node2") (read-keyset "node4")])
+(env-sigs [{"key": "node4-key", "caps": [(oracle-feed.PUBLISH-AUTH "node4")]}])
+(oracle-feed.post "KDA/USD" "node4" 1.20)
+(expect "new publisher's answer counts immediately" 3
+  (oracle-feed.answer-count "KDA/USD" 120.0))
+(expect "odd median over the new set" 1.10
+  (oracle-feed.get-price "KDA/USD" 120.0))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Consumer pattern: staleness via max-age + a deviation circuit-breaker
+;; against the last accepted price. This is how a contract should consume a
+;; feed: fail closed on thin/stale data (the feed does that) AND on sudden
+;; moves (the consumer does this).
+;; ---------------------------------------------------------------------------
+(begin-tx "consumer-module")
+(env-sigs [{"key": "gov-key", "caps": []}])
+(module price-consumer CONSUMER-GOV
+  (defcap CONSUMER-GOV () (enforce-guard (keyset-ref-guard "oracle-feed-gov")))
+  (defschema state last:decimal)
+  (deftable st:{state})
+  (defun accept-price:decimal (max-age:decimal max-dev:decimal)
+    @doc "Read the feed, but reject a price that moved more than MAX-DEV \
+         \(relative) from the last accepted one."
+    (let* ((p (oracle-feed.get-price "KDA/USD" max-age))
+           (prev (with-default-read st "s" { 'last: 0.0 } { 'last := l } l))
+           (dev-ok (or (= prev 0.0)
+                       (<= (abs (- p prev)) (* prev max-dev)))))
+      (enforce dev-ok "price deviates too far from last accepted")
+      (write st "s" { 'last: p })
+      p)))
+(create-table st)
+(commit-tx)
+
+(begin-tx "consumer-accepts-first")
+(env-chain-data { "block-time": (time "2026-01-01T00:01:40Z") })
+(expect "first read accepted (no baseline)" 1.10
+  (price-consumer.accept-price 120.0 0.10))
+(commit-tx)
+
+(begin-tx "consumer-rejects-jump")
+;; the whole publisher set repoints ~2x higher — quorum and freshness pass,
+;; but the consumer's deviation breaker trips
+(env-chain-data { "block-time": (time "2026-01-01T00:02:00Z") })
+(env-sigs [{"key": "node1-key", "caps": [(oracle-feed.PUBLISH-AUTH "node1")]}
+          ,{"key": "node2-key", "caps": [(oracle-feed.PUBLISH-AUTH "node2")]}
+          ,{"key": "node4-key", "caps": [(oracle-feed.PUBLISH-AUTH "node4")]}])
+(oracle-feed.post "KDA/USD" "node1" 2.00)
+(oracle-feed.post "KDA/USD" "node2" 2.10)
+(oracle-feed.post "KDA/USD" "node4" 2.20)
+(expect "feed itself reads fine" 2.10 (oracle-feed.get-price "KDA/USD" 60.0))
+(expect-failure "consumer rejects a >10% jump"
+  "price deviates too far from last accepted"
+  (price-consumer.accept-price 60.0 0.10))
+(rollback-tx)
+
+(begin-tx "consumer-accepts-drift")
+(env-chain-data { "block-time": (time "2026-01-01T00:02:00Z") })
+(env-sigs [{"key": "node1-key", "caps": [(oracle-feed.PUBLISH-AUTH "node1")]}
+          ,{"key": "node2-key", "caps": [(oracle-feed.PUBLISH-AUTH "node2")]}
+          ,{"key": "node4-key", "caps": [(oracle-feed.PUBLISH-AUTH "node4")]}])
+(oracle-feed.post "KDA/USD" "node1" 1.15)
+(oracle-feed.post "KDA/USD" "node2" 1.16)
+(oracle-feed.post "KDA/USD" "node4" 1.17)
+(expect "consumer accepts a within-band move" 1.16
+  (price-consumer.accept-price 60.0 0.10))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Re-post upserts: a publisher's newer value replaces the old one (no
+;; history accumulation in state; the POSTED event stream is the history).
+;; ---------------------------------------------------------------------------
+(begin-tx "repost-upserts")
+(env-chain-data { "block-time": (time "2026-01-01T00:02:30Z") })
+(env-sigs [{"key": "node1-key", "caps": [(oracle-feed.PUBLISH-AUTH "node1")]}])
+(oracle-feed.post "KDA/USD" "node1" 1.18)
+(expect "latest value replaces the previous" 1.18
+  (at 'value (oracle-feed.get-observation "KDA/USD" "node1")))
+(expect "timestamp advanced" (time "2026-01-01T00:02:30Z")
+  (at 'updated (oracle-feed.get-observation "KDA/USD" "node1")))
+(commit-tx)

--- a/contracts/library/oracle-feed/metadata.yaml
+++ b/contracts/library/oracle-feed/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'Oracle Feed (median, staleness-guarded)'
+slug: 'oracle-feed'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['oracle', 'price-feed', 'median', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'oracle', 'price-feed', 'median', 'staleness', 'publisher']

--- a/contracts/library/oracle-feed/oracle-feed.pact
+++ b/contracts/library/oracle-feed/oracle-feed.pact
@@ -1,0 +1,282 @@
+(module oracle-feed GOV
+
+  @doc "PCO library template: a median price/data feed with staleness-guarded  \
+  \consumption.                                                                \
+  \                                                                              \
+  \A governed set of PUBLISHER accounts posts observations (positive decimal   \
+  \values) per feed. Consumers read an aggregate that is robust by             \
+  \construction:                                                               \
+  \  - the MEDIAN of observations: with n fresh answers, fewer than n/2       \
+  \    rogue publishers cannot move the answer beyond the honest range.       \
+  \    That guarantee needs n >= 3 (n >= 2f+1): a 1-answer read is one        \
+  \    publisher's word, and a 2-answer read averages - giving either         \
+  \    publisher unbounded pull. Set MIN-ANSWERS >= 3 for adversarial         \
+  \    robustness;                                                             \
+  \  - only observations FRESHER than the caller-supplied max-age count       \
+  \    (timestamps are assigned by the chain at post time - publishers        \
+  \    cannot backdate or forward-date);                                       \
+  \  - only observations from CURRENTLY enrolled publishers count             \
+  \    (rotating a compromised publisher out immediately revokes their        \
+  \    standing observation);                                                  \
+  \  - at least the feed's MIN-ANSWERS fresh observations must exist, or      \
+  \    the read aborts - consumers fail closed, never on stale/thin data.     \
+  \                                                                              \
+  \Governance curates the publisher set and creates feeds; it cannot post     \
+  \or alter observations. NOTE: unlike this library's custody templates,      \
+  \an oracle's governance is OPERATIONALLY trusted - it chooses who may       \
+  \publish. Put it under a multi-sig.                                          \
+  \                                                                              \
+  \Deployment checklist (see README.md):                                        \
+  \  1. Wrap in your namespace; replace the 'oracle-feed-gov' keyset.           \
+  \  2. Deploy, create-table, (init publishers guards), (create-feed ...).     \
+  \  3. Validate on devnet before mainnet."
+
+  ;; -----------------------------
+  ;; Governance
+  ;; -----------------------------
+
+  (defconst GOV_KEYSET:string "oracle-feed-gov"
+    @doc "Governance keyset name. Replace with your deployed, namespace- \
+         \qualified keyset (multi-sig recommended). Governance enrolls and \
+         \rotates publishers, creates feeds, and upgrades the module. It \
+         \cannot post or alter observations.")
+
+  (defcap GOV ()
+    @doc "Module governance: publisher set, feed creation, upgrade."
+    (enforce-guard (keyset-ref-guard GOV_KEYSET)))
+
+  ;; -----------------------------
+  ;; Schemas & tables
+  ;; -----------------------------
+
+  (defschema config-row
+    @doc "Singleton publisher-set config."
+    publishers:[string])
+
+  (deftable config:{config-row})
+
+  (defschema publisher-row
+    @doc "Row-level guard for a publisher account, captured at enrollment."
+    guard:guard)
+
+  (deftable publisher-guards:{publisher-row})
+
+  (defschema feed-row
+    @doc "A feed and its read quorum."
+    description:string
+    min-answers:integer)  ;; fresh observations required for a read
+
+  (deftable feeds:{feed-row})
+
+  (defschema observation-row
+    @doc "A publisher's LATEST observation for a feed (upserted on post). \
+         \UPDATED is assigned from chain time at post - never caller-supplied."
+    feed:string
+    publisher:string
+    value:decimal
+    updated:time)
+
+  (deftable observations:{observation-row})
+
+  (defconst CONFIG_KEY:string "config")
+
+  (defconst MAX_PUBLISHERS:integer 20
+    @doc "Upper bound on the publisher set. Reads map over all publishers \
+         \and sort their fresh values - bounded and cheap at 20; real-world \
+         \oracle sets are small and curated.")
+
+  (defconst EPOCH:time (time "1970-01-01T00:00:00Z"))
+
+  ;; -----------------------------
+  ;; Events
+  ;; -----------------------------
+
+  (defcap FEED_CREATED (feed:string description:string min-answers:integer)
+    @event true)
+
+  (defcap POSTED (feed:string publisher:string value:decimal)
+    @event true)
+
+  (defcap PUBLISHERS_ROTATED (publishers:[string])
+    @event true)
+
+  ;; -----------------------------
+  ;; Internal helpers
+  ;; -----------------------------
+
+  (defun chain-time:time ()
+    @doc "Current block time (the PARENT block's timestamp on Chainweb - \
+         \about one block behind wall-clock; factor that into max-age)."
+    (at 'block-time (chain-data)))
+
+  (defun get-config:object{config-row} ()
+    (read config CONFIG_KEY))
+
+  (defun is-publisher:bool (account:string)
+    (contains account (at 'publishers (get-config))))
+
+  (defcap PUBLISH-AUTH (account:string)
+    @doc "Authenticate ACCOUNT as a current publisher: it must be enrolled \
+         \AND the caller must satisfy its enrolled guard. As a capability, a \
+         \publisher scopes their signature to \
+         \(oracle-feed.PUBLISH-AUTH \"node-1\"), so a posting signature does \
+         \NOT also authorize other operations the same key could satisfy. \
+         \The scope is per-PUBLISHER, not per-feed: one signature covers \
+         \posts to any number of feeds in the transaction (publishers are \
+         \module-wide by design)."
+    ; NODE-SAFETY: bind the table read to a local FIRST, then enforce - a
+    ; table read inside an enforce condition passes in the REPL but FAILS on
+    ; the KDA-CE node.
+    (let ((publisher-ok (is-publisher account)))
+      (enforce publisher-ok "not an enrolled publisher"))
+    (with-read publisher-guards account { 'guard := g }
+      (enforce-guard g)))
+
+  (defun enforce-valid-publishers:bool (publishers:[string] guards:[guard])
+    @doc "Shared validation for the publisher set."
+    (enforce (> (length publishers) 0) "at least one publisher required")
+    (enforce (<= (length publishers) MAX_PUBLISHERS)
+      (format "publisher count exceeds maximum of {}" [MAX_PUBLISHERS]))
+    (enforce (= (length publishers) (length guards))
+      "publishers/guards length mismatch")
+    (enforce (= (length (distinct publishers)) (length publishers))
+      "duplicate publishers")
+    ; ':' is the observation-key separator (obs-key); allowing it in names
+    ; would let distinct (feed, publisher) pairs alias the same row
+    (map (lambda (p:string)
+           (enforce (and (!= p "") (not (contains ":" p)))
+             "publisher names must be non-empty and must not contain ':'"))
+         publishers)
+    true)
+
+  (defun obs-key:string (feed:string publisher:string)
+    @doc "Injective because ':' is banned in both feed ids and publisher \
+         \names (enforced at create-feed / enforce-valid-publishers)."
+    (format "{}:{}" [feed publisher]))
+
+  (defun median:decimal (values:[decimal])
+    @doc "Median of a non-empty list. Even count averages the two middle \
+         \values - the result may carry one decimal place more than the \
+         \inputs; round to your token's precision before money math."
+    (let* ((sorted (sort values))
+           (n (length sorted))
+           (mid (/ n 2)))
+      (if (= 1 (mod n 2))
+        (at mid sorted)
+        (/ (+ (at (- mid 1) sorted) (at mid sorted)) 2.0))))
+
+  ;; -----------------------------
+  ;; Lifecycle & governance
+  ;; -----------------------------
+
+  (defun init:string (publishers:[string] guards:[guard])
+    @doc "One-time setup: enroll the publisher set (guards align \
+         \positionally). The config insert enforces one-time setup."
+    (with-capability (GOV)
+      (enforce-valid-publishers publishers guards)
+      (insert config CONFIG_KEY { 'publishers: publishers })
+      (zip (lambda (p:string g:guard) (write publisher-guards p { 'guard: g }))
+           publishers guards)
+      (emit-event (PUBLISHERS_ROTATED publishers))
+      "initialized"))
+
+  (defun rotate-publishers:string (publishers:[string] guards:[guard])
+    @doc "Governance: replace the publisher set. Observations from \
+         \rotated-out publishers stop counting IMMEDIATELY (reads only \
+         \aggregate current publishers). Respond to a publisher key \
+         \compromise by enrolling a FRESH NAME, never by re-enrolling the \
+         \same name with a new guard: observation rows are never deleted, so \
+         \a re-enrolled name instantly revives that name's last posted - \
+         \possibly poisoned - value, under its OLD timestamp (which may \
+         \still pass a generous max-age)."
+    (with-capability (GOV)
+      (enforce-valid-publishers publishers guards)
+      (update config CONFIG_KEY { 'publishers: publishers })
+      (zip (lambda (p:string g:guard) (write publisher-guards p { 'guard: g }))
+           publishers guards)
+      (emit-event (PUBLISHERS_ROTATED publishers))
+      "rotated"))
+
+  (defun create-feed:string (feed:string description:string min-answers:integer)
+    @doc "Governance creates a feed with a read quorum. MIN-ANSWERS >= 1, \
+         \but understand the trust each value buys: 1 = a single publisher's \
+         \word; 2 = an average either publisher can pull without bound; \
+         \>= 3 = a true median that bounds any minority. A quorum above the \
+         \current publisher count simply makes the feed unreadable until \
+         \enough publishers post (fail closed). Feed ids must not contain \
+         \':' (the observation-key separator)."
+    (with-capability (GOV)
+      (enforce (!= feed "") "feed id required")
+      (enforce (not (contains ":" feed)) "feed id must not contain ':'")
+      (enforce (>= min-answers 1) "min-answers must be >= 1")
+      (insert feeds feed { 'description: description, 'min-answers: min-answers })
+      (emit-event (FEED_CREATED feed description min-answers))
+      feed))
+
+  ;; -----------------------------
+  ;; Publishing
+  ;; -----------------------------
+
+  (defun post:string (feed:string publisher:string value:decimal)
+    @doc "A publisher posts (upserts) their latest observation for FEED. The \
+         \timestamp is the chain's, not the caller's. The publisher signs \
+         \scoped to PUBLISH-AUTH."
+    (with-capability (PUBLISH-AUTH publisher)
+      (enforce (> value 0.0) "value must be positive")
+      ; feed must exist (bind the read; aborts on a missing feed)
+      (let ((feed-exists (at 'min-answers (read feeds feed))))
+        (write observations (obs-key feed publisher)
+          { 'feed: feed
+          , 'publisher: publisher
+          , 'value: value
+          , 'updated: (chain-time) }))
+      (emit-event (POSTED feed publisher value))
+      feed))
+
+  ;; -----------------------------
+  ;; Consumption
+  ;; -----------------------------
+
+  (defun fresh-values:[decimal] (feed:string max-age:decimal)
+    @doc "Values from CURRENT publishers whose observation for FEED is no \
+         \older than MAX-AGE seconds. Missing observations are excluded (the \
+         \sentinel default can never satisfy the value>0 filter)."
+    (let* ((publishers (at 'publishers (get-config)))
+           (now (chain-time))
+           (raw (map (lambda (p:string)
+                       (with-default-read observations (obs-key feed p)
+                         { 'value: -1.0, 'updated: EPOCH }
+                         { 'value := v, 'updated := ts }
+                         (if (<= (diff-time now ts) max-age) v -1.0)))
+                     publishers)))
+      (filter (lambda (v:decimal) (> v 0.0)) raw)))
+
+  (defun get-price:decimal (feed:string max-age:decimal)
+    @doc "The median of fresh, current-publisher observations for FEED. \
+         \Aborts (fails closed) unless at least the feed's MIN-ANSWERS fresh \
+         \observations exist. MAX-AGE (seconds) is the consumer's staleness \
+         \tolerance - choose it for your use case; remember block-time is \
+         \the parent block's timestamp."
+    (enforce (> max-age 0.0) "max-age must be positive")
+    (with-read feeds feed { 'min-answers := min-answers }
+      (let* ((values (fresh-values feed max-age))
+             (answers (length values)))
+        (enforce (>= answers min-answers)
+          (format "insufficient fresh answers: {} of {} required"
+                  [answers min-answers]))
+        (median values))))
+
+  ;; -----------------------------
+  ;; Views
+  ;; -----------------------------
+
+  (defun get-feed:object{feed-row} (feed:string)
+    (read feeds feed))
+
+  (defun get-observation:object{observation-row} (feed:string publisher:string)
+    (read observations (obs-key feed publisher)))
+
+  (defun answer-count:integer (feed:string max-age:decimal)
+    @doc "How many fresh, current-publisher observations FEED has right now."
+    (length (fresh-values feed max-age)))
+)

--- a/docs/index.json
+++ b/docs/index.json
@@ -147,6 +147,37 @@
 }
 ,
 {
+  "name": "Oracle Feed (median, staleness-guarded)",
+  "slug": "oracle-feed",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "oracle",
+    "price-feed",
+    "median",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "oracle",
+    "price-feed",
+    "median",
+    "staleness",
+    "publisher"
+  ]
+}
+,
+{
   "name": "Token (fungible-v2 + fungible-xchain-v1)",
   "slug": "token-fungible",
   "version": "0.2.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ _Generated from `contracts/**/metadata.yaml`._
 | Hello World | hello-world | 1.0.0 | self-reviewed | hello-world, tutorial, basic |
 | Multisig Treasury (M-of-N) | multisig-treasury | 1.0.0 | self-reviewed | treasury, multisig, governance, template, library |
 | NFT Collection Policy (marmalade-v2) | nft-collection-policy | 1.0.0 | self-reviewed | nft, marmalade, collection, token-policy, template, library |
+| Oracle Feed (median, staleness-guarded) | oracle-feed | 1.0.0 | self-reviewed | oracle, price-feed, median, template, library |
 | Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
 | Token Vesting (cliff + linear) | vesting | 1.0.0 | self-reviewed | vesting, escrow, timelock, template, library |
 


### PR DESCRIPTION
## What

New PCO library template: `contracts/library/oracle-feed` — an on-chain **median data/price feed with fail-closed consumption**. This completes the WS3 template library (8 entries).

- **Median at a real quorum**: with n ≥ 3 fresh answers, fewer than n/2 rogue publishers cannot move the answer (docs state plainly what 1- and 2-answer reads actually buy).
- **Fail closed, never stale**: consumers choose their staleness window (`max-age`); reads abort below the per-feed `min-answers` quorum. No path returns thin or stale data.
- **Chain-assigned timestamps**: publishers control only the value, never the freshness bookkeeping.
- **Rotation is revocation**: reads aggregate only currently enrolled publishers — rotating a compromised publisher out removes their influence instantly (regression-tested, flips the price). Compromise response: enroll a **fresh name** (re-keying a name revives its possibly-poisoned last observation).
- **Worked consumer pattern**: the suite ships a `price-consumer` module demonstrating the deviation circuit-breaker every integrator should copy — the feed defends against minorities; the consumer decides whether a sudden whole-set move is acceptable.

## Review process

Independent `pact-auditor` pass: **GO conditional on two LOWs** (zero CRITICAL/HIGH/MEDIUM; node-safety sweep clean). Both fixed:

- **obs-key injectivity**: `"{feed}:{publisher}"` aliased distinct pairs when names contain `":"` (reproduced: `obs-key("A:B","n1") == obs-key("A","B:n1")`) — a landmine since `KDA:USD` is a natural feed id. `":"` is now rejected in feed ids and publisher names; regression-tested.
- **Robustness overclaim**: docs said the median unconditionally bounds minorities; corrected to the real guarantee (n ≥ 2f+1, `min-answers ≥ 3` recommended) after the auditor reproduced a 2-answer read where one publisher pulled the average to half a million.

INFO items folded in: fresh-name compromise-response doc, low-outlier median regression, per-publisher capability-scope doc.

## Evidence

- `examples/oracle-feed-test.repl`: **51 assertions**, fully standalone, controlled clock — auth attacks, both-direction outlier resistance, staleness thinning to fail-closed aborts, rotation regression, colon-rejection regressions, consumer breaker accepting drift and rejecting a jump. Blocking CI step.
- Static gate: PASS, 0 violations (clean standalone Tier-1 load).
- `AUDIT.md` documents findings/fixes, the threat model, and the devnet mandate.
- Index regenerated; entry validates under the library quality gate at `self-reviewed`.

## Milestone

With this merge, **WS3 is complete**: token-fungible, gas-station, multisig-treasury, vesting, dao-voting, nft-collection-policy, oracle-feed (+ hello-world) — every template auditor-gated with blocking CI tests and honest audit records.