### PR TITLE
feat(library): add property-lease rental rails template

### DIFF
--- a/contracts/library/property-lease/AUDIT.md
+++ b/contracts/library/property-lease/AUDIT.md
@@ -1,0 +1,146 @@
+# AUDIT — library/property-lease
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `property-lease` (namespace: project-specific) |
+| **Version** | 1.0.0 |
+| **Audit Status** | self-reviewed |
+| **Category** | PCO Library Template |
+| **Source** | PCO-authored reference implementation |
+| **Last review** | 2026-07-06 |
+
+## Purpose
+
+Deployable on-chain rental-lease rails: a property registry with immutable
+revenue splits, per-property rent bucketing inside one capability-guarded
+vault, deposit escrow, and claim-window settlement. The enforceable lease is
+the signed off-chain document whose hash each lease anchors; this module is the
+money-and-record layer.
+
+## Trust model (read alongside the README)
+
+v1 has **no arbiter**. At lease end the landlord files one deposit-deduction
+claim — capped at the escrowed amount, one claim only, only inside the claim
+window — and after the window anyone may settle (claim to the landlord,
+remainder to the tenant). The claim is *bounded* but not *adjudicated*: the
+tenant has no on-chain dispute path. This is the template's largest trust
+asymmetry and is appropriate only where a real off-chain lease and legal system
+back the rails. The independent review confirmed the cap and window bounds
+cannot be exceeded; the asymmetry is a documented design choice, not a defect.
+A v2 would add an arbiter-guard slot gating the claim.
+
+## Pre-catalog finding (spike testing)
+
+Before catalog review, the test suite caught a `lease-state` cond-ordering
+bug: a fully-settled lease (deposit-held zeroed) was reported as
+`AWAITING-DEPOSIT`/`SETTLEMENT-DUE` rather than its correct terminal
+`CLOSED` state. Fixed by branching the post-`end` states on
+`deposit-held > 0` first; regression-asserted (the settle lifecycle test
+asserts `CLOSED`).
+
+## Audit history: findings and fixes
+
+An independent `pact-auditor` pass returned **NO-GO** on the first version,
+with two blocking findings. All were fixed:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| F1 | **HIGH** | `give-notice` authenticated the parties with `(enforce-one [ (with-capability (LANDLORD …) true) (with-capability (TENANT …) true) ])`. The `LANDLORD`/`TENANT` capability bodies read the `properties`/`leases` tables, and an `enforce-one` **condition** evaluates in read-only mode — so this was a table read inside an enforce condition (the KDA-CE `BUG-010` class): **REPL-green but node-fatal**, which would have killed `give-notice` (the only early-termination path) on-chain for everyone, extending deposit lock duration. This was introduced by the (well-intended) promotion of party auth to scoped capabilities. | A new `PARTY (lease-id)` capability authenticates either party. Its body binds **both** guards to locals *before* the `enforce-one`, so the reads run in the defcap body (node-safe), not inside the enforce-one condition; the condition enforces only the bound locals. `give-notice` is now `(with-capability (PARTY lease-id) …)`, and parties scope their signature to `(property-lease.PARTY "lease-id")`. **This class is REPL-invisible — devnet validation is the required evidence (see below).** |
+| F2 | MEDIUM | `settle-deposit` called `vault-pay` twice (claim → landlord, remainder → tenant). When **landlord == tenant** and **claim == held/2**, the two payouts installed the *identical* managed `(coin.TRANSFER vault payee amount)` capability, and the second install aborted (`already installed`) — a non-recoverable failure that, with the claim window already closed, **permanently locked the deposit**. | `settle-deposit` now coalesces identical payees: when the landlord and tenant are the same account it pays the full `held` amount once; otherwise the original two-payout path is unchanged. Regression-tested with a self-lease (`landlord == tenant`, `claim == held/2`) that now settles cleanly. |
+| F3 | LOW | `set-property-active` (the only state-mutating admin toggle) emitted no event — an audit-trail gap. | Added `PROPERTY-ACTIVE-SET` `@event` and emit it. Regression-tested. |
+| F4 | INFO | The final billing period is not prorated: `pay-rent`'s gate is `paid-through < end` *before* paying, so the last payment can advance `paid-through` past `end` by up to `period-days` (the tenant pays a whole final period). Conservation still holds. | Documented (README "Known limits": no partial payments; fixed-period billing). |
+| F5 | INFO | If a landlord loses their key, the TAX / REPAIRS / LANDLORD buckets are permanently unreachable (only the `LANDLORD`-guarded withdrawal exits them). BENEFICIARY and the deposit have permissionless exits and survive key loss. | Documented as an inherent key-custody residual. |
+
+A **second** independent pass verified F1–F3 closed with no regression, but
+found one new MEDIUM (also fixed):
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| N1 | MEDIUM | Stored payout destinations (landlord, beneficiary, tenant) are paid via `coin.transfer-create` with their *enrolled* guard. A **vanity** (non-principal) account name could be squatted by anyone with a foreign guard at gas-only cost, after which coin aborts every payout to it (`account guards do not match`) — permanently locking the tenant's deposit (a bricked `settle-deposit`), a landlord bucket, or the beneficiary bucket. Grief-only (the squatter can never *receive* the funds), but a real liveness/fund-lock defect. | `register-property` now enforces `validate-principal` on the landlord and beneficiary accounts, and `create-lease` on the tenant account — every stored payout destination must be a principal (`k:`/`w:`/`r:`). coin's reserved-name protocol then makes squatting impossible and guarantees the enrolled guard matches (and structurally excludes the vault account). Regression-tested (vanity landlord / beneficiary / tenant all rejected). Free withdrawal payees are unaffected — they are paid at withdrawal time, not from stored state. |
+
+With N1 fixed, the second pass returned **GO**.
+
+## Threat model & defenses
+
+| Vector | Defense | Test |
+|---|---|---|
+| Attacker moves vault funds to a chosen account | `VAULT` is internal-only; every payout is landlord-guarded or bounded to recorded accounting paid to a *stored* destination — no attacker-chosen payee+amount path exists | withdrawal + push + settle cases |
+| Non-landlord withdraws / registers | `LANDLORD` cap enforces the enrolled guard; registration enforces the landlord guard | stranger-withdraw, unsigned-register |
+| Signature scoped to the wrong property | `LANDLORD (property-id)` is per-property; a sig scoped elsewhere is rejected | scoped-signature isolation case |
+| One party forges a lease / renewal | `create-lease` / `renew-lease` require BOTH guards in one tx | one-sided lease + one-sided renewal rejections |
+| Stranger terminates a lease | `PARTY` cap enforces landlord-or-tenant | stranger-notice rejection |
+| Rent paid before deposit escrowed | `pay-rent` gates on `deposit-held == deposit` | deposit-gate case |
+| Bucket overdraw / beneficiary pull by landlord | `debit-bucket` balance check; BENEFICIARY not landlord-withdrawable | overdraw + beneficiary-pull rejections |
+| Value leak in the split | landlord residual absorbs floor dust; conservation asserted to 12 dp | on-time / late / 33.33%×3 dust cases |
+| Claim above deposit / twice / out of window | `claim-deposit` bounds (`<= held`, `not filed`, in-window) | claim rejection cases |
+| Settle early / twice / self-brick | window gate + single-shot `held > 0` + same-payee coalescing (F2) | settle rejections + self-lease regression |
+| `add-time` int64 overflow | all stored times bounded 1970–2200, day-counts capped | far-future-end rejection |
+| Squatted payout account bricks settlement | landlord / beneficiary / tenant must be principal accounts (N1) | vanity-account rejection cases |
+| Two same-payee vault payouts collide in one tx | `settle-deposit` coalesces landlord==tenant; README notes one-payout-per-payee-per-tx | self-lease settlement case |
+| Bucket-key collision | ids forbid `|`; bucket names are fixed constants | (structural; ids ASCII ≤64) |
+
+## Capability model
+
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard GOV_KEYSET` | upgrade only; no fund path |
+| `LANDLORD (property-id)` | authentication | enrolled landlord guard (read in `enforce-guard` arg position) | scoped per property |
+| `TENANT (lease-id)` | authentication | enrolled tenant guard | scoped per lease; used in `renew-lease` |
+| `PARTY (lease-id)` | authentication | landlord OR tenant (both bound before `enforce-one`) | either-party; used only by `give-notice` |
+| `VAULT` | weak-body | — | Safe: internal-only; guards the vault account + bucket ledger; every acquisition is landlord-guarded or bounded to recorded accounting to a stored account |
+| `PROPERTY-REGISTERED` / `LEASE-SIGNED` / `DEPOSIT-PAID` / `RENT-PAID` / `WITHDRAWAL` / `DEPOSIT-CLAIMED` / `DEPOSIT-SETTLED` / `NOTICE-GIVEN` / `LEASE-RENEWED` / `PROPERTY-ACTIVE-SET` | `@event` | — | emit-only audit trail |
+
+The vault account guard requires `VAULT`, which is composed only inside this
+module and never on a path that pays an attacker-chosen account. Conservation
+(`vault balance == Σ bucket balances + Σ deposits held`) holds across every
+mutating path — verified by the independent review and asserted to 12 decimals
+throughout the suite.
+
+## Node-safety
+
+Every table read that feeds an `enforce` (or an `enforce-one` condition) is
+bound to a local first: the `LANDLORD` / `TENANT` guard reads sit in
+`enforce-guard` argument position, and the `PARTY` cap binds both guards before
+its `enforce-one` (the F1 fix). This class is **REPL-invisible on KDA-CE**, so
+a **devnet run of `give-notice` (either party), plus a full
+create → deposit → rent → claim → settle cycle, is the required evidence**
+before any production use — the single most important gate for this entry.
+
+## Risk profile
+
+| Risk | Level | Notes |
+|---|---|---|
+| Vault theft | Low | no attacker-chosen payout path; `VAULT` internal-only |
+| Conservation break | Low | dust-absorbing residual; asserted to 12 dp |
+| Unauthorized party action | Low | scoped `LANDLORD`/`TENANT`/`PARTY` caps; mutual assent on create/renew |
+| Fund lock | Low | F2 self-brick fixed; residual landlord-key-loss lock documented (F5) |
+| Deposit dispute | **Medium (by design)** | no arbiter — see Trust model; off-chain document is the backstop |
+| Governance dependency | Medium | upgrade power: pin the module hash, multi-sig the keyset |
+
+## Static analysis note
+
+`pact-static-check.sh` reports **PASS, 0 violations**. The `enforce-guard`
+WARNs are dispositioned SAFE: inside `GOV`, inside the `LANDLORD`/`TENANT`/
+`PARTY` defcaps, and at the two guard-*enrollment* points (`register-property`,
+`create-lease`) where the guard is being stored this transaction and no
+capability yet exists to scope to — the same pattern the treasury and vesting
+templates use at setup.
+
+## What self-reviewed means here
+
+Reviewed by the template's maintainers against the PCO checklist, with all
+authorization / conservation / lifecycle scenarios encoded as runnable
+regression tests, plus two independent `pact-auditor` passes (automated,
+fresh-context) whose blocking findings are all fixed. **Not independent human
+review.** Promotion requires a second reviewer (`community-reviewed`) or a
+third-party report with a matching source hash (`independently-audited`) — see
+`docs/CONTRACT_POLICIES.md` §3.1.
+
+## Reproduce the review
+
+```bash
+cd contracts/library/property-lease/examples
+pact property-lease-test.repl   # 83 assertions
+```

--- a/contracts/library/property-lease/README.md
+++ b/contracts/library/property-lease/README.md
@@ -1,0 +1,75 @@
+# Property Lease (rental rails)
+
+PCO library template: **on-chain rental-lease rails** — a property registry, per-property rent splitting into earmarked buckets, and deposit escrow with claim-window settlement. All money moves through one capability-guarded vault and every payment is evented for an auditable trail. This is the money-and-record layer; the legal contract lives off-chain.
+
+> **Read this first — what this template is NOT.** These are *rails*, not a legal lease. The enforceable contract is the signed off-chain document whose hash each lease anchors; jurisdiction-specific tenancy law cannot be universalized on-chain. And **v1 has no arbiter**: a landlord's capped deposit claim is honored **unilaterally** — the tenant cannot dispute it on-chain. Use this only where the off-chain document and legal system are the real backstop. See [Trust model](#trust-model) and `AUDIT.md`.
+
+## How it works
+
+1. **`register-property id landlord landlord-guard beneficiary beneficiary-guard info tax-bps repairs-bps beneficiary-bps`** — a landlord self-registers (their guard signs). The three revenue-split basis points are **immutable after registration** (so the beneficiary — a protocol fee, co-owner, or DAO treasury — cannot later be zeroed); the landlord takes the residual `10000 − sum`.
+2. **`create-lease …`** — landlord and tenant **co-sign one transaction** (mutual assent). The lease stores the hash of the signed off-chain document plus rent, period, grace, late fee, deposit, term, notice period, and claim window.
+3. **`pay-deposit id payer`** — escrow the security deposit into the vault (anyone may pay). Rent is gated until it's fully escrowed.
+4. **`pay-rent id payer`** — covers exactly one period: rent splits into the TAX / REPAIRS / BENEFICIARY / LANDLORD buckets, a flat late fee past grace goes to the landlord, and the landlord residual absorbs floor-rounding dust so the vault conserves exactly. **Anyone may pay** (guarantor pattern — coin authorizes the payer).
+5. **`withdraw-bucket …`** (landlord) — pull TAX / REPAIRS / LANDLORD to any payee with a memo. **`push-beneficiary id`** (anyone) — sweep the BENEFICIARY bucket to its fixed destination.
+6. **`give-notice id new-end`** — either party shortens the term, bounded by the notice period and never below `paid-through`. **`renew-lease …`** — both parties co-sign to extend and re-price.
+7. **`claim-deposit id amount memo`** (landlord, once, in-window) then **`settle-deposit id`** (anyone, after the window) — claim to the landlord, remainder to the tenant.
+
+## Security model
+
+- **One capability-guarded vault.** All KDA sits in a principal account guarded by an internal `VAULT` capability, acquired only inside this module — every payout is either landlord-guarded, or bounded to recorded accounting paid to a *stored* destination (rent credits, the fixed beneficiary, the settlement parties). There is no path that pays an attacker-chosen account an attacker-chosen amount.
+- **Exact conservation.** `vault balance == Σ bucket balances + Σ deposits held`, to the last of coin's 12 decimals — the landlord residual absorbs split dust, and the suite asserts this after every phase including a `33.33% × 3` odd-rent case.
+- **Scoped party signatures.** Landlord and tenant authenticate through `LANDLORD (property-id)` / `TENANT (lease-id)` capabilities, so a signature authorizes exactly one action on one property or lease — not anything else the key could satisfy in the transaction. Lease creation and renewal require **both** guards.
+- **Immutable splits, immutable beneficiary destination.** Neither can be changed after registration, protecting the beneficiary from unilateral rerouting or zeroing.
+- **Bounded time & ids.** All stored times are bounded to 1970–2200 and day-counts are capped, closing the `add-time` int64-overflow class; ids are ASCII, ≤64 chars, and cannot contain the `|` bucket-key separator.
+- **Principal payout accounts — enforced.** The landlord, beneficiary, and tenant accounts (every *stored* payout destination) must be principal accounts (`k:`/`w:`/`r:`). This binds each name to its guard so it cannot be squatted with a foreign guard, which would otherwise make coin abort every payout to it and permanently lock the deposit or a bucket. Free withdrawal payees (`withdraw-bucket`) are not restricted — they receive at withdrawal time, not from stored state.
+
+## Trust model
+
+This template deliberately encodes an **asymmetry**: at lease end the landlord files a single deposit-deduction claim (capped at the escrowed amount, inside the claim window), and after the window **anyone** can settle — claim to the landlord, remainder to the tenant. **There is no on-chain arbiter and no tenant dispute path.** The claim is bounded (never more than the deposit, one claim only, only in-window) but not *adjudicated*. This is appropriate when a real-world lease and legal system sit behind the rails; it is not appropriate as a trustless escrow between adversaries. A future version would add an arbiter-guard slot (a third-party or multi-sig gate on the claim) — the schema and settlement are structured to accept one.
+
+## Deployment checklist
+
+1. Wrap the module in your namespace; replace the `"property-lease-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig recommended**; governance is upgrade-only and touches no funds).
+2. Deploy and `create-table` (`properties`, `leases`, `buckets`).
+3. Validate the end-to-end flow on **devnet** before mainnet — **mandatory**, not optional (the party-auth capabilities read on-chain tables; that class of bug is invisible in the REPL).
+
+## Usage
+
+```pact
+;; landlord registers (8% tax / 7% repairs / 5% beneficiary; 80% residual)
+(free.property-lease.register-property "unit-12"
+  "k:landlord…" (read-keyset "landlord") "k:dao-treasury…" (read-keyset "benef")
+  "ipfs://premises-record" 800 700 500)
+
+;; landlord + tenant co-sign the lease (both scope their capability)
+(free.property-lease.create-lease "unit-12-2026" "unit-12"
+  "k:tenant…" (read-keyset "tenant") (hash "signed-lease.pdf")
+  1000.0 30 5 25.0 1500.0
+  (time "2026-01-01T00:00:00Z") (time "2026-07-01T00:00:00Z") 30 14)
+```
+
+## Testing
+
+`examples/property-lease-test.repl` is self-contained (loads `coin` + interfaces from `registry/`):
+
+```bash
+cd contracts/library/property-lease/examples && pact property-lease-test.repl
+```
+
+83 assertions on a controlled clock: registration validation and immutable splits, mutual-assent lease signing (one-sided rejected), the deposit gate, on-time and late rent with exact bucket splits, guarded and permissionless withdrawals, scoped-signature isolation (a signature scoped to the wrong property is rejected), rounding-dust conservation, the guarantor payment path, notice and renewal bounds, and the full claim → settle lifecycle including double-claim and double-settle rejection. Conservation is asserted to 12 decimals throughout. CI runs this suite as a blocking check.
+
+## Known limits
+
+- **No arbiter (the headline limitation).** The landlord's deposit claim is unilateral within its cap and window — see [Trust model](#trust-model).
+- **Day-based periods, not calendar months.** `pay-rent` advances `paid-through` by `period-days`; a "monthly" lease drifts against calendar months. Model your periods in days.
+- **No partial payments and no refunds.** `pay-rent` covers exactly one whole period; `give-notice` cannot cut below `paid-through` (rent already paid is not refunded).
+- **KDA only.** Rent, deposits, and payouts are native KDA (`coin`). Supporting an arbitrary `fungible-v2` token would be a v2 generalization.
+- **The TAX bucket is savings accounting, not legal remittance.** It earmarks funds and lets the landlord withdraw to a tax authority; it does not file or remit anything.
+- **The off-chain document is the legal contract.** On-chain state anchors its hash and moves money; it does not encode tenancy terms, habitability, or local law.
+- **One payout per payee per transaction.** coin's managed transfer capability is keyed by (sender, receiver) — so two vault payouts to the *same* account in one transaction collide and abort. `settle-deposit` handles the landlord-is-tenant case internally; if you batch calls (e.g. settling two leases that share a landlord), put each in its own transaction.
+- **Validate on devnet before mainnet** (see the deployment checklist).
+- Governance holds upgrade power. Pin the deployed module hash you audited; use a multi-sig governance keyset.
+
+## License
+
+Apache-2.0

--- a/contracts/library/property-lease/examples/property-lease-test.repl
+++ b/contracts/library/property-lease/examples/property-lease-test.repl
@@ -1,0 +1,561 @@
+;; property-lease-test.repl — PCO library template test suite
+;;
+;; Self-contained: loads coin + interfaces from this repo's registry tree.
+;;
+;; Scenarios: property registration, mutual-assent lease signing, deposit
+;; escrow gating rent, on-time + late rent with exact bucket splits, guarded
+;; and permissionless withdrawals, rounding-dust conservation (33.33%x3),
+;; notice/renewal bounds, and the deposit claim + settlement lifecycle.
+;; Every expect-failure that could mutate state sits in its own rolled-back tx.
+;; Conservation (vault = Sum buckets + Sum deposits held) is asserted to 12dp.
+
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-01-01T00:00:00Z") })
+
+;; --- coin environment (root namespace) ---
+(begin-tx "load coin")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+;; --- fund actors (test-capability CREDIT, the catalog's funding pattern) ---
+(begin-tx "fund actors")
+(env-data
+  { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "tenant-ks":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"],   "pred": "keys-all" }
+  , "rando-ks":    { "keys": ["rando-key"],    "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(coin.credit "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks) 10000.0)
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'tenant-ks) 10000.0)
+(test-capability (coin.CREDIT "rando-acct"))
+(coin.credit "rando-acct" (read-keyset 'rando-ks) 1000.0)
+(commit-tx)
+
+;; --- namespace + module ---
+(begin-tx "load property-lease")
+(env-data { "gov-ks": { "keys": ["admin-key"], "pred": "keys-all" } })
+(env-keys ["admin-key"])
+(define-namespace "free" (read-keyset 'gov-ks) (read-keyset 'gov-ks))
+(namespace "free")
+(define-keyset "free.property-lease-gov" (read-keyset 'gov-ks))
+(load "../property-lease.pact")
+(commit-tx)
+
+;; ===========================================================================
+;; 1. Property registration
+;; ===========================================================================
+(begin-tx "register casa-verde: 8% tax / 7% repairs / 5% beneficiary")
+(env-data
+  { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "benef-ks":    { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"],    "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(free.property-lease.register-property "casa-verde"
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks)
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset 'benef-ks)
+  "hash-of-premises-record-casa-verde"
+  800 700 500)
+(expect "splits stored" 800 (at 'tax-bps (free.property-lease.get-property "casa-verde")))
+(commit-tx)
+
+(begin-tx "REJECT duplicate property id")
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+          , "benef-ks": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(expect-failure "duplicate id rejected" "Value already found while in Insert mode"
+  (free.property-lease.register-property "casa-verde"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks)
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset 'benef-ks) "x" 0 0 0))
+(rollback-tx)
+
+(begin-tx "REJECT splits over 100%")
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+          , "benef-ks": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(expect-failure "bps sum > 10000 rejected" "splits exceed 100%"
+  (free.property-lease.register-property "over-prop"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks)
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset 'benef-ks) "x" 5000 4000 2000))
+(rollback-tx)
+
+(begin-tx "REJECT registration without the landlord's signature")
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+          , "benef-ks": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "rando-key", "caps": [] } ])
+(expect-failure "unsigned registration rejected" "Keyset failure"
+  (free.property-lease.register-property "stolen-prop"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks)
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset 'benef-ks) "x" 100 100 100))
+(rollback-tx)
+
+;; N1 regression: payout destinations must be PRINCIPAL accounts. A vanity
+;; name could be squatted with a foreign guard, and coin.transfer-create would
+;; then abort every payout to it - permanently locking the deposit/bucket.
+(begin-tx "REJECT vanity (non-principal) landlord/beneficiary payout account")
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+          , "benef-ks": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(expect-failure "vanity landlord rejected (N1)" "landlord must be a principal account"
+  (free.property-lease.register-property "vanity-prop"
+    "landlord-vanity" (read-keyset 'landlord-ks)
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset 'benef-ks)
+    "x" 0 0 0))
+(expect-failure "vanity beneficiary rejected (N1)" "beneficiary must be a principal account"
+  (free.property-lease.register-property "vanity-prop"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks)
+    "revenue-vanity" (read-keyset 'benef-ks)
+    "x" 0 0 0))
+(rollback-tx)
+
+;; ===========================================================================
+;; 2. Lease signing = mutual assent (both guards in one tx), scoped sigs
+;; ===========================================================================
+(begin-tx "sign LSE-1: 1000/30d, grace 5d, late fee 25, deposit 1500")
+(env-data { "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222",   "caps": [] } ])
+(free.property-lease.create-lease "LSE-1" "casa-verde"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'tenant-ks)
+  (hash "signed-lease-document-LSE-1-v1")
+  1000.0 30 5 25.0
+  1500.0
+  (time "2026-01-01T00:00:00Z") (time "2026-07-01T00:00:00Z")
+  30 14)
+(expect "paid-through initialized to start"
+  (time "2026-01-01T00:00:00Z") (at 'paid-through (free.property-lease.get-lease "LSE-1")))
+(expect "state awaits deposit" "AWAITING-DEPOSIT" (free.property-lease.lease-state "LSE-1"))
+(commit-tx)
+
+(begin-tx "REJECT lease with tenant signature only")
+(env-data { "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(expect-failure "landlord must co-sign" "Keyset failure"
+  (free.property-lease.create-lease "LSE-X" "casa-verde" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'tenant-ks)
+    "h" 1000.0 30 5 25.0 0.0
+    (time "2026-01-01T00:00:00Z") (time "2026-07-01T00:00:00Z") 30 14))
+(rollback-tx)
+
+(begin-tx "REJECT vanity (non-principal) tenant payout account (N1)")
+(env-data { "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(expect-failure "vanity tenant rejected (bricks deposit refund)" "tenant must be a principal account"
+  (free.property-lease.create-lease "LSE-X" "casa-verde" "tenant-vanity" (read-keyset 'tenant-ks)
+    "h" 1000.0 30 5 25.0 0.0
+    (time "2026-01-01T00:00:00Z") (time "2026-07-01T00:00:00Z") 30 14))
+(rollback-tx)
+
+(begin-tx "REJECT start >= end")
+(env-data { "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(expect-failure "degenerate term rejected" "start must precede end"
+  (free.property-lease.create-lease "LSE-X" "casa-verde" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'tenant-ks)
+    "h" 1000.0 30 5 25.0 0.0
+    (time "2026-07-01T00:00:00Z") (time "2026-07-01T00:00:00Z") 30 14))
+(rollback-tx)
+
+(begin-tx "REJECT over-precise rent (13 decimals)")
+(env-data { "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(expect-failure "precision > 12 rejected" "rent must be positive with precision <= 12"
+  (free.property-lease.create-lease "LSE-X" "casa-verde" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'tenant-ks)
+    "h" 0.0000000000005 30 5 25.0 0.0
+    (time "2026-01-01T00:00:00Z") (time "2026-07-01T00:00:00Z") 30 14))
+(rollback-tx)
+
+(begin-tx "REJECT far-future end (add-time overflow guard)")
+(env-data { "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(expect-failure "end past 2200 rejected" "end out of bounds"
+  (free.property-lease.create-lease "LSE-X" "casa-verde" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'tenant-ks)
+    "h" 1000.0 30 5 25.0 0.0
+    (time "2026-01-01T00:00:00Z") (time "2300-01-01T00:00:00Z") 30 14))
+(rollback-tx)
+
+;; ===========================================================================
+;; 3. Deposit escrow gates rent
+;; ===========================================================================
+(begin-tx "REJECT rent before the deposit is escrowed")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222" free.property-lease.VAULT-ACCOUNT 1000.0)] } ])
+(expect-failure "deposit gate" "security deposit must be fully escrowed before rent"
+  (free.property-lease.pay-rent "LSE-1" "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(rollback-tx)
+
+(begin-tx "escrow the 1500 deposit")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222" free.property-lease.VAULT-ACCOUNT 1500.0)] } ])
+(free.property-lease.pay-deposit "LSE-1" "k:2222222222222222222222222222222222222222222222222222222222222222")
+(expect "deposit held" 1500.0 (at 'deposit-held (free.property-lease.get-lease "LSE-1")))
+(expect "vault holds the deposit" 1500.0 (coin.get-balance free.property-lease.VAULT-ACCOUNT))
+(expect "state now active" "ACTIVE" (free.property-lease.lease-state "LSE-1"))
+(commit-tx)
+
+(begin-tx "REJECT double deposit")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222" free.property-lease.VAULT-ACCOUNT 1500.0)] } ])
+(expect-failure "no second escrow" "deposit already fully escrowed"
+  (free.property-lease.pay-deposit "LSE-1" "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(rollback-tx)
+
+;; ===========================================================================
+;; 4. On-time rent: exact 8/7/5/80 split
+;; ===========================================================================
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-01-03T00:00:00Z") })
+(env-events true) ; clear the event log
+(begin-tx "pay period 1 on time")
+(expect "due = plain rent, not late" 1000.0 (at 'amount (free.property-lease.rent-due "LSE-1")))
+(expect "not late" false (at 'late (free.property-lease.rent-due "LSE-1")))
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222" free.property-lease.VAULT-ACCOUNT 1000.0)] } ])
+(free.property-lease.pay-rent "LSE-1" "k:2222222222222222222222222222222222222222222222222222222222222222")
+(expect "TAX bucket 8%" 80.0 (free.property-lease.bucket-balance "casa-verde" "TAX"))
+(expect "REPAIRS bucket 7%" 70.0 (free.property-lease.bucket-balance "casa-verde" "REPAIRS"))
+(expect "BENEFICIARY bucket 5%" 50.0 (free.property-lease.bucket-balance "casa-verde" "BENEFICIARY"))
+(expect "LANDLORD residual 80%" 800.0 (free.property-lease.bucket-balance "casa-verde" "LANDLORD"))
+(expect "vault = deposit + rent" 2500.0 (coin.get-balance free.property-lease.VAULT-ACCOUNT))
+(expect "paid-through advanced 30d"
+  (time "2026-01-31T00:00:00Z") (at 'paid-through (free.property-lease.get-lease "LSE-1")))
+(expect "exactly one RENT-PAID event" 1
+  (length (filter (lambda (ev) (= "free.property-lease.RENT-PAID" (at 'name ev)))
+                  (env-events true))))
+(commit-tx)
+
+;; ===========================================================================
+;; 5. Late rent: past grace (due 2026-01-31 + 5d) => +25 fee to landlord
+;; ===========================================================================
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-02-10T00:00:00Z") })
+(begin-tx "pay period 2 late")
+(expect "due includes late fee" 1025.0 (at 'amount (free.property-lease.rent-due "LSE-1")))
+(expect "flagged late" true (at 'late (free.property-lease.rent-due "LSE-1")))
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222" free.property-lease.VAULT-ACCOUNT 1025.0)] } ])
+(free.property-lease.pay-rent "LSE-1" "k:2222222222222222222222222222222222222222222222222222222222222222")
+(expect "TAX 160" 160.0 (free.property-lease.bucket-balance "casa-verde" "TAX"))
+(expect "REPAIRS 140" 140.0 (free.property-lease.bucket-balance "casa-verde" "REPAIRS"))
+(expect "BENEFICIARY 100" 100.0 (free.property-lease.bucket-balance "casa-verde" "BENEFICIARY"))
+(expect "LANDLORD 1600 + 25 fee" 1625.0 (free.property-lease.bucket-balance "casa-verde" "LANDLORD"))
+(expect "vault 3525" 3525.0 (coin.get-balance free.property-lease.VAULT-ACCOUNT))
+(commit-tx)
+
+;; ===========================================================================
+;; 6. Withdrawals (landlord scopes LANDLORD)
+;; ===========================================================================
+(begin-tx "landlord withdraws 100 TAX to the tax authority")
+(env-data { "taxman-ks": { "keys": ["taxman-key"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(free.property-lease.withdraw-bucket "casa-verde" "TAX" 100.0
+  "tax-authority-acct" (read-keyset 'taxman-ks) "2026 property tax prepayment")
+(expect "TAX bucket debited" 60.0 (free.property-lease.bucket-balance "casa-verde" "TAX"))
+(expect "tax authority paid" 100.0 (coin.get-balance "tax-authority-acct"))
+(commit-tx)
+
+(begin-tx "scoped signature does not authorize a DIFFERENT property")
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+          , "benef-ks": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(free.property-lease.register-property "casa-azul"
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks)
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset 'benef-ks) "second property" 0 0 0)
+(commit-tx)
+
+(begin-tx "REJECT withdrawal scoped to the WRONG property")
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+;; landlord signs but scopes the cap to casa-azul while acting on casa-verde
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-azul")] } ])
+(expect-failure "sig scoped to another property is rejected" "Keyset failure"
+  (free.property-lease.withdraw-bucket "casa-verde" "TAX" 10.0
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks) "wrong scope"))
+(rollback-tx)
+
+(begin-tx "REJECT withdrawal by a stranger")
+(env-data { "rando-ks": { "keys": ["rando-key"], "pred": "keys-all" } })
+(env-sigs [ { "key": "rando-key", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(expect-failure "stranger cannot withdraw" "Keyset failure"
+  (free.property-lease.withdraw-bucket "casa-verde" "TAX" 10.0
+    "rando-acct" (read-keyset 'rando-ks) "theft"))
+(rollback-tx)
+
+(begin-tx "REJECT overdraw of a bucket")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(expect-failure "bucket overdraw rejected" "insufficient bucket balance"
+  (free.property-lease.withdraw-bucket "casa-verde" "REPAIRS" 1000.0
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks) "drain"))
+(rollback-tx)
+
+(begin-tx "REJECT landlord pull of the BENEFICIARY bucket")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(expect-failure "beneficiary is push-only" "bucket not landlord-withdrawable"
+  (free.property-lease.withdraw-bucket "casa-verde" "BENEFICIARY" 10.0
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks) "grab"))
+(rollback-tx)
+
+(begin-tx "landlord pays a contractor 40 from REPAIRS")
+(env-data { "contractor-ks": { "keys": ["contractor-key"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(free.property-lease.withdraw-bucket "casa-verde" "REPAIRS" 40.0
+  "contractor-acct" (read-keyset 'contractor-ks) "water heater replacement")
+(expect "REPAIRS debited" 100.0 (free.property-lease.bucket-balance "casa-verde" "REPAIRS"))
+(expect "contractor paid" 40.0 (coin.get-balance "contractor-acct"))
+(commit-tx)
+
+(begin-tx "ANYONE pushes the beneficiary bucket (no signature at all)")
+(env-sigs [])
+(free.property-lease.push-beneficiary "casa-verde")
+(expect "beneficiary bucket emptied" 0.0 (free.property-lease.bucket-balance "casa-verde" "BENEFICIARY"))
+(expect "beneficiary account funded" 100.0 (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(commit-tx)
+
+(begin-tx "REJECT push of an empty beneficiary bucket")
+(env-sigs [])
+(expect-failure "nothing to push" "beneficiary bucket empty"
+  (free.property-lease.push-beneficiary "casa-verde"))
+(rollback-tx)
+
+(begin-tx "landlord takes their 1625 residual")
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(free.property-lease.withdraw-bucket "casa-verde" "LANDLORD" 1625.0
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks) "net rent distribution")
+(expect "LANDLORD bucket emptied" 0.0 (free.property-lease.bucket-balance "casa-verde" "LANDLORD"))
+(expect "landlord balance grew" 11625.0 (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(commit-tx)
+
+;; conservation: vault = Sum buckets + Sum deposits held
+(expect "conservation after withdrawals: 60+100+0+0 buckets + 1500 deposit"
+  1660.0 (coin.get-balance free.property-lease.VAULT-ACCOUNT))
+
+;; ===========================================================================
+;; 7. Second lease on the registry + guarantor payment
+;; ===========================================================================
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-03-05T00:00:00Z") })
+(begin-tx "sign LSE-2: 500/30d, no deposit, grace 3d")
+(env-data { "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(free.property-lease.create-lease "LSE-2" "casa-verde"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'tenant-ks)
+  (hash "signed-lease-document-LSE-2-v1")
+  500.0 30 3 10.0
+  0.0
+  (time "2026-03-05T00:00:00Z") (time "2027-03-01T00:00:00Z")
+  30 7)
+(expect "zero-deposit lease immediately active" "ACTIVE" (free.property-lease.lease-state "LSE-2"))
+(commit-tx)
+
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-03-06T00:00:00Z") })
+(begin-tx "guarantor (rando) pays LSE-2 rent")
+(env-sigs [ { "key": "rando-key"
+            , "caps": [(coin.TRANSFER "rando-acct" free.property-lease.VAULT-ACCOUNT 500.0)] } ])
+(free.property-lease.pay-rent "LSE-2" "rando-acct")
+(expect "TAX 60+40" 100.0 (free.property-lease.bucket-balance "casa-verde" "TAX"))
+(expect "REPAIRS 100+35" 135.0 (free.property-lease.bucket-balance "casa-verde" "REPAIRS"))
+(expect "BENEFICIARY 0+25" 25.0 (free.property-lease.bucket-balance "casa-verde" "BENEFICIARY"))
+(expect "LANDLORD 0+400" 400.0 (free.property-lease.bucket-balance "casa-verde" "LANDLORD"))
+(expect "vault 2160" 2160.0 (coin.get-balance free.property-lease.VAULT-ACCOUNT))
+(commit-tx)
+
+;; ===========================================================================
+;; 8. Rounding dust: 33.33%/33.33%/33.33% of an odd rent conserves mass
+;; ===========================================================================
+(begin-tx "register dust-prop + sign LSE-D with rent 1.000000000001")
+(env-data { "landlord-ks": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+          , "benef-ks": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+          , "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(free.property-lease.register-property "dust-prop"
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'landlord-ks)
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset 'benef-ks) "dust test" 3333 3333 3333)
+(commit-tx)
+
+(begin-tx "sign LSE-D")
+(env-data { "tenant-ks": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "dust-prop")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(free.property-lease.create-lease "LSE-D" "dust-prop"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'tenant-ks) "h"
+  1.000000000001 30 0 0.0
+  0.0
+  (time "2026-03-05T00:00:00Z") (time "2026-06-01T00:00:00Z")
+  0 0)
+(commit-tx)
+
+(begin-tx "dust split conserves exactly (landlord absorbs residual)")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222" free.property-lease.VAULT-ACCOUNT 1.000000000001)] } ])
+(free.property-lease.pay-rent "LSE-D" "k:2222222222222222222222222222222222222222222222222222222222222222")
+(expect "TAX floor(33.33%)" 0.3333 (free.property-lease.bucket-balance "dust-prop" "TAX"))
+(expect "REPAIRS floor(33.33%)" 0.3333 (free.property-lease.bucket-balance "dust-prop" "REPAIRS"))
+(expect "BENEFICIARY floor(33.33%)" 0.3333 (free.property-lease.bucket-balance "dust-prop" "BENEFICIARY"))
+(expect "LANDLORD residual carries the dust" 0.000100000001
+  (free.property-lease.bucket-balance "dust-prop" "LANDLORD"))
+(expect "vault gained exactly the rent" 2161.000000000001
+  (coin.get-balance free.property-lease.VAULT-ACCOUNT))
+(commit-tx)
+
+;; ===========================================================================
+;; 9. Renewal (mutual) and notice (unilateral, bounded)
+;; ===========================================================================
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-03-08T00:00:00Z") })
+(begin-tx "renew LSE-2 to 2027-06-01 at 550")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.property-lease.TENANT "LSE-2")] } ])
+(free.property-lease.renew-lease "LSE-2" (time "2027-06-01T00:00:00Z") 550.0)
+(expect "end extended" (time "2027-06-01T00:00:00Z") (at 'end (free.property-lease.get-lease "LSE-2")))
+(expect "re-priced" 550.0 (at 'rent (free.property-lease.get-lease "LSE-2")))
+(commit-tx)
+
+(begin-tx "REJECT one-sided renewal")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(expect-failure "tenant must co-sign renewal" "Keyset failure"
+  (free.property-lease.renew-lease "LSE-2" (time "2028-01-01T00:00:00Z") 600.0))
+(rollback-tx)
+
+(begin-tx "REJECT renewal that shortens the term")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.property-lease.TENANT "LSE-2")] } ])
+(expect-failure "shortening is notice, not renewal" "renewal must extend the term"
+  (free.property-lease.renew-lease "LSE-2" (time "2026-05-01T00:00:00Z") 550.0))
+(rollback-tx)
+
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-03-10T00:00:00Z") })
+(begin-tx "REJECT notice shorter than notice-days (30)")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.property-lease.PARTY "LSE-2")] } ])
+(expect-failure "30-day notice enforced" "notice period too short"
+  (free.property-lease.give-notice "LSE-2" (time "2026-03-20T00:00:00Z")))
+(rollback-tx)
+
+(begin-tx "REJECT notice from a stranger")
+(env-sigs [ { "key": "rando-key", "caps": [] } ])
+(expect-failure "stranger cannot terminate" "landlord or tenant signature required"
+  (free.property-lease.give-notice "LSE-2" (time "2026-04-15T00:00:00Z")))
+(rollback-tx)
+
+(begin-tx "tenant gives valid notice: end -> 2026-04-15")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.property-lease.PARTY "LSE-2")] } ])
+(free.property-lease.give-notice "LSE-2" (time "2026-04-15T00:00:00Z"))
+(expect "term shortened" (time "2026-04-15T00:00:00Z") (at 'end (free.property-lease.get-lease "LSE-2")))
+(commit-tx)
+
+;; ===========================================================================
+;; 10. Deposit claim + settlement (LSE-1 ends 2026-07-01, window 14d)
+;; ===========================================================================
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-05-01T00:00:00Z") })
+(begin-tx "REJECT claim while the lease is running")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(expect-failure "no claim before end" "lease not ended yet"
+  (free.property-lease.claim-deposit "LSE-1" 400.0 "early grab"))
+(rollback-tx)
+
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-07-03T00:00:00Z") })
+(expect "state shows the claim window" "CLAIM-WINDOW" (free.property-lease.lease-state "LSE-1"))
+
+(begin-tx "REJECT settlement while the window is open")
+(env-sigs [])
+(expect-failure "window must close first" "claim window still open"
+  (free.property-lease.settle-deposit "LSE-1"))
+(rollback-tx)
+
+(begin-tx "REJECT claim above the escrowed deposit")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(expect-failure "claim capped at deposit" "claim exceeds escrowed deposit"
+  (free.property-lease.claim-deposit "LSE-1" 2000.0 "greedy"))
+(rollback-tx)
+
+(begin-tx "landlord files a 400 deduction claim")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(free.property-lease.claim-deposit "LSE-1" 400.0 "broken window + deep cleaning")
+(expect "claim recorded" 400.0 (at 'claim-amount (free.property-lease.get-lease "LSE-1")))
+(commit-tx)
+
+(begin-tx "REJECT a second claim")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-verde")] } ])
+(expect-failure "one claim only" "claim already filed"
+  (free.property-lease.claim-deposit "LSE-1" 100.0 "second bite"))
+(rollback-tx)
+
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-07-20T00:00:00Z") })
+(begin-tx "ANYONE settles after the window: 400 landlord / 1100 tenant")
+(env-sigs [])
+(free.property-lease.settle-deposit "LSE-1")
+;; tenant: 10000 - 1500 deposit - 1000 - 1025 - 1.000000000001 (LSE-D) + 1100 refund
+(expect "tenant refunded 1100" 7573.999999999999 (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "landlord got the 400 claim" 12025.0 (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "deposit ledger zeroed" 0.0 (at 'deposit-held (free.property-lease.get-lease "LSE-1")))
+(expect "state closed" "CLOSED" (free.property-lease.lease-state "LSE-1"))
+(commit-tx)
+
+(begin-tx "REJECT double settlement")
+(env-sigs [])
+(expect-failure "nothing left to settle" "no deposit to settle"
+  (free.property-lease.settle-deposit "LSE-1"))
+(rollback-tx)
+
+;; final conservation: vault = Sum all buckets, all deposits settled
+(expect "final conservation: 100+135+25+400 casa + 1.000000000001 dust"
+  661.000000000001 (coin.get-balance free.property-lease.VAULT-ACCOUNT))
+
+;; ===========================================================================
+;; 11. F2 regression: landlord == tenant settlement must NOT self-brick.
+;; Two identical (payee, amount) vault payouts in one settle tx would collide
+;; on the managed coin.TRANSFER install and permanently lock the deposit;
+;; settle-deposit coalesces same-account parties into a single full payout.
+;; ===========================================================================
+(begin-tx "register self-prop + self-lease (landlord IS the tenant)")
+(env-data { "self-ks": { "keys": ["4444444444444444444444444444444444444444444444444444444444444444"], "pred": "keys-all" }
+          , "benef-ks": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:4444444444444444444444444444444444444444444444444444444444444444"))
+(coin.credit "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset 'self-ks) 5000.0)
+(env-sigs [ { "key": "4444444444444444444444444444444444444444444444444444444444444444", "caps": [] } ])
+(free.property-lease.register-property "self-prop"
+  "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset 'self-ks)
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset 'benef-ks) "self lease" 0 0 0)
+(env-sigs [ { "key": "4444444444444444444444444444444444444444444444444444444444444444", "caps": [(free.property-lease.LANDLORD "self-prop")] } ])
+(free.property-lease.create-lease "LSE-SELF" "self-prop"
+  "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset 'self-ks) "h"
+  100.0 30 0 0.0
+  800.0
+  (time "2026-08-01T00:00:00Z") (time "2026-08-15T00:00:00Z")
+  0 7)
+(env-sigs [ { "key": "4444444444444444444444444444444444444444444444444444444444444444"
+            , "caps": [(coin.TRANSFER "k:4444444444444444444444444444444444444444444444444444444444444444" free.property-lease.VAULT-ACCOUNT 800.0)] } ])
+(free.property-lease.pay-deposit "LSE-SELF" "k:4444444444444444444444444444444444444444444444444444444444444444")
+(commit-tx)
+
+(begin-tx "self-landlord files a 400 claim (== held/2, the collision trigger)")
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-08-16T00:00:00Z") })
+(env-sigs [ { "key": "4444444444444444444444444444444444444444444444444444444444444444", "caps": [(free.property-lease.LANDLORD "self-prop")] } ])
+(free.property-lease.claim-deposit "LSE-SELF" 400.0 "self claim")
+(commit-tx)
+
+(begin-tx "settle self-lease: coalesced single 800 payout, no install collision")
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-08-23T00:00:00Z") })
+(env-sigs [])
+(let ((before (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444")))
+  (free.property-lease.settle-deposit "LSE-SELF")
+  (expect "self party made whole with the full 800 (no self-brick)"
+    (+ before 800.0) (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444")))
+(expect "self-lease deposit ledger zeroed" 0.0
+  (at 'deposit-held (free.property-lease.get-lease "LSE-SELF")))
+(expect "self-lease closed" "CLOSED" (free.property-lease.lease-state "LSE-SELF"))
+(commit-tx)
+
+;; ===========================================================================
+;; 12. F3 regression: set-property-active emits an audit event.
+;; ===========================================================================
+(begin-tx "deactivating a property emits PROPERTY-ACTIVE-SET")
+(env-events true)
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.property-lease.LANDLORD "casa-azul")] } ])
+(free.property-lease.set-property-active "casa-azul" false)
+(expect "PROPERTY-ACTIVE-SET emitted" true
+  (contains "free.property-lease.PROPERTY-ACTIVE-SET"
+    (map (at 'name) (env-events true))))
+(expect "new leases blocked while inactive" false
+  (at 'active (free.property-lease.get-property "casa-azul")))
+(commit-tx)

--- a/contracts/library/property-lease/metadata.yaml
+++ b/contracts/library/property-lease/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'Property Lease (rental rails)'
+slug: 'property-lease'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['lease', 'rental', 'escrow', 'revenue-split', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'lease', 'rental', 'deposit-escrow', 'rent-split', 'property']

--- a/contracts/library/property-lease/property-lease.pact
+++ b/contracts/library/property-lease/property-lease.pact
@@ -1,0 +1,563 @@
+(module property-lease GOV
+
+  @doc "PCO library template: on-chain rental-lease rails.                       \
+  \                                                                              \
+  \A registry of PROPERTIES, each holding many LEASES. All money sits in one    \
+  \capability-guarded vault coin account; an internal bucket ledger earmarks    \
+  \every payment per property into TAX / REPAIRS / BENEFICIARY / LANDLORD       \
+  \shares. Jurisdiction-specific law is NOT on-chain: each lease anchors the    \
+  \hash of a signed off-chain lease document (rails on-chain, contract          \
+  \off-chain).                                                                   \
+  \                                                                              \
+  \Model:                                                                        \
+  \  - A landlord self-registers a property with immutable revenue-split basis  \
+  \    points (tax / repairs / a configurable BENEFICIARY - a protocol fee,     \
+  \    co-owner, or DAO treasury; the landlord takes the residual). Splits are  \
+  \    locked at registration so the beneficiary cannot be zeroed later.        \
+  \  - Landlord + tenant co-sign to create or renew a lease (mutual assent).    \
+  \  - The tenant (or anyone) escrows the security deposit, then rent is paid   \
+  \    one period at a time - rent splits into the buckets, a flat late fee     \
+  \    past grace goes to the landlord, and the landlord residual absorbs       \
+  \    rounding dust so the vault conserves to the last decimal.                \
+  \  - Landlord withdraws TAX / REPAIRS / LANDLORD to any payee (evented with   \
+  \    a memo). BENEFICIARY is push-only to its fixed destination.              \
+  \  - Either party may give notice to shorten the term; at the end the         \
+  \    landlord files ONE capped deposit claim inside a claim window, after     \
+  \    which anyone may settle (claim to landlord, remainder to tenant).        \
+  \                                                                              \
+  \Governance is upgrade-only: no function under GOV touches leases, buckets,   \
+  \or the vault.                                                                 \
+  \                                                                              \
+  \KEY TRUST LIMITATION: v1 has NO ARBITER. The landlord's capped deposit       \
+  \claim is honored unilaterally - the tenant cannot dispute it on-chain. Use   \
+  \this only where the off-chain document and legal system are the real         \
+  \backstop. See README.md and AUDIT.md.                                        \
+  \                                                                              \
+  \Deployment checklist (see README.md):                                        \
+  \  1. Wrap in your namespace; replace the 'property-lease-gov' keyset.        \
+  \  2. Deploy and create-table (properties, leases, buckets).                  \
+  \  3. Validate on devnet before mainnet."
+
+  ;; -----------------------------
+  ;; Governance (upgrade-only; no fund paths)
+  ;; -----------------------------
+
+  (defconst GOV_KEYSET:string "property-lease-gov"
+    @doc "Governance keyset name. Replace with your deployed, namespace- \
+         \qualified keyset (multi-sig recommended). Governance can upgrade the \
+         \module and nothing else - no function under GOV touches leases, \
+         \buckets, or the vault.")
+
+  (defcap GOV ()
+    @doc "Module governance: upgrade only."
+    (enforce-guard (keyset-ref-guard GOV_KEYSET)))
+
+  ;; -----------------------------
+  ;; Vault (capability-guarded)
+  ;; -----------------------------
+  ;; Internal token guarding the vault coin account and all bucket mutation.
+  ;; Weak body by design; every public acquisition is either behind a real
+  ;; guard (landlord withdrawals) or pays only recorded accounting to a stored
+  ;; destination (pay-rent credits, push-beneficiary, settle-deposit).
+
+  (defcap VAULT ()
+    @doc "Internal vault + bucket-ledger token. NEVER a public authorization: \
+         \acquired only inside this module, always after a real guard check or \
+         \bounded to recorded accounting paid to a stored account."
+    true)
+
+  (defconst VAULT-GUARD (create-capability-guard (VAULT)))
+  (defconst VAULT-ACCOUNT (create-principal VAULT-GUARD))
+
+  ;; -----------------------------
+  ;; Limits
+  ;; -----------------------------
+
+  (defconst MIN-TIME (time "1970-01-01T00:00:00Z"))
+  (defconst MAX-TIME (time "2200-01-01T00:00:00Z"))
+  (defconst BPS-DENOM 10000)
+  (defconst MAX-ID-LEN 64)
+  (defconst MAX-MEMO-LEN 256)
+
+  (defconst BUCKET-TAX "TAX")
+  (defconst BUCKET-REPAIRS "REPAIRS")
+  (defconst BUCKET-BENEFICIARY "BENEFICIARY")
+  (defconst BUCKET-LANDLORD "LANDLORD")
+
+  ;; -----------------------------
+  ;; Schemas & tables
+  ;; -----------------------------
+
+  (defschema property
+    landlord:string          ; landlord coin account (payout target)
+    landlord-guard:guard     ; authorizes all landlord operations
+    beneficiary:string       ; configurable revenue-share beneficiary account
+    beneficiary-guard:guard
+    info:string              ; free-form premises pointer/hash
+    tax-bps:integer          ; immutable after registration
+    repairs-bps:integer
+    beneficiary-bps:integer
+    active:bool)             ; false = no NEW leases (withdrawals unaffected)
+  (deftable properties:{property})
+
+  (defschema lease
+    property-id:string
+    tenant:string
+    tenant-guard:guard
+    doc-hash:string          ; hash of the signed off-chain lease document
+    rent:decimal             ; KDA per period
+    period-days:integer
+    grace-days:integer
+    late-fee:decimal         ; flat KDA, entirely to the landlord bucket
+    deposit:decimal
+    deposit-held:decimal
+    start:time
+    end:time
+    paid-through:time        ; rent covered until this instant
+    notice-days:integer
+    claim-window-days:integer
+    claim-amount:decimal
+    claim-filed:bool)
+  (deftable leases:{lease})
+
+  (defschema bucket balance:decimal)
+  (deftable buckets:{bucket}) ; key: "<property-id>|<BUCKET>"
+
+  ;; -----------------------------
+  ;; Events
+  ;; -----------------------------
+
+  (defcap PROPERTY-REGISTERED (property-id:string landlord:string) @event true)
+  (defcap LEASE-SIGNED (lease-id:string property-id:string tenant:string rent:decimal doc-hash:string) @event true)
+  (defcap DEPOSIT-PAID (lease-id:string payer:string amount:decimal) @event true)
+  (defcap RENT-PAID (lease-id:string payer:string amount:decimal late-fee:decimal paid-through:time) @event true)
+  (defcap WITHDRAWAL (property-id:string bucket:string amount:decimal payee:string memo:string) @event true)
+  (defcap DEPOSIT-CLAIMED (lease-id:string amount:decimal memo:string) @event true)
+  (defcap DEPOSIT-SETTLED (lease-id:string to-tenant:decimal to-landlord:decimal) @event true)
+  (defcap NOTICE-GIVEN (lease-id:string new-end:time) @event true)
+  (defcap LEASE-RENEWED (lease-id:string new-end:time new-rent:decimal) @event true)
+  (defcap PROPERTY-ACTIVE-SET (property-id:string active:bool) @event true)
+
+  ;; -----------------------------
+  ;; Party authentication (scoped capabilities)
+  ;; -----------------------------
+  ;; As capabilities, a party scopes their signature to exactly one action on
+  ;; one property/lease, instead of signing unscoped. The stored guard is read
+  ;; and bound in the enforce-guard ARGUMENT position (node-safe: a guard read
+  ;; there is not a table read inside an enforce CONDITION).
+
+  (defcap LANDLORD (property-id:string)
+    @doc "Authenticate the landlord of PROPERTY-ID via the guard enrolled at \
+         \registration."
+    (enforce-guard (at 'landlord-guard (read properties property-id))))
+
+  (defcap TENANT (lease-id:string)
+    @doc "Authenticate the tenant of LEASE-ID via the guard enrolled at lease \
+         \creation."
+    (enforce-guard (at 'tenant-guard (read leases lease-id))))
+
+  (defcap PARTY (lease-id:string)
+    @doc "Authenticate EITHER party to LEASE-ID (landlord or tenant). Both \
+         \guards are bound to locals FIRST (node-safe), then enforce-one \
+         \accepts whichever the caller satisfies. A party scopes their \
+         \termination signature to (property-lease.PARTY \"lease-id\")."
+    (let* ((l (read leases lease-id))
+           (lg (at 'landlord-guard (read properties (at 'property-id l))))
+           (tg (at 'tenant-guard l)))
+      (enforce-one "landlord or tenant signature required"
+        [ (enforce-guard lg) (enforce-guard tg) ])))
+
+  ;; -----------------------------
+  ;; Validation helpers (pure)
+  ;; -----------------------------
+
+  (defun enforce-valid-id (id:string)
+    (enforce (!= id "") "id empty")
+    (enforce (<= (length id) MAX-ID-LEN) "id too long")
+    (enforce (is-charset 0 id) "id must be ASCII")
+    (enforce (not (contains "|" id)) "id must not contain |"))
+
+  (defun enforce-precision (amount:decimal msg:string)
+    (enforce (= (floor amount 12) amount) msg))
+
+  (defun enforce-positive (amount:decimal msg:string)
+    (enforce (> amount 0.0) msg)
+    (enforce-precision amount msg))
+
+  (defun enforce-non-negative (amount:decimal msg:string)
+    (enforce (>= amount 0.0) msg)
+    (enforce-precision amount msg))
+
+  (defun enforce-time-bounds (t:time msg:string)
+    ;; add-time can silently wrap int64; bounding every stored time closes it
+    (enforce (>= t MIN-TIME) msg)
+    (enforce (<= t MAX-TIME) msg))
+
+  (defun chain-now:time ()
+    (at 'block-time (chain-data)))
+
+  (defun split-amount:decimal (amount:decimal bps:integer)
+    ;; floor to coin precision; the landlord residual absorbs the dust,
+    ;; so the four cuts always sum EXACTLY to the rent (conservation)
+    (floor (/ (* amount (dec bps)) 10000.0) 12))
+
+  ;; -----------------------------
+  ;; Internal ledger (VAULT-only)
+  ;; -----------------------------
+
+  (defun bucket-key:string (property-id:string bucket:string)
+    (format "{}|{}" [property-id bucket]))
+
+  (defun credit-bucket:string (property-id:string bucket:string amount:decimal)
+    (require-capability (VAULT))
+    (if (> amount 0.0)
+      (let ((key (bucket-key property-id bucket)))
+        (with-default-read buckets key { "balance": 0.0 } { "balance" := bal }
+          (write buckets key { "balance": (+ bal amount) })))
+      "zero credit skipped"))
+
+  (defun debit-bucket:string (property-id:string bucket:string amount:decimal)
+    (require-capability (VAULT))
+    (let* ((key (bucket-key property-id bucket))
+           (bal (at 'balance (read buckets key))))
+      (enforce (>= bal amount) "insufficient bucket balance")
+      (update buckets key { "balance": (- bal amount) })))
+
+  (defun vault-pay:string (payee:string payee-guard:guard amount:decimal)
+    (require-capability (VAULT))
+    (install-capability (coin.TRANSFER VAULT-ACCOUNT payee amount))
+    (coin.transfer-create VAULT-ACCOUNT payee payee-guard amount))
+
+  ;; -----------------------------
+  ;; Registry
+  ;; -----------------------------
+
+  (defun register-property:string
+    ( property-id:string
+      landlord:string landlord-guard:guard
+      beneficiary:string beneficiary-guard:guard
+      info:string
+      tax-bps:integer repairs-bps:integer beneficiary-bps:integer )
+    @doc "Landlord self-registers a property (their guard must sign). Split \
+    \bps are IMMUTABLE afterwards; landlord share = 10000 - sum(bps)."
+    (enforce-valid-id property-id)
+    ;; Payout destinations MUST be principal accounts (k:/w:/r:). They are paid
+    ;; via coin.transfer-create with their ENROLLED guard; a vanity name could
+    ;; be squatted with a foreign guard (or never created), and coin would then
+    ;; abort every payout to it - permanently locking the LANDLORD/beneficiary
+    ;; funds (and, via a bricked settle, the tenant's deposit). validate-principal
+    ;; binds name==principal(guard), which coin's reserved-name protocol makes
+    ;; unsquattable and guarantees the guard matches.
+    (enforce (validate-principal landlord-guard landlord)
+      "landlord must be a principal account (k:/w:/r:)")
+    (enforce (validate-principal beneficiary-guard beneficiary)
+      "beneficiary must be a principal account (k:/w:/r:)")
+    (enforce (<= (length info) MAX-MEMO-LEN) "info too long")
+    (enforce (>= tax-bps 0) "tax-bps negative")
+    (enforce (>= repairs-bps 0) "repairs-bps negative")
+    (enforce (>= beneficiary-bps 0) "beneficiary-bps negative")
+    (enforce (<= (+ tax-bps (+ repairs-bps beneficiary-bps)) BPS-DENOM)
+      "splits exceed 100%")
+    (enforce-guard landlord-guard)
+    (insert properties property-id
+      { "landlord": landlord, "landlord-guard": landlord-guard
+      , "beneficiary": beneficiary, "beneficiary-guard": beneficiary-guard
+      , "info": info
+      , "tax-bps": tax-bps, "repairs-bps": repairs-bps
+      , "beneficiary-bps": beneficiary-bps
+      , "active": true })
+    (emit-event (PROPERTY-REGISTERED property-id landlord))
+    (format "property {} registered" [property-id]))
+
+  (defun set-property-active:string (property-id:string active:bool)
+    @doc "Landlord gates NEW lease creation; existing leases and withdrawals \
+    \are unaffected."
+    (with-capability (LANDLORD property-id)
+      (update properties property-id { "active": active })
+      (emit-event (PROPERTY-ACTIVE-SET property-id active))
+      (format "property {} active: {}" [property-id active])))
+
+  ;; -----------------------------
+  ;; Lease lifecycle
+  ;; -----------------------------
+
+  (defun create-lease:string
+    ( lease-id:string property-id:string
+      tenant:string tenant-guard:guard
+      doc-hash:string
+      rent:decimal period-days:integer grace-days:integer late-fee:decimal
+      deposit:decimal
+      start:time end:time
+      notice-days:integer claim-window-days:integer )
+    @doc "Mutual assent: BOTH landlord and tenant guards must sign the tx \
+    \(landlord scopes LANDLORD, tenant scopes TENANT is not yet possible - the \
+    \lease does not exist - so the tenant guard is enforced directly here). \
+    \doc-hash anchors the signed off-chain lease document."
+    (enforce-valid-id lease-id)
+    (let ((p (read properties property-id)))
+      (enforce (at 'active p) "property not active")
+      ;; the tenant is a settlement payout destination (deposit refund) - it
+      ;; must be a principal account for the same reason as the landlord /
+      ;; beneficiary (see register-property); otherwise a squatted refund
+      ;; account bricks settle-deposit and locks the deposit forever.
+      (enforce (validate-principal tenant-guard tenant)
+        "tenant must be a principal account (k:/w:/r:)")
+      (enforce (!= doc-hash "") "doc-hash required")
+      (enforce (<= (length doc-hash) 128) "doc-hash too long")
+      (enforce-positive rent "rent must be positive with precision <= 12")
+      (enforce-non-negative late-fee "late-fee must be >= 0 with precision <= 12")
+      (enforce-non-negative deposit "deposit must be >= 0 with precision <= 12")
+      (enforce (and (>= period-days 1) (<= period-days 366)) "period-days out of range [1,366]")
+      (enforce (and (>= grace-days 0) (<= grace-days 366)) "grace-days out of range [0,366]")
+      (enforce (and (>= notice-days 0) (<= notice-days 365)) "notice-days out of range [0,365]")
+      (enforce (and (>= claim-window-days 0) (<= claim-window-days 365)) "claim-window-days out of range [0,365]")
+      (enforce-time-bounds start "start out of bounds")
+      (enforce-time-bounds end "end out of bounds")
+      (enforce (< start end) "start must precede end")
+      ;; mutual assent: landlord (scoped) + tenant (the guard being enrolled)
+      (with-capability (LANDLORD property-id)
+        (enforce-guard tenant-guard)
+        (insert leases lease-id
+          { "property-id": property-id
+          , "tenant": tenant, "tenant-guard": tenant-guard
+          , "doc-hash": doc-hash
+          , "rent": rent, "period-days": period-days
+          , "grace-days": grace-days, "late-fee": late-fee
+          , "deposit": deposit, "deposit-held": 0.0
+          , "start": start, "end": end, "paid-through": start
+          , "notice-days": notice-days
+          , "claim-window-days": claim-window-days
+          , "claim-amount": 0.0, "claim-filed": false })
+        (emit-event (LEASE-SIGNED lease-id property-id tenant rent doc-hash))
+        (format "lease {} signed" [lease-id]))))
+
+  (defun pay-deposit:string (lease-id:string payer:string)
+    @doc "Escrow the remaining security deposit. Payer signs coin.TRANSFER \
+    \payer -> vault for (deposit - deposit-held); anyone may pay."
+    (let* ((l (read leases lease-id))
+           (deposit (at 'deposit l))
+           (held (at 'deposit-held l))
+           (due (- deposit held))
+           (now (chain-now))
+           (lease-end (at 'end l)))
+      (enforce (> due 0.0) "deposit already fully escrowed")
+      (enforce (< now lease-end) "lease term is over")
+      (coin.transfer-create payer VAULT-ACCOUNT VAULT-GUARD due)
+      (update leases lease-id { "deposit-held": deposit })
+      (emit-event (DEPOSIT-PAID lease-id payer due))
+      (format "deposit escrowed: {}" [due])))
+
+  (defun pay-rent:string (lease-id:string payer:string)
+    @doc "Pay exactly ONE billing period (the next uncovered one): rent plus \
+    \the late fee when past paid-through + grace. Anyone may pay (guarantor \
+    \pattern) - coin's DEBIT authorizes the payer. Requires escrowed deposit."
+    (let* ((l (read leases lease-id))
+           (property-id (at 'property-id l))
+           (p (read properties property-id))
+           (now (chain-now))
+           (rent (at 'rent l))
+           (paid-through (at 'paid-through l))
+           (grace-end (add-time paid-through (days (at 'grace-days l))))
+           (late (> now grace-end))
+           (fee (if late (at 'late-fee l) 0.0))
+           (total (+ rent fee))
+           (tax-cut (split-amount rent (at 'tax-bps p)))
+           (repairs-cut (split-amount rent (at 'repairs-bps p)))
+           (beneficiary-cut (split-amount rent (at 'beneficiary-bps p)))
+           (landlord-cut (+ fee (- rent (+ tax-cut (+ repairs-cut beneficiary-cut)))))
+           (new-paid-through (add-time paid-through (days (at 'period-days l))))
+           (deposit (at 'deposit l))
+           (held (at 'deposit-held l))
+           (lease-end (at 'end l)))
+      (enforce (= held deposit) "security deposit must be fully escrowed before rent")
+      (enforce (< paid-through lease-end) "lease term already fully paid")
+      (coin.transfer-create payer VAULT-ACCOUNT VAULT-GUARD total)
+      (with-capability (VAULT)
+        (credit-bucket property-id BUCKET-TAX tax-cut)
+        (credit-bucket property-id BUCKET-REPAIRS repairs-cut)
+        (credit-bucket property-id BUCKET-BENEFICIARY beneficiary-cut)
+        (credit-bucket property-id BUCKET-LANDLORD landlord-cut))
+      (update leases lease-id { "paid-through": new-paid-through })
+      (emit-event (RENT-PAID lease-id payer total fee new-paid-through))
+      (format "rent paid; covered through {}" [new-paid-through])))
+
+  ;; -----------------------------
+  ;; Withdrawals
+  ;; -----------------------------
+
+  (defun withdraw-bucket:string
+    ( property-id:string bucket:string amount:decimal
+      payee:string payee-guard:guard memo:string )
+    @doc "Landlord-guarded withdrawal from TAX / REPAIRS / LANDLORD. Payee is \
+    \free (tax authority, contractor, self); evented with memo for on-chain \
+    \spend transparency. BENEFICIARY is push-only."
+    (enforce (contains bucket [BUCKET-TAX BUCKET-REPAIRS BUCKET-LANDLORD])
+      "bucket not landlord-withdrawable")
+    (enforce (<= (length memo) MAX-MEMO-LEN) "memo too long")
+    (enforce-positive amount "amount must be positive with precision <= 12")
+    (with-capability (LANDLORD property-id)
+      (with-capability (VAULT)
+        (debit-bucket property-id bucket amount)
+        (vault-pay payee payee-guard amount))
+      (emit-event (WITHDRAWAL property-id bucket amount payee memo))
+      (format "{} withdrawn from {} {}" [amount property-id bucket])))
+
+  (defun push-beneficiary:string (property-id:string)
+    @doc "Permissionless: push the entire BENEFICIARY bucket to the property's \
+    \fixed beneficiary account (destination immutable => no auth needed)."
+    (let* ((p (read properties property-id))
+           (key (bucket-key property-id BUCKET-BENEFICIARY))
+           (bal (at 'balance (read buckets key))))
+      (enforce (> bal 0.0) "beneficiary bucket empty")
+      (with-capability (VAULT)
+        (debit-bucket property-id BUCKET-BENEFICIARY bal)
+        (vault-pay (at 'beneficiary p) (at 'beneficiary-guard p) bal))
+      (emit-event (WITHDRAWAL property-id BUCKET-BENEFICIARY bal (at 'beneficiary p) "push"))
+      (format "pushed {} to beneficiary" [bal])))
+
+  ;; -----------------------------
+  ;; Deposit settlement
+  ;; -----------------------------
+
+  (defun claim-deposit:string (lease-id:string amount:decimal memo:string)
+    @doc "Landlord files ONE deduction claim (<= escrowed deposit) inside the \
+    \claim window after end. v1 has NO ARBITER - the claim is unilateral; the \
+    \off-chain document + legal system are the backstop."
+    (enforce (<= (length memo) MAX-MEMO-LEN) "memo too long")
+    (enforce-non-negative amount "claim must be >= 0 with precision <= 12")
+    (let* ((l (read leases lease-id))
+           (property-id (at 'property-id l))
+           (now (chain-now))
+           (lease-end (at 'end l))
+           (window-end (add-time lease-end (days (at 'claim-window-days l))))
+           (held (at 'deposit-held l))
+           (filed (at 'claim-filed l)))
+      (enforce (not filed) "claim already filed")
+      (enforce (>= now lease-end) "lease not ended yet")
+      (enforce (< now window-end) "claim window closed")
+      (enforce (<= amount held) "claim exceeds escrowed deposit")
+      (with-capability (LANDLORD property-id)
+        (update leases lease-id { "claim-amount": amount, "claim-filed": true })
+        (emit-event (DEPOSIT-CLAIMED lease-id amount memo))
+        (format "claim of {} filed" [amount]))))
+
+  (defun settle-deposit:string (lease-id:string)
+    @doc "Permissionless after the claim window: claim -> landlord, \
+    \remainder -> tenant."
+    (let* ((l (read leases lease-id))
+           (p (read properties (at 'property-id l)))
+           (now (chain-now))
+           (window-end (add-time (at 'end l) (days (at 'claim-window-days l))))
+           (held (at 'deposit-held l))
+           (claim (at 'claim-amount l))
+           (to-tenant (- held claim)))
+      (enforce (> held 0.0) "no deposit to settle")
+      (enforce (>= now window-end) "claim window still open")
+      (with-capability (VAULT)
+        ;; Coalesce identical payees: if the landlord and tenant are the same
+        ;; account, two vault-pays would install the SAME managed
+        ;; (coin.TRANSFER vault payee amount) twice and abort ("already
+        ;; installed"), stranding the deposit. Pay the full held amount once.
+        (if (= (at 'landlord p) (at 'tenant l))
+          (vault-pay (at 'landlord p) (at 'landlord-guard p) held)
+          [ (if (> claim 0.0)
+              (vault-pay (at 'landlord p) (at 'landlord-guard p) claim)
+              "no landlord claim")
+            (if (> to-tenant 0.0)
+              (vault-pay (at 'tenant l) (at 'tenant-guard l) to-tenant)
+              "full deposit claimed") ]))
+      (update leases lease-id { "deposit-held": 0.0 })
+      (emit-event (DEPOSIT-SETTLED lease-id to-tenant claim))
+      (format "settled: {} to tenant, {} to landlord" [to-tenant claim])))
+
+  ;; -----------------------------
+  ;; Termination / renewal
+  ;; -----------------------------
+
+  (defun give-notice:string (lease-id:string new-end:time)
+    @doc "Either party shortens the term, respecting notice-days. Cannot cut \
+    \below paid-through (no refund logic in v1)."
+    (let* ((l (read leases lease-id))
+           (property-id (at 'property-id l))
+           (now (chain-now))
+           (lease-end (at 'end l))
+           (earliest (add-time now (days (at 'notice-days l))))
+           (paid-through (at 'paid-through l)))
+      (enforce (< now lease-end) "lease already ended")
+      (enforce-time-bounds new-end "new-end out of bounds")
+      (enforce (< new-end lease-end) "notice must shorten the term")
+      (enforce (>= new-end earliest) "notice period too short")
+      (enforce (>= new-end paid-through) "cannot end before paid-through (no refunds in v1)")
+      ;; Either party may terminate; they scope their signature to PARTY, whose
+      ;; body binds both guards BEFORE the enforce-one (node-safe: the reads run
+      ;; in the defcap body, not inside an enforce/enforce-one CONDITION).
+      (with-capability (PARTY lease-id)
+        (update leases lease-id { "end": new-end })
+        (emit-event (NOTICE-GIVEN lease-id new-end))
+        (format "term shortened to {}" [new-end]))))
+
+  (defun renew-lease:string (lease-id:string new-end:time new-rent:decimal)
+    @doc "Mutual assent: BOTH guards must sign (landlord scopes LANDLORD, \
+    \tenant scopes TENANT). Extends term, re-prices future periods."
+    (let* ((l (read leases lease-id))
+           (property-id (at 'property-id l))
+           (now (chain-now))
+           (lease-end (at 'end l)))
+      (enforce (< now lease-end) "lease already ended; create a new lease")
+      (enforce-time-bounds new-end "new-end out of bounds")
+      (enforce (> new-end lease-end) "renewal must extend the term")
+      (enforce-positive new-rent "rent must be positive with precision <= 12")
+      (with-capability (LANDLORD property-id)
+        (with-capability (TENANT lease-id)
+          (update leases lease-id { "end": new-end, "rent": new-rent })
+          (emit-event (LEASE-RENEWED lease-id new-end new-rent))
+          (format "renewed to {} at rent {}" [new-end new-rent])))))
+
+  ;; -----------------------------
+  ;; Views (local reads)
+  ;; -----------------------------
+
+  (defun get-property:object{property} (property-id:string)
+    (read properties property-id))
+
+  (defun get-lease:object{lease} (lease-id:string)
+    (read leases lease-id))
+
+  (defun bucket-balance:decimal (property-id:string bucket:string)
+    (with-default-read buckets (bucket-key property-id bucket)
+      { "balance": 0.0 } { "balance" := bal }
+      bal))
+
+  (defun vault-account:string () VAULT-ACCOUNT)
+
+  (defun rent-due:object (lease-id:string)
+    @doc "Next period's amount (incl. late fee), lateness, and payability."
+    (let* ((l (read leases lease-id))
+           (now (chain-now))
+           (paid-through (at 'paid-through l))
+           (grace-end (add-time paid-through (days (at 'grace-days l))))
+           (late (> now grace-end))
+           (fee (if late (at 'late-fee l) 0.0)))
+      { "amount": (+ (at 'rent l) fee)
+      , "late": late
+      , "next-period-start": paid-through
+      , "payable": (and (< paid-through (at 'end l))
+                        (= (at 'deposit-held l) (at 'deposit l))) }))
+
+  (defun lease-state:string (lease-id:string)
+    @doc "Lifecycle is computed from time + row state, never stored."
+    (let* ((l (read leases lease-id))
+           (now (chain-now))
+           (lease-end (at 'end l))
+           (window-end (add-time lease-end (days (at 'claim-window-days l)))))
+      (cond
+        ((< now lease-end)
+          (if (< (at 'deposit-held l) (at 'deposit l)) "AWAITING-DEPOSIT" "ACTIVE"))
+        ((> (at 'deposit-held l) 0.0)
+          (if (< now window-end) "CLAIM-WINDOW" "SETTLEMENT-DUE"))
+        "CLOSED")))
+)
+
+(create-table properties)
+(create-table leases)
+(create-table buckets)

--- a/docs/index.json
+++ b/docs/index.json
@@ -178,6 +178,38 @@
 }
 ,
 {
+  "name": "Property Lease (rental rails)",
+  "slug": "property-lease",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "lease",
+    "rental",
+    "escrow",
+    "revenue-split",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "lease",
+    "rental",
+    "deposit-escrow",
+    "rent-split",
+    "property"
+  ]
+}
+,
+{
   "name": "Token (fungible-v2 + fungible-xchain-v1)",
   "slug": "token-fungible",
   "version": "0.2.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ _Generated from `contracts/**/metadata.yaml`._
 | Multisig Treasury (M-of-N) | multisig-treasury | 1.0.0 | self-reviewed | treasury, multisig, governance, template, library |
 | NFT Collection Policy (marmalade-v2) | nft-collection-policy | 1.0.0 | self-reviewed | nft, marmalade, collection, token-policy, template, library |
 | Oracle Feed (median, staleness-guarded) | oracle-feed | 1.0.0 | self-reviewed | oracle, price-feed, median, template, library |
+| Property Lease (rental rails) | property-lease | 1.0.0 | self-reviewed | lease, rental, escrow, revenue-split, template, library |
 | Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
 | Token Vesting (cliff + linear) | vesting | 1.0.0 | self-reviewed | vesting, escrow, timelock, template, library |
 


### PR DESCRIPTION
## What

The ninth Library template: `contracts/library/property-lease` — **on-chain rental-lease rails**. A property registry with immutable revenue splits, per-property rent bucketing (TAX / REPAIRS / BENEFICIARY / LANDLORD) inside one capability-guarded vault, deposit escrow, and claim-window settlement. This is the money-and-record layer; the enforceable lease is the signed off-chain document whose hash each lease anchors.

- **Mutual assent** on create/renew (both guards, one tx); scoped `LANDLORD`/`TENANT`/`PARTY` capabilities so wallets scope signatures; governance is upgrade-only with zero fund paths.
- **Exact conservation** — `vault == Σ buckets + Σ deposits held` to coin's 12 decimals, the landlord residual absorbing floor dust (asserted through a 33.33%×3 odd-rent case).
- **Guarantor rent** (anyone may pay), **permissionless beneficiary push** to a fixed destination, **permissionless settlement** after the claim window.

## Trust model — read this

**v1 has no arbiter.** The landlord's deposit-deduction claim is bounded (≤ deposit, one claim, in-window) but **unilateral** — the tenant has no on-chain dispute path. Appropriate only where a real off-chain lease and legal system back the rails, not as trustless escrow between adversaries. A v2 would add an arbiter-guard slot. This is foregrounded in both the README and `AUDIT.md`.

## Review process

Two independent `pact-auditor` passes:

- **Pass 1 — NO-GO.** HIGH: promoting `give-notice` auth to capabilities put table reads inside an `enforce-one` read-only condition — the node-fatal, REPL-invisible read-in-enforce class. Fixed with a `PARTY` capability that binds both guards *before* the `enforce-one`. Plus MEDIUM (settle self-brick: duplicate managed-transfer install when landlord==tenant → coalesced) and LOW (missing event).
- **Pass 2 — GO.** MEDIUM: squattable **vanity** payout accounts could permanently lock settlements/buckets. Fixed by enforcing principal (`k:`/`w:`/`r:`) landlord/beneficiary/tenant accounts — same defense as the vesting template.

## Evidence

- `examples/property-lease-test.repl`: **83 assertions**, self-contained (registry `coin`), controlled clock. Splits + dust conservation, late fees, deposit gate, guarded/permissionless withdrawals, scoped-signature isolation, notice/renewal bounds, full claim→settle lifecycle, self-lease settlement regression, vanity-account rejections. Blocking CI.
- Static gate: PASS, 0 violations.
- `AUDIT.md` documents the full findings history (F1–F5, N1), the pre-catalog `lease-state` fix, and the no-arbiter trust asymmetry; devnet validation of `give-notice` + a full lifecycle is named as the required node-safety evidence.
- Index regenerated; entry validates under the library quality gate at `self-reviewed`.

Library is now **nine templates**.