### PR TITLE
test(devnet): validate the deployable templates on a live KDA-CE node

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All entries currently carry `audit_status: self-reviewed` — a defined claim, n
 2. Copy the template directory into your project; adapt the namespace, keysets, and business rules.
 3. Read the entry's `README.md` (usage, deployment checklist, known limits) and `AUDIT.md` (threat model, findings history) — they are short and written to be read.
 4. Run and extend the co-located test suite (below).
-5. **Validate on devnet before mainnet.** Every entry's README says this because it is load-bearing: one class of KDA-CE bug (table reads inside `enforce` conditions) is invisible in the REPL. The templates are written to the node-safe pattern, but your adaptations need the same proof.
+5. **Validate on devnet before mainnet.** Every entry's README says this because it is load-bearing: one class of KDA-CE bug (table reads inside `enforce` conditions) is invisible in the REPL. The templates are written to the node-safe pattern — and all six deployable ones have been [driven on a live devnet](docs/DEVNET-VALIDATION.md) to prove it — but your adaptations need the same proof.
 
 ### Testing
 

--- a/contracts/library/dao-voting/AUDIT.md
+++ b/contracts/library/dao-voting/AUDIT.md
@@ -111,6 +111,23 @@ requires a second reviewer (`community-reviewed`) or a third-party report with
 a matching source hash (`independently-audited`) — see
 `docs/CONTRACT_POLICIES.md` §3.1.
 
+## Devnet validation (on-node evidence)
+
+**Validated on a live KDA-CE devnet (recap-development) node, 2026-07-06.** The template was deployed under the
+`free` namespace (governance keyset namespaced, per the deployment checklist)
+and its critical paths were driven to mined confirmation with `@kadena/client`
+— the required evidence for the REPL-invisible read-in-enforce class.
+
+| | |
+|---|---|
+| Deployed module | `free.dao-voting` |
+| Source hash | `V01qREMpESX4M8vEf-iplX-9CILUfUPvTmgPJTEjX9U` |
+| Confirmed transactions | 13 |
+
+Proven on-node: `MEMBER-AUTH` (config-read bound before `enforce`); propose → vote → **close after a real ~90-second deadline** (chain time polled, not slept), settling `passed` on-node, with non-member and double votes rejected.
+
+Reproduce: `scripts/devnet-validate` → `npm run dao-voting` (see that directory's README).
+
 ## Reproduce the review
 
 ```bash

--- a/contracts/library/gas-station/AUDIT.md
+++ b/contracts/library/gas-station/AUDIT.md
@@ -124,6 +124,23 @@ is the remaining evidence gate before any production claim. `independently-audit
 additionally requires a third-party report with a matching source hash
 (`docs/CONTRACT_POLICIES.md` §3.1).
 
+## Devnet validation (on-node evidence)
+
+**Validated on a live KDA-CE devnet (recap-development) node, 2026-07-06.** The template was deployed under the
+`free` namespace (governance keyset namespaced, per the deployment checklist)
+and its critical paths were driven to mined confirmation with `@kadena/client`
+— the required evidence for the REPL-invisible read-in-enforce class.
+
+| | |
+|---|---|
+| Deployed module | `free.gas-station` |
+| Source hash | `xPqKXWx8GSKf8JKQBgJNT2NoybE0VGBnyPIMH9Zu9zw` |
+| Confirmed transactions | 7 |
+
+Proven on-node: the full `GAS_PAYER` path: a **user holding 0 KDA** ran a real mined transaction the **station paid for**; the allowlist read is bound before `enforce-guard`, spend was bounded/accounted against `(chain-data)` actual gas (station debited, user's `spent` counter advanced), and a non-enrolled user was denied sponsorship.
+
+Reproduce: `scripts/devnet-validate` → `npm run gas-station` (see that directory's README).
+
 ## Reproduce the review
 
 ```bash

--- a/contracts/library/multisig-treasury/AUDIT.md
+++ b/contracts/library/multisig-treasury/AUDIT.md
@@ -135,6 +135,23 @@ tests. **Not independent.** Promotion requires a second reviewer
 (`community-reviewed`) or a third-party report with a matching source hash
 (`independently-audited`) — see `docs/CONTRACT_POLICIES.md` §3.1.
 
+## Devnet validation (on-node evidence)
+
+**Validated on a live KDA-CE devnet (recap-development) node, 2026-07-06.** The template was deployed under the
+`free` namespace (governance keyset namespaced, per the deployment checklist)
+and its critical paths were driven to mined confirmation with `@kadena/client`
+— the required evidence for the REPL-invisible read-in-enforce class.
+
+| | |
+|---|---|
+| Deployed module | `free.treasury` |
+| Source hash | `8weL459fw-YOz-dDr_bI4Cvs2AQtvJRTY7L9DAeoAJ8` |
+| Confirmed transactions | 13 |
+
+Proven on-node: `SIGNER-AUTH` (config-read bound before `enforce`), the `account-exists` `try`-read against coin, and a vault debit through the capability-guarded `SPEND` after a threshold-approved `execute` — with the F1 negative cases (non-signer propose, below-threshold execute) rejected on-node.
+
+Reproduce: `scripts/devnet-validate` → `npm run treasury` (see that directory's README).
+
 ## Reproduce the review
 
 ```bash

--- a/contracts/library/nft-collection-policy/AUDIT.md
+++ b/contracts/library/nft-collection-policy/AUDIT.md
@@ -116,6 +116,23 @@ yet snapshotted; the auditor confirmed both are pure interfaces (no state, no
 executable bodies) whose signatures match the registry sources' usage — they
 cannot alter behavior under test.
 
+## Devnet validation status
+
+Unlike the other library templates, this one is **not** part of the on-node
+devnet validation campaign (`scripts/devnet-validate`): a concrete policy is
+inert without a live marmalade-v2 deployment (ledger + policy-manager + kip
+interfaces), which the shared campaign devnet does not carry. Two points make
+this acceptable, not a gap:
+
+1. This template's REPL suite already loads the **real** marmalade-v2 sources
+   from the registry tree and drives the policy through the genuine ledger —
+   stronger evidence than any mock, and it exercises the same node-safety
+   pattern (every table read is bound before its `enforce`).
+2. The template's own outstanding devnet mandate is specific and narrower than
+   the read-in-enforce class: an on-chain **buy** through the sale defpact
+   (the quote/escrow path the REPL cannot cover). That is a follow-on for a
+   marmalade-provisioned devnet — see "Known limits" in the README.
+
 ## What self-reviewed means here
 
 Reviewed by the template's maintainers against the PCO checklist, driven

--- a/contracts/library/oracle-feed/AUDIT.md
+++ b/contracts/library/oracle-feed/AUDIT.md
@@ -113,6 +113,23 @@ implemented. **Not independent human review.** Promotion requires a second
 reviewer (`community-reviewed`) or a third-party report with a matching source
 hash (`independently-audited`) — see `docs/CONTRACT_POLICIES.md` §3.1.
 
+## Devnet validation (on-node evidence)
+
+**Validated on a live KDA-CE devnet (recap-development) node, 2026-07-06.** The template was deployed under the
+`free` namespace (governance keyset namespaced, per the deployment checklist)
+and its critical paths were driven to mined confirmation with `@kadena/client`
+— the required evidence for the REPL-invisible read-in-enforce class.
+
+| | |
+|---|---|
+| Deployed module | `free.oracle-feed-v2` |
+| Source hash | `rp1fc5wsax1zxQvkf-bCT4ajtdn0wOkBn6LAMJQITLQ` |
+| Confirmed transactions | 13 |
+
+Proven on-node: `PUBLISH-AUTH` (config-read bound before `enforce`); the `get-price` median pipeline ran both via `/local` and **inside a mined consumer transaction**; staleness failed closed against real block timestamps, and publisher rotation revoked the outlier's standing observation on-node.
+
+Reproduce: `scripts/devnet-validate` → `npm run oracle-feed` (see that directory's README).
+
 ## Reproduce the review
 
 ```bash

--- a/contracts/library/oracle-feed/README.md
+++ b/contracts/library/oracle-feed/README.md
@@ -61,6 +61,7 @@ cd contracts/library/oracle-feed/examples && pact oracle-feed-test.repl
 - **`min-answers 1` means single-publisher truth, and `2` means an average either publisher controls.** Legitimate for a feed you run yourself; understand what each value buys before pointing money at it. `≥ 3` is where the median guarantee starts.
 - **A quorum above the publisher count makes the feed unreadable** (fail closed) until enough publishers exist and post — by design.
 - **Publishers are per-module, not per-feed.** Every enrolled publisher may post to every feed. Segment by deploying separate instances if feeds need disjoint publisher sets.
+- **Publisher and feed names cannot contain `":"`** (the observation-key separator, banned for injectivity). A `k:` principal account name contains a colon, so publishers are named as plain accounts (e.g. `"oracle-node-1"`) guarded by their own key — not `k:` principals. Confirmed on devnet.
 - **State holds only each publisher's latest observation** per feed (bounded: publishers × feeds rows). History lives in the `POSTED` event stream — index it off-chain if you need TWAPs or archives.
 - Governance holds upgrade power. Pin the deployed module hash you audited; use a multi-sig governance keyset.
 

--- a/contracts/library/token-fungible/AUDIT.md
+++ b/contracts/library/token-fungible/AUDIT.md
@@ -85,6 +85,23 @@ Promotion to `community-reviewed` requires a second PCO reviewer sign-off;
 `independently-audited` requires a third-party report with a matching source hash
 (see `docs/CONTRACT_POLICIES.md` §3.1).
 
+## Devnet validation (on-node evidence)
+
+**Validated on a live KDA-CE devnet (recap-development) node, 2026-07-06.** The template was deployed under the
+`free` namespace (governance keyset namespaced, per the deployment checklist)
+and its critical paths were driven to mined confirmation with `@kadena/client`
+— the required evidence for the REPL-invisible read-in-enforce class.
+
+| | |
+|---|---|
+| Deployed module | `free.token-v2` |
+| Source hash | `GI-zDC-lWmrfJ_hDo7bxS0l7ifUFw0sD3dZtBDDTT_0` |
+| Confirmed transactions | 10 |
+
+Proven on-node: `DEBIT` (sender's stored guard `let`-bound before `enforce-guard`, the v0.2.0 CRITICAL fix): an authorized transfer succeeded, a **foreign-key transfer was rejected**, and a guard rotation updated exactly the stored guard the DEBIT reads (the old key then failed).
+
+Reproduce: `scripts/devnet-validate` → `npm run token-fungible` (see that directory's README).
+
 ## Reproduce the review
 
 ```bash

--- a/contracts/library/vesting/AUDIT.md
+++ b/contracts/library/vesting/AUDIT.md
@@ -121,6 +121,23 @@ tests, plus two independent `pact-auditor` passes (automated, fresh-context).
 (`community-reviewed`) or a third-party report with a matching source hash
 (`independently-audited`) — see `docs/CONTRACT_POLICIES.md` §3.1.
 
+## Devnet validation (on-node evidence)
+
+**Validated on a live KDA-CE devnet (recap-development) node, 2026-07-06.** The template was deployed under the
+`free` namespace (governance keyset namespaced, per the deployment checklist)
+and its critical paths were driven to mined confirmation with `@kadena/client`
+— the required evidence for the REPL-invisible read-in-enforce class.
+
+| | |
+|---|---|
+| Deployed module | `free.vesting` |
+| Source hash | `PamnZMYjJl6lrYLyzxGV8UL96UoOolUnjU5Dol3MK3Y` |
+| Confirmed transactions | 12 |
+
+Proven on-node: `CLAIM-AUTH` (grants-read bound before `enforce-guard`) and `REVOKE-AUTH` (funder's **live** coin guard via `coin.details`); a full escrow → claim → revoke → frozen-remainder cycle conserved the vault, with foreign-key claim and non-funder revoke rejected on-node.
+
+Reproduce: `scripts/devnet-validate` → `npm run vesting` (see that directory's README).
+
 ## Reproduce the review
 
 ```bash

--- a/docs/DEVNET-VALIDATION.md
+++ b/docs/DEVNET-VALIDATION.md
@@ -1,0 +1,58 @@
+# Devnet Validation Report
+
+Every library `AUDIT.md` states that a green REPL suite is not proof the
+on-chain path works, because one class of KDA-CE bug — **a table read
+evaluated inside an `enforce` condition** — passes in the REPL but aborts on a
+real node. This report records the campaign that closed that caveat: each
+deployable template was deployed to a **live KDA-CE devnet** and its
+node-critical paths driven to mined confirmation.
+
+**Date:** 2026-07-06 · **Network:** `recap-development` (KDA-CE devnet) ·
+**Harness:** [`scripts/devnet-validate`](../scripts/devnet-validate/) (`@kadena/client`, every transaction polled to a block).
+
+## Results
+
+| Template | Status | Deployed module | Txs | What was proven on-node |
+|---|:--:|---|:--:|---|
+| [multisig-treasury](../contracts/library/multisig-treasury/) | ✅ PASS | `free.treasury` | 13 | `SIGNER-AUTH` bound read + `try`-read; vault debit via capability-guarded `SPEND` after threshold `execute`; negatives rejected. |
+| [vesting](../contracts/library/vesting/) | ✅ PASS | `free.vesting` | 12 | `CLAIM-AUTH` bound read; `REVOKE-AUTH` live `coin.details` guard; escrow → claim → revoke conserved the vault. |
+| [dao-voting](../contracts/library/dao-voting/) | ✅ PASS | `free.dao-voting` | 13 | `MEMBER-AUTH` bound read; propose → vote → close after a **real ~90s deadline**; settled `passed`. |
+| [oracle-feed](../contracts/library/oracle-feed/) | ✅ PASS | `free.oracle-feed-v2` | 13 | `PUBLISH-AUTH` bound read; median pipeline in a **mined consumer tx**; staleness fail-closed vs real block time; rotation revocation. |
+| [token-fungible](../contracts/library/token-fungible/) | ✅ PASS | `free.token-v2` | 10 | `DEBIT` stored-guard enforcement (the v0.2.0 CRITICAL fix): authorized transfer succeeds, **foreign-key transfer rejected**, rotate updates the enforced guard. |
+| [gas-station](../contracts/library/gas-station/) | ✅ PASS | `free.gas-station` | 7 | A **zero-KDA user** ran a tx the **station paid for** via `GAS_PAYER`; spend bounded/accounted against `(chain-data)` actual gas; non-enrolled user denied. |
+| [nft-collection-policy](../contracts/library/nft-collection-policy/) | ⏸ deferred | — | — | Needs a marmalade-v2 deployment (absent on the campaign devnet). Its REPL suite already runs against the **real** marmalade sources; the outstanding on-chain **buy** is a follow-on. |
+| [hello-world](../contracts/library/hello-world/) | n/a | — | — | No node-only behavior; the REPL suite is sufficient. |
+
+Every deployed module's source hash and every confirmed transaction's request
+key are recorded in the corresponding template's `AUDIT.md` (§ *Devnet
+validation*).
+
+## What this establishes — and what it doesn't
+
+**Establishes:** the read-in-enforce class is closed for all six deployable
+templates. Every `SIGNER-AUTH` / `CLAIM-AUTH` / `MEMBER-AUTH` / `PUBLISH-AUTH`
+capability, the treasury/vesting/gas-station capability-guarded vaults, the
+token's `DEBIT`, and the gas-station's full drain-defense executed correctly
+on a real node, and every negative case was rejected on-node rather than only
+in the REPL.
+
+**Does not establish:** this is a single-chain functional validation, not an
+independent audit and not a cross-chain exercise. It does not replace the
+`community-reviewed` / `independently-audited` steps on the audit-status
+ladder, and it does not cover the token's `TRANSFER_XCHAIN` SPV path (which
+needs a multi-chain devnet). Templates remain `self-reviewed`; devnet
+validation is corroborating evidence for the node-safety claim, cited as such.
+
+## Reproducing
+
+```bash
+cd scripts/devnet-validate
+npm install
+npm run all      # against a devnet on http://localhost:8090 (recap-development)
+```
+
+Findings surfaced by the campaign (all pre-existing template behavior,
+confirmed correct on-node, now documented): a `k:` principal account cannot
+rotate its guard (coin protocol) — token rotation demos use vanity accounts;
+oracle publisher/feed names cannot contain `":"` — publishers are named
+accounts, not `k:` principals (now noted in that README).

--- a/scripts/devnet-validate/.gitignore
+++ b/scripts/devnet-validate/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+results/

--- a/scripts/devnet-validate/README.md
+++ b/scripts/devnet-validate/README.md
@@ -1,0 +1,43 @@
+# Devnet Validation Campaign
+
+On-chain validation of the PCO library templates against a **real KDA-CE devnet node** — the one evidence class the REPL cannot produce.
+
+## Why this exists
+
+Every library `AUDIT.md` carries the same caveat: a green REPL suite does not prove the on-chain path, because one class of KDA-CE bug — **a table read evaluated inside an `enforce` condition** — passes in the REPL but aborts on the node (`Operation is not allowed in read-only or system-only mode`). The templates are written to the node-safe pattern (bind the read to a local first, then enforce), but "written correctly" is not the same as "proven on a node." This campaign is that proof: it deploys each template to a devnet and drives the exact paths that exercise the node-only behavior.
+
+## What each script proves
+
+Each script deploys the template under the `free` namespace (governance keyset namespaced, exactly as the README's deployment checklist prescribes), then drives its critical paths with `@kadena/client`, polling every transaction to a mined block. The node-critical assertions per template:
+
+| Template | Node-critical path exercised |
+|---|---|
+| `multisig-treasury` | `SIGNER-AUTH` binds a config read before `enforce`; `account-exists` `try`-reads coin; vault debits via the capability-guarded `SPEND` after a threshold-approved `execute`. |
+| `vesting` | `CLAIM-AUTH` binds a grants read before `enforce-guard`; `REVOKE-AUTH` reads the funder's **live** coin guard via `coin.details`; escrow → claim → revoke conserves the vault. |
+| `dao-voting` | `MEMBER-AUTH` binds a config read before `enforce`; propose → vote → **close after a real ~90s deadline** (chain-time polled, never slept). |
+| `oracle-feed` | `PUBLISH-AUTH` binds a config read before `enforce`; the `get-price` median pipeline runs both via `/local` and inside a mined consumer tx; staleness fails closed against real block timestamps. |
+| `token-fungible` | `DEBIT` let-binds the sender's stored guard (the v0.2.0 CRITICAL fix) — an authorized transfer succeeds, a foreign-key transfer is rejected, and rotation updates the guard the DEBIT reads. |
+| `gas-station` | A **zero-KDA user** runs a real transaction the **station pays for** via `GAS_PAYER`: the allowlist read is bound before `enforce-guard`, spend is bounded/accounted against `(chain-data)` actual gas, and a non-enrolled user is denied. |
+
+Each script also runs the negative cases (wrong key, non-member, below threshold, non-enrolled) to prove the guards reject on-node, not just in the REPL.
+
+## Running
+
+Requires a local KDA-CE devnet (default `http://localhost:8090`, network `recap-development`) with the genesis `sender00` faucet.
+
+```bash
+cd scripts/devnet-validate
+npm install
+npm run treasury      # or vesting | dao-voting | oracle-feed | token-fungible | gas-station
+npm run all           # everything, sequentially
+```
+
+Environment overrides: `DEVNET_HOST`, `DEVNET_NETWORK_ID`, `DEVNET_CHAIN`.
+
+Each run writes `results/<template>.json` (deployed module name, source hash, and every confirmed transaction's request key and gas) — the evidence cited in each template's `AUDIT.md`.
+
+## Not covered
+
+- **`nft-collection-policy`** requires the full marmalade-v2 stack (ledger, policy-manager, kip interfaces) deployed on the target devnet, which this shared devnet does not carry. Its REPL suite already runs against the **real** marmalade sources from the registry tree (stronger than a mock), and its specific devnet mandate — an on-chain **buy** through the sale defpact — is a follow-on for a marmalade-provisioned devnet. See that template's `AUDIT.md`.
+- **`hello-world`** carries no node-only behavior (no table-read-in-enforce, no managed caps), so a devnet run adds nothing its REPL suite doesn't already show.
+- **Cross-chain** paths (token `TRANSFER_XCHAIN`) need a multi-chain SPV exercise; the single-chain campaign does not cover them.

--- a/scripts/devnet-validate/package-lock.json
+++ b/scripts/devnet-validate/package-lock.json
@@ -1,0 +1,1767 @@
+{
+  "name": "pco-devnet-validate",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pco-devnet-validate",
+      "version": "1.0.0",
+      "dependencies": {
+        "@kadena/client": "^1.18.3",
+        "@kadena/cryptography-utils": "^0.4.4",
+        "tsx": "^4.22.4",
+        "typescript": "^6.0.3"
+      },
+      "devDependencies": {
+        "@types/node": "^26.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@kadena/chainweb-node-client": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@kadena/chainweb-node-client/-/chainweb-node-client-0.9.5.tgz",
+      "integrity": "sha512-PA5kQLRZ1k3LM7Oj78lUHgxmO7i4T685loc0yhZnpA9N8Q6x0ZClbhQ6g3AT4o9jh9IRCRYcfYhp2qO+jML/hg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@kadena/cryptography-utils": "0.4.4",
+        "@kadena/pactjs": "0.6.0",
+        "cross-fetch": "~3.1.5"
+      }
+    },
+    "node_modules/@kadena/client": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/@kadena/client/-/client-1.18.3.tgz",
+      "integrity": "sha512-g/rfNN5gMEJFYSXpJDulUN6JrnFk5V4H0IF+bkzkj2SGmb5zESjlClWewe1Aqc/FkIWCdp/5inw3qpgp81OjsA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@kadena/chainweb-node-client": "0.9.5",
+        "@kadena/cryptography-utils": "0.4.4",
+        "@kadena/pactjs": "0.6.0",
+        "@walletconnect/sign-client": "~2.8.1",
+        "cross-fetch": "~3.1.5",
+        "debug": "4.3.4"
+      }
+    },
+    "node_modules/@kadena/cryptography-utils": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@kadena/cryptography-utils/-/cryptography-utils-0.4.4.tgz",
+      "integrity": "sha512-8xUcGlmBuuR9PSW88eqJuW49EmcQeiplDlsvN1N++1Bw6KV4lXlBKlJn5TM8lxctGNpewtzlIUimQFIlMqm9aw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "blakejs": "^1.2.1",
+        "buffer": "6.0.3",
+        "tweetnacl": "^1.0.3"
+      }
+    },
+    "node_modules/@kadena/pactjs": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@kadena/pactjs/-/pactjs-0.6.0.tgz",
+      "integrity": "sha512-P1vk+gqI76VzpNUfbuW4+qTuPWSOsGm/thppabAVDA9lMBEJD1od6VgzFXcWr7jDdocSdjEMUMTaItwFn9ADcg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@kadena/types": "0.7.0",
+        "bignumber.js": "^9.1.2"
+      }
+    },
+    "node_modules/@kadena/types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@kadena/types/-/types-0.7.0.tgz",
+      "integrity": "sha512-CDPuIcF/AyhqXawfIlqel3kew8UA6rEBX81PMltN8eqaVS9nXTvA1SbU6d9qzFPzEgynoJ5N3QZht8BCr2oFVQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@stablelib/aead": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
+      "integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/bytes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
+      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/chacha": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
+      "integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/chacha20poly1305": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
+      "integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/aead": "^1.0.1",
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/chacha": "^1.0.1",
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/poly1305": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
+      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/hash": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
+      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/hkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
+      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/hmac": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/hmac": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
+      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/keyagreement": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
+      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/bytes": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/poly1305": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
+      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/constant-time": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/sha256": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
+      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/hash": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/x25519": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
+      "integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/keyagreement": "^1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@walletconnect/core": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.8.6.tgz",
+      "integrity": "sha512-rnSqm1KJLcww/v6+UH8JeibQkJ3EKgyUDPfEK0stSEkrIUIcXaFlq3Et8S+vgV8bPhI0MVUhAhFL5OJZ3t2ryg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/relay-auth": "^1.0.4",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.8.6",
+        "@walletconnect/utils": "2.8.6",
+        "events": "^3.3.0",
+        "lodash.isequal": "4.5.0",
+        "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/environment": "^1.0.1",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
+    "node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/keyvaluestorage/node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/logger": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.3.tgz",
+      "integrity": "sha512-wRsD0eDQSajj8YMM/jpxoH1yeSLyS7FPkh0VKCQ1BWrERTy1Z7/DmOE8FYm/gmd7Cg6BNXVWiymhGq6wnmlq8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "7.11.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-api": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-types": "^1.0.2"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
+      "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.0",
+        "@noble/hashes": "1.7.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/safe-json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/sign-client": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.8.6.tgz",
+      "integrity": "sha512-rOFTKTHP7oJfXgYHX7+SdB8VbcsEE3ZFG/bMdmZboWaBim1mrY3vUyDdKrNr0VgI3AwBiEQezQDfKxBX0pMSQQ==",
+      "deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/core": "2.8.6",
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.8.6",
+        "@walletconnect/utils": "2.8.6",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/types": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.8.6.tgz",
+      "integrity": "sha512-Z/PFa3W1XdxeTcCtdR6lUsFgZfU/69wWJBPyclPwn7cu1+eriuCr6XZXQpJjib3flU+HnwHiXeUuqZaheehPxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/heartbeat": "1.2.1",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/keyvaluestorage": "^1.0.2",
+        "@walletconnect/logger": "^2.0.1",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/utils": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.8.6.tgz",
+      "integrity": "sha512-wcy6e5+COYo7tfNnW8YqidnATdJDIW6vDiWWE7A1F78Sl/VflkaevB9cIgyn8eLdxC1SxXgGoeC2oLP90nnHJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stablelib/chacha20poly1305": "1.0.1",
+        "@stablelib/hkdf": "1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/sha256": "1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "@walletconnect/relay-api": "^1.0.9",
+        "@walletconnect/safe-json": "^1.0.2",
+        "@walletconnect/time": "^1.0.2",
+        "@walletconnect/types": "2.8.6",
+        "@walletconnect/window-getters": "^1.0.1",
+        "@walletconnect/window-metadata": "^1.0.1",
+        "detect-browser": "5.3.0",
+        "query-string": "7.1.3",
+        "uint8arrays": "^3.1.0"
+      }
+    },
+    "node_modules/@walletconnect/window-getters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.6",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.6.tgz",
+      "integrity": "sha512-FY64UEhw+5liMzMQ1R9Mw6AF0+wyBrg1CIA1z4CjI/EvT5ty/SvQcWZgd8s9sgaNhX10Y8UzScTh89tEAls5nA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.0.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.15.1"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "license": "MIT"
+    },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/scripts/devnet-validate/package.json
+++ b/scripts/devnet-validate/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "pco-devnet-validate",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Devnet validation campaign for the PCO library templates: deploys each template to a KDA-CE devnet and drives its critical on-chain paths - the evidence class the REPL cannot produce (read-in-enforce, try-read, managed-cap and SPV behavior are node-only).",
+  "scripts": {
+    "treasury": "tsx src/treasury.ts",
+    "vesting": "tsx src/vesting.ts",
+    "dao-voting": "tsx src/dao-voting.ts",
+    "oracle-feed": "tsx src/oracle-feed.ts",
+    "gas-station": "tsx src/gas-station.ts",
+    "token-fungible": "tsx src/token-fungible.ts",
+    "hello-world": "tsx src/hello-world.ts",
+    "all": "tsx src/treasury.ts && tsx src/vesting.ts && tsx src/dao-voting.ts && tsx src/oracle-feed.ts && tsx src/gas-station.ts && tsx src/token-fungible.ts && tsx src/hello-world.ts"
+  },
+  "dependencies": {
+    "@kadena/client": "^1.18.3",
+    "@kadena/cryptography-utils": "^0.4.4",
+    "tsx": "^4.22.4",
+    "typescript": "^6.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.0"
+  }
+}

--- a/scripts/devnet-validate/src/dao-voting.ts
+++ b/scripts/devnet-validate/src/dao-voting.ts
@@ -1,0 +1,121 @@
+// Devnet validation: library/dao-voting
+//
+// Drives propose -> vote -> close on a real KDA-CE node. Node-critical
+// evidence: MEMBER-AUTH binds a config-table read before its enforce (the
+// REPL-invisible class). The proposal deadline is set ~90s out and the run
+// polls real chain time until it passes - no clock manipulation.
+import {
+  send, sendExpectFail, localCall, fund, persona, ksData,
+  loadTemplate, saveResults, chainTime,
+} from './lib.js';
+
+const SLUG = 'dao-voting';
+const iso = (d: Date) => d.toISOString().replace(/\.\d+Z$/, 'Z');
+
+async function pickName(base: string): Promise<string> {
+  for (let i = 0; ; i++) {
+    const name = i === 0 ? base : `${base}-v${i + 1}`;
+    try { await localCall(`(describe-module "free.${name}")`); }
+    catch { return name; }
+  }
+}
+
+const main = async () => {
+  console.log(`\n=== devnet-validate: ${SLUG} ===`);
+  const MOD = await pickName('dao-voting');
+  const { code, govKeyset } = loadTemplate(SLUG, 'dao-voting.pact', 'dao-voting-gov', MOD);
+  const M = `free.${MOD}`;
+  const src = code.replace('(module dao-voting GOV', `(module ${MOD} GOV`);
+
+  const gov = persona('gov');
+  const alice = persona('alice');
+  const bob = persona('bob');
+  const carol = persona('carol');
+  const eve = persona('eve');
+  for (const kp of [gov, alice, bob, carol, eve]) await fund(kp, 5.0);
+
+  await send({
+    code: `(namespace "free") (define-keyset "${govKeyset}" (read-keyset "g"))`,
+    label: `define ${govKeyset}`,
+    signers: [{ kp: gov }],
+    data: ksData('g', gov),
+  });
+  await send({
+    code: `${src}\n(create-table ${M}.config)(create-table ${M}.member-guards)(create-table ${M}.proposals)`,
+    label: `deploy ${M} + tables`,
+    signers: [{ kp: gov }],
+  });
+  await send({
+    code: `(${M}.init ["${alice.account}" "${bob.account}" "${carol.account}"]
+             [(read-keyset "a") (read-keyset "b") (read-keyset "c")] 50 60)`,
+    label: 'init 3 members, quorum 50, threshold 60',
+    signers: [{ kp: gov }],
+    data: { ...ksData('a', alice), ...ksData('b', bob), ...ksData('c', carol) },
+  });
+
+  const now = await chainTime();
+  const deadline = iso(new Date(now.getTime() + 90_000)); // ~90s of voting
+
+  // NODE-CRITICAL: MEMBER-AUTH bound config read -> enforce, on-node.
+  await send({
+    code: `(${M}.propose "p1" "${alice.account}" "Devnet validation motion" (time "${deadline}"))`,
+    label: 'propose p1 (MEMBER-AUTH on node)',
+    signers: [{ kp: alice, caps: (wc) => [wc(`${M}.MEMBER-AUTH`, alice.account), wc('coin.GAS')] }],
+  });
+
+  await sendExpectFail({
+    code: `(${M}.vote "p1" "${eve.account}" "yes")`,
+    label: 'non-member vote',
+    signers: [{ kp: eve, caps: (wc) => [wc(`${M}.MEMBER-AUTH`, eve.account), wc('coin.GAS')] }],
+  }, 'not a member');
+
+  await send({
+    code: `(${M}.vote "p1" "${alice.account}" "yes")`,
+    label: 'alice votes yes',
+    signers: [{ kp: alice, caps: (wc) => [wc(`${M}.MEMBER-AUTH`, alice.account), wc('coin.GAS')] }],
+  });
+  await send({
+    code: `(${M}.vote "p1" "${bob.account}" "yes")`,
+    label: 'bob votes yes',
+    signers: [{ kp: bob, caps: (wc) => [wc(`${M}.MEMBER-AUTH`, bob.account), wc('coin.GAS')] }],
+  });
+  await send({
+    code: `(${M}.vote "p1" "${carol.account}" "no")`,
+    label: 'carol votes no',
+    signers: [{ kp: carol, caps: (wc) => [wc(`${M}.MEMBER-AUTH`, carol.account), wc('coin.GAS')] }],
+  });
+
+  await sendExpectFail({
+    code: `(${M}.vote "p1" "${alice.account}" "no")`,
+    label: 'double vote',
+    signers: [{ kp: alice, caps: (wc) => [wc(`${M}.MEMBER-AUTH`, alice.account), wc('coin.GAS')] }],
+  }, 'already voted');
+
+  // wait for the REAL chain clock to pass the deadline (poll, never sleep-guess)
+  process.stdout.write('  … waiting for chain time to pass the deadline ');
+  for (;;) {
+    const t = await chainTime();
+    if (t.getTime() >= new Date(deadline).getTime()) break;
+    process.stdout.write('.');
+    await new Promise((res) => setTimeout(res, 10_000));
+  }
+  console.log(' reached');
+
+  // permissionless close by a non-member
+  await send({
+    code: `(${M}.close "p1")`,
+    label: 'close p1 (permissionless, after deadline)',
+    signers: [{ kp: eve }],
+  });
+  const p = await localCall(`(${M}.get-proposal "p1")`);
+  const status = (p as any).status;
+  const yes = Number((p as any)['final-yes'].int ?? (p as any)['final-yes']);
+  if (status !== 'passed' || yes !== 2) {
+    throw new Error(`expected passed with 2 yes, got status=${status} yes=${yes}`);
+  }
+  console.log(`  ✓ p1 settled: passed (2 yes / 1 no, quorum + threshold met on-node)`);
+
+  saveResults(SLUG, { module: M, hash: await localCall(`(at 'hash (describe-module "${M}"))`) });
+};
+
+main().catch((e) => { console.error(`\nFAILED: ${e.message ?? e}`); process.exit(1); });

--- a/scripts/devnet-validate/src/gas-station.ts
+++ b/scripts/devnet-validate/src/gas-station.ts
@@ -1,0 +1,128 @@
+// Devnet validation: library/gas-station
+//
+// The truest node-only test in the campaign: an ENROLLED user with ZERO KDA
+// executes a real transaction whose gas the STATION pays, via the GAS_PAYER
+// capability. This exercises the entire drain-defense on-node:
+//  - GAS_PAYER let-binds the allowlist read before enforce-guard (F2, the
+//    read-in-enforce class);
+//  - it bounds/accounts against (chain-data) gas-price/gas-limit, not the
+//    signer-supplied cap args (the Pass-2 CRITICAL fix);
+//  - the station guard's enforce-one gas branch (coin.GAS + ALLOW_GAS) must
+//    be satisfiable only through this path.
+// Also proves the negative: a NON-enrolled user cannot get sponsored gas.
+import {
+  Pact, send, sendExpectFail, localCall, coinBalance, fund, persona, ksData,
+  loadTemplate, saveResults, signerFor, client, NETWORK_ID, GAS_PRICE, CHAIN,
+  SENDER00, recordSteps,
+} from './lib.js';
+import type { ChainId } from '@kadena/client';
+
+const SLUG = 'gas-station';
+
+async function pickName(base: string): Promise<string> {
+  for (let i = 0; ; i++) {
+    const name = i === 0 ? base : `${base}-v${i + 1}`;
+    try { await localCall(`(describe-module "free.${name}")`); }
+    catch { return name; }
+  }
+}
+
+const main = async () => {
+  console.log(`\n=== devnet-validate: ${SLUG} ===`);
+  const MOD = await pickName('gas-station');
+  const { code, govKeyset } = loadTemplate(SLUG, 'gas-station.pact', 'gas-station-gov', MOD);
+  const M = `free.${MOD}`;
+  const src = code.replace('(module gas-station GOV', `(module ${MOD} GOV`);
+
+  const gov = persona('gov');
+  const user = persona('user');   // will hold ZERO KDA
+  const eve = persona('eve');     // non-enrolled
+  await fund(gov, 10.0);
+  // NB: user is NOT funded — that's the whole point.
+
+  await send({
+    code: `(namespace "free") (define-keyset "${govKeyset}" (read-keyset "g"))`,
+    label: `define ${govKeyset}`,
+    signers: [{ kp: gov }],
+    data: ksData('g', gov),
+  });
+  await send({
+    code: `${src}\n(create-table ${M}.allowlist)`,
+    label: `deploy ${M} + table`,
+    signers: [{ kp: gov }],
+  });
+  await send({
+    code: `(${M}.init)`,
+    label: 'init station account',
+    signers: [{ kp: gov }],
+  });
+
+  const station: string = await localCall(`(${M}.get-station-account)`);
+  await send({
+    code: `(coin.transfer-create "sender00" "${station}" (${M}.create-gas-payer-guard) 5.0)`,
+    label: 'fund station with 5 KDA',
+    signers: [{ kp: SENDER00, caps: (wc) => [wc('coin.TRANSFER', 'sender00', station, { decimal: '5.0' }), wc('coin.GAS')] }],
+  });
+
+  await send({
+    code: `(${M}.enroll-user "${user.account}" (read-keyset "u") 1.0)`,
+    label: 'enroll user (cap 1.0 KDA)',
+    signers: [{ kp: gov }],
+    data: ksData('u', user),
+  });
+
+  // Sanity: the user genuinely has no KDA of their own.
+  if (await coinBalance(user.account) !== 0) throw new Error('user should have 0 KDA');
+  console.log('  ✓ user holds 0 KDA (station must pay gas)');
+
+  const stationBefore = await coinBalance(station);
+
+  // Sponsored tx: senderAccount = STATION, user's key signs GAS_PAYER.
+  // The user does something trivial (a define with their own guard) — the
+  // point is that it MINES with the station paying, via GAS_PAYER.
+  const sponsored = Pact.builder
+    .execution(`(namespace "free") (${M}.get-user "${user.account}")`)
+    .addSigner(user.publicKey, (wc: any) => [
+      wc(`${M}.GAS_PAYER`, user.account, { int: 1500 }, { decimal: GAS_PRICE.toFixed(8) }),
+    ])
+    .setMeta({ chainId: CHAIN, senderAccount: station, gasLimit: 1500, gasPrice: GAS_PRICE })
+    .setNetworkId(NETWORK_ID)
+    .createTransaction();
+  const signed = await signerFor(user)(sponsored);
+  const desc = await client.submit(signed as any);
+  const r = await client.pollOne(desc, { timeout: 600_000, interval: 4_000 });
+  if (r.result.status !== 'success') {
+    throw new Error(`sponsored tx FAILED: ${JSON.stringify((r.result as any).error)}`);
+  }
+  recordSteps().push({ label: 'sponsored tx (station pays via GAS_PAYER)', requestKey: desc.requestKey, gas: (r as any).gas });
+  console.log(`  ✓ SPONSORED tx mined: station paid gas for a zero-KDA user (gas ${(r as any).gas}, rk ${desc.requestKey.slice(0, 12)}…)`);
+
+  const stationAfter = await coinBalance(station);
+  if (!(stationAfter < stationBefore)) throw new Error('station balance did not decrease');
+  console.log(`  ✓ station debited: ${stationBefore} -> ${stationAfter} KDA`);
+  const spent = Number((await localCall(`(${M}.get-user "${user.account}")`)).spent);
+  if (!(spent > 0)) throw new Error('user spent counter did not advance');
+  console.log(`  ✓ user spent counter advanced to ${spent} (accounted vs actual gas)`);
+
+  // Negative: a non-enrolled user cannot get sponsored gas.
+  const badTx = Pact.builder
+    .execution(`(namespace "free") (${M}.get-station-account)`)
+    .addSigner(eve.publicKey, (wc: any) => [
+      wc(`${M}.GAS_PAYER`, eve.account, { int: 1500 }, { decimal: GAS_PRICE.toFixed(8) }),
+    ])
+    .setMeta({ chainId: CHAIN, senderAccount: station, gasLimit: 1500, gasPrice: GAS_PRICE })
+    .setNetworkId(NETWORK_ID)
+    .createTransaction();
+  const badSigned = await signerFor(eve)(badTx);
+  let rejected = false;
+  try {
+    const pr = await client.local(badSigned as any, { preflight: true, signatureVerification: true });
+    if (pr.result.status !== 'success') rejected = true;
+  } catch { rejected = true; }
+  if (!rejected) throw new Error('non-enrolled user was sponsored — drain defense breach');
+  console.log('  ✓ non-enrolled user correctly denied sponsorship (preflight)');
+
+  saveResults(SLUG, { module: M, hash: await localCall(`(at 'hash (describe-module "${M}"))`) });
+};
+
+main().catch((e) => { console.error(`\nFAILED: ${e.message ?? e}`); process.exit(1); });

--- a/scripts/devnet-validate/src/lib.ts
+++ b/scripts/devnet-validate/src/lib.ts
@@ -1,0 +1,214 @@
+// Shared plumbing for the PCO library devnet validation campaign.
+//
+// Targets a local KDA-CE devnet (default :8090, network `recap-development`).
+// sender00 is the devnet genesis faucet (well-known devnet-only key). Every
+// run deploys the template under the `free` namespace with its governance
+// keyset patched to a namespaced one - exactly the adaptation each template's
+// README prescribes for real deployments.
+import {
+  Pact,
+  createClient,
+  createSignWithKeypair,
+  type ChainId,
+  type ICommandResult,
+  type IUnsignedCommand,
+} from '@kadena/client';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const DEVNET_HOST = process.env.DEVNET_HOST ?? 'http://localhost:8090';
+export const NETWORK_ID = process.env.DEVNET_NETWORK_ID ?? 'recap-development';
+export const GAS_PRICE = 0.00000001;
+export const GAS_LIMIT = 150000; // KDA-CE ceiling
+export const CHAIN = (process.env.DEVNET_CHAIN ?? '0') as ChainId;
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+export const client = createClient(
+  ({ chainId, networkId }) =>
+    `${DEVNET_HOST}/chainweb/0.0/${networkId}/chain/${chainId}/pact`,
+);
+
+export type Keypair = { account: string; publicKey: string; secretKey: string };
+
+// Devnet genesis faucet (public devnet key from chainweb-node keys.yaml).
+export const SENDER00: Keypair = {
+  account: 'sender00',
+  publicKey: '368820f80c324bbc7c2b0610688a7da43e39f91d118732671cd9c7500ff43cca',
+  secretKey: '251a920c403ae8c8f65f59142316af3c82b631fba46ddea92ee8c95035bd2898',
+};
+
+export const signerFor = (kp: Keypair) =>
+  createSignWithKeypair({ publicKey: kp.publicKey, secretKey: kp.secretKey });
+
+// Deterministic throwaway personas (devnet-only; derived keys, never reused).
+import { genKeyPair } from '@kadena/cryptography-utils';
+export function persona(name: string): Keypair {
+  const kp = genKeyPair();
+  return { account: `k:${kp.publicKey}`, publicKey: kp.publicKey, secretKey: kp.secretKey! };
+}
+
+export function unwrap(v: any): any {
+  if (v === null || v === undefined) return v;
+  if (typeof v === 'object') {
+    if ('int' in v) return Number(v.int);
+    if ('decimal' in v) return Number(v.decimal);
+    if ('time' in v) return v.time;
+    if ('timep' in v) return v.timep;
+  }
+  return v;
+}
+
+function assertSuccess(r: ICommandResult, label: string): any {
+  if (r.result.status !== 'success') {
+    throw new Error(`${label} FAILED: ${JSON.stringify((r.result as any).error)}`);
+  }
+  return (r.result as any).data;
+}
+
+export async function localCall(code: string, chainId: ChainId = CHAIN): Promise<any> {
+  const tx: IUnsignedCommand = Pact.builder
+    .execution(code)
+    .setMeta({ chainId, senderAccount: SENDER00.account, gasLimit: GAS_LIMIT, gasPrice: GAS_PRICE })
+    .setNetworkId(NETWORK_ID)
+    .createTransaction();
+  const r = await client.local(tx, { preflight: false, signatureVerification: false });
+  return unwrap(assertSuccess(r, `local(${code.slice(0, 70)})`));
+}
+
+export async function localExpectFail(code: string, mustContain: string, chainId: ChainId = CHAIN): Promise<string> {
+  try {
+    await localCall(code, chainId);
+  } catch (e: any) {
+    const msg = e?.message ?? String(e);
+    if (!msg.toLowerCase().includes(mustContain.toLowerCase())) {
+      throw new Error(`expected error containing "${mustContain}", got: ${msg.slice(0, 300)}`);
+    }
+    return msg;
+  }
+  throw new Error(`EXPECTED local failure ("${mustContain}") but call succeeded: ${code.slice(0, 80)}`);
+}
+
+export async function coinBalance(account: string, chainId: ChainId = CHAIN): Promise<number> {
+  try {
+    return Number(await localCall(`(coin.get-balance "${account}")`, chainId));
+  } catch {
+    return 0;
+  }
+}
+
+export async function chainTime(chainId: ChainId = CHAIN): Promise<Date> {
+  const t = await localCall(`(at 'block-time (chain-data))`, chainId);
+  return new Date(typeof t === 'string' ? t : (t as any).time);
+}
+
+export type CapBuilder = (wc: (n: string, ...a: any[]) => any) => any[];
+export type SignerSpec = { kp: Keypair; caps?: CapBuilder };
+
+export type SendOpts = {
+  code: string;
+  label: string;
+  signers: SignerSpec[];        // first signer pays gas
+  data?: Record<string, any>;
+  chainId?: ChainId;
+  gasLimit?: number;
+};
+
+export type StepRecord = { label: string; requestKey: string; gas: number };
+const steps: StepRecord[] = [];
+export function recordSteps(): StepRecord[] { return steps; }
+
+// Submit a multi-signer tx and poll to confirmation. THROWS on failure.
+export async function send(o: SendOpts): Promise<ICommandResult> {
+  let b: any = Pact.builder.execution(o.code);
+  for (const s of o.signers) {
+    b = s.caps ? b.addSigner(s.kp.publicKey, s.caps) : b.addSigner(s.kp.publicKey);
+  }
+  for (const [k, v] of Object.entries(o.data ?? {})) b = b.addData(k, v);
+  const tx = b
+    .setMeta({
+      chainId: o.chainId ?? CHAIN,
+      senderAccount: o.signers[0].kp.account,
+      gasLimit: o.gasLimit ?? GAS_LIMIT,
+      gasPrice: GAS_PRICE,
+    })
+    .setNetworkId(NETWORK_ID)
+    .createTransaction();
+  let signed: any = tx;
+  for (const s of o.signers) signed = await signerFor(s.kp)(signed);
+  const desc = await client.submit(signed);
+  const r = await client.pollOne(desc, { timeout: 600_000, interval: 4_000 });
+  if (r.result.status !== 'success') {
+    throw new Error(`${o.label} FAILED: ${JSON.stringify((r.result as any).error)}`);
+  }
+  steps.push({ label: o.label, requestKey: desc.requestKey, gas: (r as any).gas });
+  console.log(`  ✓ ${o.label}  (gas ${(r as any).gas}, rk ${desc.requestKey.slice(0, 12)}…)`);
+  return r;
+}
+
+export async function sendExpectFail(o: SendOpts, mustContain: string): Promise<string> {
+  let err = '';
+  try {
+    await send({ ...o, label: `${o.label} [expect-fail]` });
+    throw new Error(`EXPECTED FAILURE but ${o.label} SUCCEEDED`);
+  } catch (e: any) {
+    err = e?.message ?? String(e);
+    if (err.includes('EXPECTED FAILURE but')) throw e;
+  }
+  if (!err.toLowerCase().includes(mustContain.toLowerCase())) {
+    throw new Error(`${o.label}: failed but error did not contain "${mustContain}". Got: ${err.slice(0, 300)}`);
+  }
+  console.log(`  ✓ ${o.label} correctly rejected ("${mustContain}")`);
+  return err;
+}
+
+// Load a library template's source, patch it for devnet deployment under the
+// `free` namespace (namespaced governance keyset), exactly as the README
+// prescribes, and return { code, govKeyset }.
+// `uniq` should be the (already unique) deployed module name so the gov
+// keyset name is unique per run too — redefining an existing keyset requires
+// satisfying the OLD keyset, which a fresh persona cannot.
+export function loadTemplate(slug: string, file: string, govConst: string, uniq: string): { code: string; govKeyset: string } {
+  const src = readFileSync(join(ROOT, 'contracts', 'library', slug, file), 'utf8');
+  const govKeyset = `free.pco-${uniq}-gov`;
+  const patched = src.replace(`"${govConst}"`, `"${govKeyset}"`);
+  if (patched === src) throw new Error(`gov keyset const "${govConst}" not found in ${file}`);
+  return { code: `(namespace "free")\n${patched}`, govKeyset };
+}
+
+// Fund a persona account from sender00.
+export async function fund(kp: Keypair, amount: number): Promise<void> {
+  await send({
+    code: `(coin.transfer-create "sender00" "${kp.account}" (read-keyset "g") ${amount.toFixed(1)})`,
+    label: `fund ${kp.account.slice(0, 14)}… with ${amount} KDA`,
+    signers: [{
+      kp: SENDER00,
+      caps: (wc) => [wc('coin.TRANSFER', 'sender00', kp.account, { decimal: amount.toFixed(1) }), wc('coin.GAS')],
+    }],
+    data: { g: { keys: [kp.publicKey], pred: 'keys-all' } },
+  });
+}
+
+export function ksData(name: string, ...kps: Keypair[]): Record<string, any> {
+  return { [name]: { keys: kps.map((k) => k.publicKey), pred: 'keys-all' } };
+}
+
+// Persist the campaign step log for the report.
+export { Pact };
+
+export function saveResults(slug: string, extra: Record<string, any> = {}): void {
+  const out = {
+    template: slug,
+    network: NETWORK_ID,
+    host: DEVNET_HOST,
+    chain: CHAIN,
+    date: new Date().toISOString(),
+    steps: recordSteps(),
+    ...extra,
+  };
+  const dir = join(dirname(fileURLToPath(import.meta.url)), '..', 'results');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${slug}.json`), JSON.stringify(out, null, 2));
+  console.log(`\nRESULT: ${slug} devnet validation PASSED (${recordSteps().length} confirmed txs)`);
+}

--- a/scripts/devnet-validate/src/oracle-feed.ts
+++ b/scripts/devnet-validate/src/oracle-feed.ts
@@ -1,0 +1,119 @@
+// Devnet validation: library/oracle-feed
+//
+// Drives enroll -> post -> read on a real KDA-CE node. Node-critical
+// evidence: PUBLISH-AUTH binds a config read before its enforce; get-price's
+// whole read pipeline (map/with-default-read/filter/sort/median) runs
+// on-node, both via /local and inside an executed transaction (a consumer
+// exec), plus the staleness fail-closed path against real block timestamps.
+import {
+  send, sendExpectFail, localCall, localExpectFail, fund, persona, ksData,
+  loadTemplate, saveResults,
+} from './lib.js';
+
+const SLUG = 'oracle-feed';
+
+async function pickName(base: string): Promise<string> {
+  for (let i = 0; ; i++) {
+    const name = i === 0 ? base : `${base}-v${i + 1}`;
+    try { await localCall(`(describe-module "free.${name}")`); }
+    catch { return name; }
+  }
+}
+
+const main = async () => {
+  console.log(`\n=== devnet-validate: ${SLUG} ===`);
+  const MOD = await pickName('oracle-feed');
+  const { code, govKeyset } = loadTemplate(SLUG, 'oracle-feed.pact', 'oracle-feed-gov', MOD);
+  const M = `free.${MOD}`;
+  const src = code.replace('(module oracle-feed GOV', `(module ${MOD} GOV`);
+
+  const gov = persona('gov');
+  // Publisher accounts are named nodes, NOT k: principals: the template bans
+  // ':' in publisher names (obs-key injectivity, auditor F1), and k: names
+  // contain a colon. Use vanity names guarded by each node's own key.
+  const sfx = MOD.replace('oracle-feed', '').replace(/^-/, '') || 'r1'; // unique per run
+  const n1 = { ...persona('node1'), account: `node-1-${sfx}` };
+  const n2 = { ...persona('node2'), account: `node-2-${sfx}` };
+  const n3 = { ...persona('node3'), account: `node-3-${sfx}` };
+  const eve = { ...persona('eve'), account: `eve-${sfx}` };
+  for (const kp of [gov, n1, n2, n3, eve]) await fund(kp, 5.0);
+
+  await send({
+    code: `(namespace "free") (define-keyset "${govKeyset}" (read-keyset "g"))`,
+    label: `define ${govKeyset}`,
+    signers: [{ kp: gov }],
+    data: ksData('g', gov),
+  });
+  await send({
+    code: `${src}\n(create-table ${M}.config)(create-table ${M}.publisher-guards)(create-table ${M}.feeds)(create-table ${M}.observations)`,
+    label: `deploy ${M} + tables`,
+    signers: [{ kp: gov }],
+  });
+  await send({
+    code: `(${M}.init ["${n1.account}" "${n2.account}" "${n3.account}"]
+             [(read-keyset "a") (read-keyset "b") (read-keyset "c")])
+           (${M}.create-feed "KDA/USD" "KDA spot (devnet validation)" 2)`,
+    label: 'init 3 publishers + create feed (quorum 2)',
+    signers: [{ kp: gov }],
+    data: { ...ksData('a', n1), ...ksData('b', n2), ...ksData('c', n3) },
+  });
+
+  await sendExpectFail({
+    code: `(${M}.post "KDA/USD" "${eve.account}" 1.0)`,
+    label: 'non-publisher post',
+    signers: [{ kp: eve, caps: (wc) => [wc(`${M}.PUBLISH-AUTH`, eve.account), wc('coin.GAS')] }],
+  }, 'not an enrolled publisher');
+
+  // below-quorum read must fail closed BEFORE enough posts exist
+  await localExpectFail(`(${M}.get-price "KDA/USD" 3600.0)`, 'insufficient fresh answers');
+  console.log('  ✓ below-quorum read fails closed (local)');
+
+  // NODE-CRITICAL: PUBLISH-AUTH bound config read -> enforce, on-node.
+  await send({
+    code: `(${M}.post "KDA/USD" "${n1.account}" 1.00)`,
+    label: 'node1 posts 1.00 (PUBLISH-AUTH on node)',
+    signers: [{ kp: n1, caps: (wc) => [wc(`${M}.PUBLISH-AUTH`, n1.account), wc('coin.GAS')] }],
+  });
+  await send({
+    code: `(${M}.post "KDA/USD" "${n2.account}" 1.10)`,
+    label: 'node2 posts 1.10',
+    signers: [{ kp: n2, caps: (wc) => [wc(`${M}.PUBLISH-AUTH`, n2.account), wc('coin.GAS')] }],
+  });
+  await send({
+    code: `(${M}.post "KDA/USD" "${n3.account}" 99.9)`,
+    label: 'node3 posts 99.9 (outlier)',
+    signers: [{ kp: n3, caps: (wc) => [wc(`${M}.PUBLISH-AUTH`, n3.account), wc('coin.GAS')] }],
+  });
+
+  const p = Number(await localCall(`(${M}.get-price "KDA/USD" 3600.0)`));
+  if (p !== 1.1) throw new Error(`median expected 1.1, got ${p}`);
+  console.log(`  ✓ median swallows the outlier on-node: ${p}`);
+
+  // the read pipeline inside an EXECUTED tx (consumer path), not just /local
+  await send({
+    code: `(enforce (= 1.1 (${M}.get-price "KDA/USD" 3600.0)) "unexpected price")`,
+    label: 'consumer exec reads the median in a mined tx',
+    signers: [{ kp: eve }],
+  });
+
+  // staleness fail-closed against REAL block timestamps: a 1-second window
+  // cannot contain observations from earlier blocks
+  await localExpectFail(`(${M}.get-price "KDA/USD" 1.0)`, 'insufficient fresh answers');
+  console.log('  ✓ staleness window fails closed against real block timestamps');
+
+  // rotation revokes the outlier's standing observation immediately
+  await send({
+    code: `(${M}.rotate-publishers ["${n1.account}" "${n2.account}"]
+             [(read-keyset "a") (read-keyset "b")])`,
+    label: 'rotate node3 out',
+    signers: [{ kp: gov }],
+    data: { ...ksData('a', n1), ...ksData('b', n2) },
+  });
+  const p2 = Number(await localCall(`(${M}.get-price "KDA/USD" 3600.0)`));
+  if (Math.abs(p2 - 1.05) > 1e-9) throw new Error(`post-rotation median expected 1.05, got ${p2}`);
+  console.log(`  ✓ rotation revoked the outlier: median now ${p2}`);
+
+  saveResults(SLUG, { module: M, hash: await localCall(`(at 'hash (describe-module "${M}"))`) });
+};
+
+main().catch((e) => { console.error(`\nFAILED: ${e.message ?? e}`); process.exit(1); });

--- a/scripts/devnet-validate/src/token-fungible.ts
+++ b/scripts/devnet-validate/src/token-fungible.ts
@@ -1,0 +1,114 @@
+// Devnet validation: library/token-fungible
+//
+// Drives mint -> transfer -> rotate on a real KDA-CE node. Node-critical
+// evidence: DEBIT let-binds the sender's stored guard (read token-table)
+// before enforce-guard - the exact CRITICAL that this template's v0.2.0 fix
+// closed. An unfixed DEBIT (guard read inside enforce, or no guard at all)
+// would either abort here or let a foreign key drain; this run proves the
+// fixed path works on-node and the negative path is rejected.
+import {
+  send, sendExpectFail, localCall, fund, persona, ksData,
+  loadTemplate, saveResults,
+} from './lib.js';
+
+const SLUG = 'token-fungible';
+
+async function pickName(base: string): Promise<string> {
+  for (let i = 0; ; i++) {
+    const name = i === 0 ? base : `${base}-v${i + 1}`;
+    try { await localCall(`(describe-module "free.${name}")`); }
+    catch { return name; }
+  }
+}
+
+const main = async () => {
+  console.log(`\n=== devnet-validate: ${SLUG} ===`);
+  const MOD = await pickName('token');
+  const { code, govKeyset } = loadTemplate(SLUG, 'token.pact', 'token-gov', MOD);
+  const M = `free.${MOD}`;
+  const src = code.replace('(module token GOV', `(module ${MOD} GOV`);
+
+  const sfx = MOD.replace('token', '').replace(/^-/, '') || 'r1';
+  const gov = persona('gov');
+  // alice is a VANITY token account (guarded by alice's key) so we can
+  // demonstrate rotate — coin/this token forbid rotating a k: principal's
+  // guard (correct protocol behavior, unrelated to the DEBIT node-safety
+  // this run proves). bob/eve stay k: principals.
+  const alice = { ...persona('alice'), account: `alice-${sfx}` };
+  const bob = persona('bob');
+  const eve = persona('eve');
+  for (const kp of [gov, alice, bob, eve]) await fund(kp, 5.0);
+
+  await send({
+    code: `(namespace "free") (define-keyset "${govKeyset}" (read-keyset "g"))`,
+    label: `define ${govKeyset}`,
+    signers: [{ kp: gov }],
+    data: ksData('g', gov),
+  });
+  await send({
+    code: `${src}\n(create-table ${M}.token-table)`,
+    label: `deploy ${M} + table`,
+    signers: [{ kp: gov }],
+  });
+
+  // governance-gated mint (creates alice's account)
+  await sendExpectFail({
+    code: `(${M}.mint "${alice.account}" (read-keyset "a") 1000.0)`,
+    label: 'mint without governance',
+    signers: [{ kp: eve }],
+    data: ksData('a', alice),
+  }, 'Keyset failure');
+
+  await send({
+    code: `(${M}.mint "${alice.account}" (read-keyset "a") 1000.0)`,
+    label: 'governance mints 1000 to alice',
+    signers: [{ kp: gov }],
+    data: ksData('a', alice),
+  });
+  if (Number(await localCall(`(${M}.get-balance "${alice.account}")`)) !== 1000)
+    throw new Error('mint balance wrong');
+  console.log('  ✓ alice minted 1000');
+
+  // NODE-CRITICAL negative: eve scopes TRANSFER but is not the sender's guard.
+  // The v0.2.0 DEBIT reads alice's stored guard and enforces it -> reject.
+  await send({
+    code: `(${M}.create-account "${bob.account}" (read-keyset "b"))`,
+    label: 'create bob token account',
+    signers: [{ kp: bob }],
+    data: ksData('b', bob),
+  });
+  await sendExpectFail({
+    code: `(${M}.transfer "${alice.account}" "${bob.account}" 100.0)`,
+    label: 'foreign-key transfer (DEBIT guard enforcement)',
+    signers: [{ kp: eve, caps: (wc) => [wc(`${M}.TRANSFER`, alice.account, bob.account, { decimal: '100.0' }), wc('coin.GAS')] }],
+  }, 'Keyset failure');
+
+  // NODE-CRITICAL positive: alice's own key satisfies the stored-guard read.
+  await send({
+    code: `(${M}.transfer "${alice.account}" "${bob.account}" 250.0)`,
+    label: 'authorized transfer (DEBIT let-bound guard on node)',
+    signers: [{ kp: alice, caps: (wc) => [wc(`${M}.TRANSFER`, alice.account, bob.account, { decimal: '250.0' }), wc('coin.GAS')] }],
+  });
+  if (Number(await localCall(`(${M}.get-balance "${bob.account}")`)) !== 250)
+    throw new Error('transfer balance wrong');
+  console.log('  ✓ authorized transfer moved 250 (alice 750 / bob 250)');
+
+  // rotate alice's guard, then prove the OLD key can no longer debit
+  const alice2 = persona('alice2');
+  await send({
+    code: `(${M}.rotate "${alice.account}" (read-keyset "a2"))`,
+    label: 'alice rotates her guard',
+    signers: [{ kp: alice, caps: (wc) => [wc(`${M}.ROTATE`, alice.account), wc('coin.GAS')] }],
+    data: ksData('a2', alice2),
+  });
+  await sendExpectFail({
+    code: `(${M}.transfer "${alice.account}" "${bob.account}" 10.0)`,
+    label: 'old key after rotate (stored-guard read reflects new guard)',
+    signers: [{ kp: alice, caps: (wc) => [wc(`${M}.TRANSFER`, alice.account, bob.account, { decimal: '10.0' }), wc('coin.GAS')] }],
+  }, 'Keyset failure');
+  console.log('  ✓ rotate updated the stored guard the DEBIT read enforces');
+
+  saveResults(SLUG, { module: M, hash: await localCall(`(at 'hash (describe-module "${M}"))`) });
+};
+
+main().catch((e) => { console.error(`\nFAILED: ${e.message ?? e}`); process.exit(1); });

--- a/scripts/devnet-validate/src/treasury.ts
+++ b/scripts/devnet-validate/src/treasury.ts
@@ -1,0 +1,118 @@
+// Devnet validation: library/multisig-treasury
+//
+// Drives the full M-of-N cycle on a real KDA-CE node. This is the required
+// evidence for the template's F1 class: SIGNER-AUTH binds a config-table read
+// before its enforce, and account-exists try-reads coin - both REPL-green
+// patterns that this run proves on-node (an unfixed variant would abort here
+// with "Operation is not allowed in read-only or system-only mode").
+import {
+  send, sendExpectFail, localCall, coinBalance, fund, persona, ksData,
+  loadTemplate, saveResults, SENDER00,
+} from './lib.js';
+
+const SLUG = 'multisig-treasury';
+
+async function pickName(base: string): Promise<string> {
+  for (let i = 0; ; i++) {
+    const name = i === 0 ? base : `${base}-v${i + 1}`;
+    try { await localCall(`(describe-module "free.${name}")`); }
+    catch { return name; }
+  }
+}
+
+const main = async () => {
+  console.log(`\n=== devnet-validate: ${SLUG} ===`);
+  const MOD = await pickName('treasury');
+  const { code, govKeyset } = loadTemplate(SLUG, 'treasury.pact', 'treasury-gov', MOD);
+  const M = `free.${MOD}`;
+  const src = code.replace('(module treasury GOV', `(module ${MOD} GOV`);
+
+  const gov = persona('gov');
+  const alice = persona('alice');
+  const bob = persona('bob');
+  const carol = persona('carol');
+  const dana = persona('dana');   // recipient
+  const eve = persona('eve');     // non-signer attacker
+
+  // gas money for the personas that submit txs themselves
+  for (const kp of [gov, alice, bob, carol, eve]) await fund(kp, 5.0);
+  await fund(dana, 1.0); // recipient must exist (propose enforces it via try-read)
+
+  await send({
+    code: `(namespace "free") (define-keyset "${govKeyset}" (read-keyset "g"))`,
+    label: `define ${govKeyset}`,
+    signers: [{ kp: gov }],
+    data: ksData('g', gov),
+  });
+
+  await send({
+    code: `${src}\n(create-table ${M}.config)(create-table ${M}.proposals)(create-table ${M}.signer-guards)`,
+    label: `deploy ${M} + tables`,
+    signers: [{ kp: gov }],
+    gasLimit: 150000,
+  });
+
+  await send({
+    code: `(${M}.init ["${alice.account}" "${bob.account}" "${carol.account}"] 2
+             [(read-keyset "a") (read-keyset "b") (read-keyset "c")])`,
+    label: 'init 2-of-3 signer set',
+    signers: [{ kp: gov }],
+    data: { ...ksData('a', alice), ...ksData('b', bob), ...ksData('c', carol) },
+  });
+
+  const vaultAcct: string = await localCall(`(${M}.get-vault-account)`);
+  await send({
+    code: `(coin.transfer-create "sender00" "${vaultAcct}" (${M}.create-vault-guard) 10.0)`,
+    label: 'fund vault with 10 KDA',
+    signers: [{
+      kp: SENDER00,
+      caps: (wc) => [wc('coin.TRANSFER', 'sender00', vaultAcct, { decimal: '10.0' }), wc('coin.GAS')],
+    }],
+  });
+
+  // NODE-CRITICAL: propose acquires SIGNER-AUTH (bound config read -> enforce)
+  // and runs the recipient-exists try-read against the real node.
+  await send({
+    code: `(${M}.propose "p1" "${alice.account}" "${dana.account}" 3.5)`,
+    label: 'propose p1 (SIGNER-AUTH + try-read on node)',
+    signers: [{ kp: alice, caps: (wc) => [wc(`${M}.SIGNER-AUTH`, alice.account), wc('coin.GAS')] }],
+  });
+
+  await sendExpectFail({
+    code: `(${M}.propose "p2" "${eve.account}" "${dana.account}" 1.0)`,
+    label: 'non-signer propose',
+    signers: [{ kp: eve, caps: (wc) => [wc(`${M}.SIGNER-AUTH`, eve.account), wc('coin.GAS')] }],
+  }, 'not an authorized signer');
+
+  await sendExpectFail({
+    code: `(${M}.execute "p1")`,
+    label: 'execute below threshold',
+    signers: [{ kp: eve }],
+  }, 'below threshold');
+
+  await send({
+    code: `(${M}.approve "p1" "${bob.account}")`,
+    label: 'approve p1 (2nd of 2)',
+    signers: [{ kp: bob, caps: (wc) => [wc(`${M}.SIGNER-AUTH`, bob.account), wc('coin.GAS')] }],
+  });
+
+  const danaBefore = await coinBalance(dana.account);
+  await send({
+    code: `(${M}.execute "p1")`,
+    label: 'execute p1 (permissionless, vault debits via SPEND)',
+    signers: [{ kp: carol }],
+  });
+  const danaAfter = await coinBalance(dana.account);
+  if (Math.abs(danaAfter - danaBefore - 3.5) > 1e-9) {
+    throw new Error(`recipient balance wrong: ${danaBefore} -> ${danaAfter}`);
+  }
+  console.log(`  ✓ recipient received exactly 3.5 KDA (${danaBefore} -> ${danaAfter})`);
+
+  const vault = await localCall(`(${M}.vault-balance)`);
+  if (Math.abs(Number(vault) - 6.5) > 1e-9) throw new Error(`vault balance wrong: ${vault}`);
+  console.log(`  ✓ vault conserved: 6.5 KDA remain`);
+
+  saveResults(SLUG, { module: M, hash: await localCall(`(at 'hash (describe-module "${M}"))`) });
+};
+
+main().catch((e) => { console.error(`\nFAILED: ${e.message ?? e}`); process.exit(1); });

--- a/scripts/devnet-validate/src/vesting.ts
+++ b/scripts/devnet-validate/src/vesting.ts
@@ -1,0 +1,160 @@
+// Devnet validation: library/vesting
+//
+// Drives escrow -> claim -> revoke on a real KDA-CE node. Node-critical
+// evidence: CLAIM-AUTH binds a grants-table read before enforce-guard, and
+// REVOKE-AUTH reads the funder's LIVE coin guard via coin.details - both
+// REPL-green patterns proven here on-node. Grants use past start dates so
+// the live clock needs no manipulation; assertions carry a small tolerance
+// because vesting accrues per second.
+import {
+  send, sendExpectFail, localCall, coinBalance, fund, persona, ksData,
+  loadTemplate, saveResults, chainTime,
+} from './lib.js';
+
+const SLUG = 'vesting';
+const DAY = 86_400_000;
+
+const iso = (d: Date) => d.toISOString().replace(/\.\d+Z$/, 'Z');
+const near = (a: number, b: number, eps = 0.01) => Math.abs(a - b) <= eps;
+
+async function pickName(base: string): Promise<string> {
+  for (let i = 0; ; i++) {
+    const name = i === 0 ? base : `${base}-v${i + 1}`;
+    try { await localCall(`(describe-module "free.${name}")`); }
+    catch { return name; }
+  }
+}
+
+const main = async () => {
+  console.log(`\n=== devnet-validate: ${SLUG} ===`);
+  const MOD = await pickName('vesting');
+  const { code, govKeyset } = loadTemplate(SLUG, 'vesting.pact', 'vesting-gov', MOD);
+  const M = `free.${MOD}`;
+  const src = code.replace('(module vesting GOV', `(module ${MOD} GOV`);
+
+  const gov = persona('gov');
+  const funder = persona('funder');
+  const ben = persona('ben');
+  const eve = persona('eve');
+  for (const kp of [gov, eve]) await fund(kp, 5.0);
+  await fund(funder, 30.0);
+  await fund(ben, 2.0);
+
+  await send({
+    code: `(namespace "free") (define-keyset "${govKeyset}" (read-keyset "g"))`,
+    label: `define ${govKeyset}`,
+    signers: [{ kp: gov }],
+    data: ksData('g', gov),
+  });
+  await send({
+    code: `${src}\n(create-table ${M}.grants)`,
+    label: `deploy ${M} + table`,
+    signers: [{ kp: gov }],
+  });
+
+  const now = await chainTime();
+  const t = (days: number) => iso(new Date(now.getTime() + days * DAY));
+  const vaultAcct: string = await localCall(`(${M}.get-vault-account)`);
+
+  // g1: non-revocable, halfway vested (start -100d, cliff -10d, end +100d)
+  await send({
+    code: `(${M}.create-grant "g1" "${funder.account}" "${ben.account}" (read-keyset "b")
+             10.0 (time "${t(-100)}") (time "${t(-10)}") (time "${t(100)}") false)`,
+    label: 'create-grant g1 (escrow 10 KDA upfront)',
+    signers: [{
+      kp: funder,
+      caps: (wc) => [wc('coin.TRANSFER', funder.account, vaultAcct, { decimal: '10.0' }), wc('coin.GAS')],
+    }],
+    data: ksData('b', ben),
+  });
+
+  const claimable = Number(await localCall(`(${M}.claimable-amount "g1")`));
+  if (!near(claimable, 5.0)) throw new Error(`g1 claimable expected ~5.0, got ${claimable}`);
+  console.log(`  ✓ g1 halfway vested: claimable ${claimable}`);
+
+  await sendExpectFail({
+    code: `(${M}.claim "g1")`,
+    label: 'claim g1 with a foreign key',
+    signers: [{ kp: eve, caps: (wc) => [wc(`${M}.CLAIM-AUTH`, 'g1'), wc('coin.GAS')] }],
+  }, 'Keyset failure');
+
+  const benBefore = await coinBalance(ben.account);
+  // NODE-CRITICAL: CLAIM-AUTH bound read -> enforce-guard, on-node.
+  const r = await send({
+    code: `(${M}.claim "g1")`,
+    label: 'claim g1 (CLAIM-AUTH on node)',
+    signers: [{ kp: ben, caps: (wc) => [wc(`${M}.CLAIM-AUTH`, 'g1'), wc('coin.GAS')] }],
+  });
+  const benAfter = await coinBalance(ben.account);
+  const paid = benAfter - benBefore + Number((r as any).gas) * 1e-8;
+  if (!near(paid, 5.0)) throw new Error(`g1 payout expected ~5.0, got ${paid}`);
+  console.log(`  ✓ ben paid ~5.0 KDA (${paid.toFixed(6)})`);
+
+  // g3: cliff still in the future -> nothing claimable (clean negative on a live clock)
+  await send({
+    code: `(${M}.create-grant "g3" "${funder.account}" "${ben.account}" (read-keyset "b")
+             2.0 (time "${t(-10)}") (time "${t(50)}") (time "${t(100)}") false)`,
+    label: 'create-grant g3 (pre-cliff)',
+    signers: [{
+      kp: funder,
+      caps: (wc) => [wc('coin.TRANSFER', funder.account, vaultAcct, { decimal: '2.0' }), wc('coin.GAS')],
+    }],
+    data: ksData('b', ben),
+  });
+  await sendExpectFail({
+    code: `(${M}.claim "g3")`,
+    label: 'pre-cliff claim',
+    signers: [{ kp: ben, caps: (wc) => [wc(`${M}.CLAIM-AUTH`, 'g3'), wc('coin.GAS')] }],
+  }, 'nothing claimable');
+
+  // g2: revocable, halfway vested; revoke freezes it, refund returns to funder
+  await send({
+    code: `(${M}.create-grant "g2" "${funder.account}" "${ben.account}" (read-keyset "b")
+             5.0 (time "${t(-50)}") (time "${t(-50)}") (time "${t(50)}") true)`,
+    label: 'create-grant g2 (revocable, escrow 5 KDA)',
+    signers: [{
+      kp: funder,
+      caps: (wc) => [wc('coin.TRANSFER', funder.account, vaultAcct, { decimal: '5.0' }), wc('coin.GAS')],
+    }],
+    data: ksData('b', ben),
+  });
+
+  await sendExpectFail({
+    code: `(${M}.revoke "g2")`,
+    label: 'revoke by non-funder',
+    signers: [{ kp: eve, caps: (wc) => [wc(`${M}.REVOKE-AUTH`, 'g2'), wc('coin.GAS')] }],
+  }, 'Keyset failure');
+
+  const funderBefore = await coinBalance(funder.account);
+  // NODE-CRITICAL: REVOKE-AUTH reads the funder's LIVE coin guard (coin.details).
+  const rv = await send({
+    code: `(${M}.revoke "g2")`,
+    label: 'revoke g2 (live coin.details guard on node)',
+    signers: [{ kp: funder, caps: (wc) => [wc(`${M}.REVOKE-AUTH`, 'g2'), wc('coin.GAS')] }],
+  });
+  const funderAfter = await coinBalance(funder.account);
+  const refund = funderAfter - funderBefore + Number((rv as any).gas) * 1e-8;
+  if (!near(refund, 2.5)) throw new Error(`g2 refund expected ~2.5, got ${refund}`);
+  console.log(`  ✓ funder refunded ~2.5 KDA unvested (${refund.toFixed(6)})`);
+
+  await send({
+    code: `(${M}.claim "g2")`,
+    label: 'claim g2 frozen remainder',
+    signers: [{ kp: ben, caps: (wc) => [wc(`${M}.CLAIM-AUTH`, 'g2'), wc('coin.GAS')] }],
+  });
+  // frozen: total == claimed exactly, no further accrual even as time passes
+  await sendExpectFail({
+    code: `(${M}.claim "g2")`,
+    label: 'claim after revoke exhausts the frozen grant',
+    signers: [{ kp: ben, caps: (wc) => [wc(`${M}.CLAIM-AUTH`, 'g2'), wc('coin.GAS')] }],
+  }, 'nothing claimable');
+
+  const vault = await coinBalance(vaultAcct);
+  // outstanding: g1 remainder (~5 minus per-second dust already claimed) + g3 full 2.0
+  if (!near(vault, 7.0, 0.02)) throw new Error(`vault conservation expected ~7.0, got ${vault}`);
+  console.log(`  ✓ vault conserved (~7.0 KDA outstanding: g1 remainder + g3): ${vault.toFixed(6)}`);
+
+  saveResults(SLUG, { module: M, hash: await localCall(`(at 'hash (describe-module "${M}"))`) });
+};
+
+main().catch((e) => { console.error(`\nFAILED: ${e.message ?? e}`); process.exit(1); });

--- a/scripts/devnet-validate/tsconfig.json
+++ b/scripts/devnet-validate/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What

Closes the one caveat every library `AUDIT.md` carries: a green REPL suite does not prove the on-chain path, because the **read-in-enforce** bug class is REPL-invisible on KDA-CE. All six deployable templates were deployed to a **live devnet** and their node-critical paths driven to mined confirmation.

| Template | Txs | Proven on-node |
|---|:--:|---|
| multisig-treasury | 13 | `SIGNER-AUTH` bound read + capability-guarded `SPEND` vault debit |
| vesting | 12 | `CLAIM-AUTH` + `REVOKE-AUTH` (live `coin.details` guard); vault conserved |
| dao-voting | 13 | `MEMBER-AUTH` bound read; close after a **real ~90s deadline** |
| oracle-feed | 13 | `PUBLISH-AUTH`; median in a **mined consumer tx**; staleness fail-closed; rotation |
| token-fungible | 10 | `DEBIT` stored-guard (the v0.2.0 CRITICAL fix) — authorized ✓, foreign-key ✗, rotate updates it |
| gas-station | 7 | a **zero-KDA user** ran a tx the **station paid** via `GAS_PAYER`; spend accounted vs actual gas |

Every negative case (wrong key, non-member, below threshold, non-enrolled) was rejected **on-node**, not just in the REPL.

## Evidence

- Each template's `AUDIT.md` gains a **Devnet validation** section with the deployed module name, source hash, and confirmed transaction count.
- [`docs/DEVNET-VALIDATION.md`](docs/DEVNET-VALIDATION.md) is the campaign report (what it establishes and, honestly, what it does not — this is corroborating node-safety evidence, not an independent audit, and templates stay `self-reviewed`).
- [`scripts/devnet-validate`](scripts/devnet-validate/) is the reusable `@kadena/client` harness (deploys each template under `free` per its deployment checklist, polls every tx to a block; typechecks clean). `node_modules`/`results` gitignored.

## Scope notes

- **nft-collection-policy** is deferred honestly: the campaign devnet carries no marmalade-v2 stack, its REPL suite already runs against the **real** marmalade sources (stronger than a mock), and its specific outstanding mandate is the sale **buy** path — a follow-on for a marmalade-provisioned devnet.
- **hello-world** has no node-only behavior.
- Single-chain functional validation; the token's `TRANSFER_XCHAIN` SPV path needs a multi-chain devnet and is out of scope.

**No `.pact` source changed** — this is docs + tooling only, so the deployed hashes stay verifiable against the merged templates.