### PR TITLE
feat(library): add royalty-sale — hardened NFT marketplace (Marmalade V2 analysis)

### DIFF
--- a/contracts/library/royalty-sale/AUDIT.md
+++ b/contracts/library/royalty-sale/AUDIT.md
@@ -1,0 +1,132 @@
+# AUDIT — library/royalty-sale
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `royalty-sale` (namespace: project-specific) |
+| **Version** | 1.0.0 |
+| **Audit Status** | self-reviewed |
+| **Category** | PCO Library Template |
+| **Source** | PCO-authored reference implementation |
+| **Last review** | 2026-07-06 |
+
+## Purpose
+
+A self-contained NFT + fixed-price royalty marketplace that owns both its token
+ledger and its sale escrow — the hardened demonstration of the fixes proposed
+in the PCO Marmalade V2 security & architecture analysis. Its correctness
+*claims* (conservation, on-chain economics, fail-closed inputs, sale-only
+enforcement) are the deliverable, so they were probed directly.
+
+## What it demonstrates (mapped to the Marmalade analysis)
+
+| Property | Marmalade finding it answers |
+|---|---|
+| Single settlement asserting `royalty + fee + proceeds == price` and that the escrow returns to its pre-sale balance; no hook holds escrow-spend authority | ARCH-1 (shared escrow sweep), POL-3 (policy reaches into escrow) |
+| Royalty fixed on the token at mint; fee rate + payee fixed on the listing by the seller; `buy` takes no money parameter | ARCH-2 (caller-supplied marketplace fee) |
+| Principal payout accounts, range-capped rates, no permissive defaults | POL-1 (fail-open guard defaults) |
+| `transferable` is an explicit, immutable per-token opt-in; sale-only enforcement can't be composed away | POL-2 (blunt always-fail transfer lock) |
+| Same-account payout merge (primary sale: creator == seller) | fund-lock + duplicate-managed-install classes |
+
+## Audit history: findings and fixes
+
+An independent `pact-auditor` pass returned **NO-GO** with two confirmed code
+defects and one high-impact node-safety gap. All were fixed:
+
+| # | Severity | Finding | Fix |
+|---|----------|---------|-----|
+| F1 | **HIGH (node-only)** | `buy` read the escrow baseline with `(try 0.0 (currency::get-balance ESCROW))` — a table read inside a `try`, a read-only context on the KDA-CE node. Same REPL-invisible class the module avoids elsewhere. On-node it could either abort every sale (if the node blocks the read) or, if caught, let a single dust donation to the *shared* escrow permanently break the baseline check (DoS). | `buy` restructured: fund the escrow **first** (the buyer's own signed transfer), then read the balance in a **plain `let`** (the account now exists — no `try`, no enforce-condition read), and prove conservation as `final-bal == funded-bal − price`. This is dust-donation robust (`funded = baseline + price` ⇒ `final == baseline`) and **validated on a live KDA-CE node** (see below). |
+| F2 | MEDIUM | The `TRANSFERRED` event emitted `(TRANSFERRED id receiver receiver)` — the sender was lost, corrupting provenance. | Capture the prior owner before the update; emit `(TRANSFERRED id from receiver)`. Regression-tested. |
+| F3 | LOW | `mint` did `(enforce-guard owner-guard)` in a bare defun, forcing the minter to sign **unscoped** — a signature-reuse foot-gun in a template others copy. | Added a `MINT-AUTH (owner-guard)` capability; `mint` acquires it, and the suite's mints now sign scoped to `(MINT-AUTH …)`. |
+| F5 | LOW | Payouts ran before the ownership/listing updates (safe only via the Pact 5.3+ reentrancy guard, not "atomic" as the comment claimed). | Reordered to checks-effects-interactions: the listing is closed and ownership flipped **before** the payouts; comment corrected. |
+| F6 | INFO | `enforce-unit` called `(currency::precision)` inside an `enforce` condition — node-safe for `coin` but latent for an arbitrary fungible. | Bind precision before the enforce. |
+| F7 | INFO | The `royalty + fee + proceeds == price` assert was tautological (proceeds is defined as the difference). | Removed; the substantive conservation proof is the escrow-baseline check. |
+| F4 / F8 | LOW / INFO | Donated funds sent directly to the shared escrow are stranded (no sweep); a seller-chosen malicious `currency` is trusted at buy time. | Documented as intentional/known limits (README): don't send to the escrow directly; trade only in trusted currencies. Conservation still holds over a dust-carrying escrow (regression-tested + devnet-proven). |
+| F9 | — | Coverage gaps (donation, `marketplace==seller/creator` merges, transfer-while-listed, non-owner-delist). | Added: provenance, transfer-while-listed rejection, non-owner-delist rejection, `marketplace==seller` merge, and the escrow-dust-donation conservation regression. |
+
+## Devnet validation (on-node evidence for F1)
+
+The F1 class is **REPL-invisible**, so it was validated on a live KDA-CE devnet
+(`recap-development`) via `scripts/devnet-validate` (`npm run royalty-sale`).
+Both node-critical cases of the fix were driven to mined confirmation:
+
+- **Fresh escrow (first sale):** `buy` funds the escrow, reads its balance in a
+  plain `let`, settles (creator + marketplace + seller, with the primary-sale
+  merge), and the escrow returns to `0` — proving the read is node-safe and the
+  settlement conserves on-node.
+- **Dust-carrying escrow:** a griefer donates dust to the shared escrow; the
+  next `buy` still settles and the escrow returns to its dust **baseline**
+  (not zero) — proving the conservation check is donation-robust on-node, not
+  just in the REPL.
+
+Module name, source hash, and confirmed request keys are recorded in
+`scripts/devnet-validate/results/royalty-sale.json`.
+
+## Threat model & defenses
+
+| Vector | Defense | Test |
+|---|---|---|
+| Value stranded in / conjured from the escrow | single settlement; `final-bal == funded-bal − price`; payouts sum to price | conservation cases + odd-price dust + devnet |
+| Buyer zeroes the royalty/fee | royalty fixed at mint, fee fixed at listing; `buy` has no money argument | listing-validation + economics-from-state |
+| Primary-sale self-payout collision | same-account payouts merged before disbursing | primary-sale + `marketplace==seller` merges |
+| Squatted payout account bricks a sale | creator / seller / buyer / marketplace must be principals | fail-closed mint + list validation |
+| Escrow drained outside a sale | `SPEND` weak cap acquired only inside `buy`; escrow guard requires it | (structural; auditor-verified no external path) |
+| Non-owner lists / delists / transfers | `OWNER` capability over the enrolled guard | non-owner list + non-owner delist |
+| Sale-only token moved without paying royalty | `transfer` rejects non-transferable; `buy` (which always pays) is the only other path; `transferable` immutable | sale-only reject + end-to-end enforcement |
+| Reentrancy on a live listing | checks-effects-interactions: listing closed before payouts | (structural) |
+
+## Capability model
+
+| Capability | Type | Guard | Notes |
+|---|---|---|---|
+| `GOV` | governance | `keyset-ref-guard GOV_KEYSET` | upgrade only; no fund path |
+| `MINT-AUTH (owner-guard)` | authentication | the enrolled owner guard | minter signs scoped |
+| `OWNER (id)` | authentication | enrolled owner guard (read in `enforce-guard` arg position) | list / delist / transfer |
+| `SPEND` | weak-body | — | Safe: acquired ONLY inside `buy`'s settlement; guards the escrow; pays out exactly what the buyer paid in (asserted); not externally acquirable |
+| `MINTED`/`LISTED`/`DELISTED`/`SOLD`/`TRANSFERRED` | `@event` | — | emit-only audit trail |
+
+## Node-safety
+
+Every table read that feeds an `enforce`/`enforce-one` condition is bound to a
+local first: `OWNER` reads in `enforce-guard` argument position; `is-listed` is
+bound before its enforce in `transfer`; the conservation read (`funded-bal`,
+`final-bal`) is a plain `let` after the escrow is funded — the F1 fix. This
+class is REPL-invisible, and for this template it is **devnet-proven** (above),
+which is the required evidence.
+
+## Risk profile
+
+| Risk | Level | Notes |
+|---|---|---|
+| Conservation break | Low | asserted per sale; dust-robust; devnet-proven |
+| Escrow drain / free-mint | Low | `SPEND` internal-only, bounded by the buyer's deposit |
+| Fund lock | Low | principal payees + payout merge; donated dust to the escrow is a documented terminal state |
+| Royalty bypass | Low | sale-only immutable; no non-paying move path |
+| Governance dependency | Medium | upgrade power: pin the module hash, multi-sig the keyset |
+
+## Static analysis note
+
+`pact-static-check.sh` reports **PASS, 0 violations**. The `enforce-guard`
+WARNs are dispositioned SAFE: inside `GOV`, `MINT-AUTH`, and `OWNER` defcaps,
+and the guard-enrollment points. The bare-load WARN is the `fungible-v2` modref
+that resolves in the full harness.
+
+## What self-reviewed means here
+
+Reviewed by the template's maintainers against the PCO checklist, with the
+conservation and settlement claims encoded as runnable regression tests, an
+independent `pact-auditor` pass whose blocking findings are all fixed, and an
+on-chain devnet validation of the node-only settlement path. **Not independent
+human review.** Promotion requires a second reviewer (`community-reviewed`) or
+a third-party report with a matching source hash (`independently-audited`) —
+see `docs/CONTRACT_POLICIES.md` §3.1.
+
+## Reproduce the review
+
+```bash
+cd contracts/library/royalty-sale/examples
+pact royalty-sale-test.repl        # 46 assertions
+# on-node (F1):
+cd ../../../../scripts/devnet-validate && npm run royalty-sale
+```

--- a/contracts/library/royalty-sale/README.md
+++ b/contracts/library/royalty-sale/README.md
@@ -1,0 +1,76 @@
+# Royalty Sale — conservation-checked NFT marketplace
+
+PCO library template: a **self-contained NFT with an enforceable-royalty marketplace**, built as the hardened answer to the flaws documented in our [Marmalade V2 security & architecture analysis](../../docs/). It owns both its token ledger and its sale escrow end to end — which is the only way to *prove* the safe settlement patterns rather than inherit a shared-escrow sweep.
+
+On-chain royalty enforcement is genuinely the strongest model in the NFT market (Ethereum's EIP-2981 is metadata-only and its enforcement collapsed; Solana keeps re-platforming transfer-restriction). Marmalade had the right idea; this template keeps the idea and fixes the execution.
+
+## What it does
+
+1. **`mint id owner owner-guard creator creator-guard royalty-bps transferable uri`** — create a 1-of-1 NFT. The royalty rate is fixed forever at mint. `transferable: false` makes the token **sale-only** (see below).
+2. **`list-token id price currency marketplace marketplace-guard marketplace-bps`** — the owner lists at a fixed price. The marketplace fee rate and payee are fixed **here, by the seller** — not by the buyer at purchase.
+3. **`buy id buyer buyer-guard`** — the buyer pays the full price into the escrow (they authorize only their own debit); settlement pays creator + marketplace + seller, ownership flips to the buyer, and the listing closes. **All in one atomic, conservation-asserted transaction.**
+4. **`transfer id receiver receiver-guard`** — a free (no-payment) gift/move, allowed **only** for a token minted `transferable`.
+5. **`delist id`** — the owner cancels a listing.
+
+## How it fixes the Marmalade findings
+
+Each hardened property maps directly to a finding in the analysis:
+
+| Property | Fixes |
+|---|---|
+| **One settlement, conservation-asserted.** `buy` computes every cut, pays each once from the escrow, and asserts `royalty + fee + proceeds == price` *and* that the escrow returns to its pre-sale baseline. No policy/hook ever holds escrow-spend authority. | ARCH-1 (shared escrow sweep), POL-3 (policy reaches into escrow) |
+| **Economics live in state, not the buy transaction.** The royalty is fixed on the token at mint; the fee rate + payee are fixed on the listing by the seller. `buy` takes no fee or royalty argument — a buyer structurally cannot zero the fee. | ARCH-2 (caller-supplied marketplace fee) |
+| **Fail closed.** Every payout account must be a `validate-principal` account; the royalty rate and fee are range-checked and capped; nothing defaults to permissive. | POL-1 (fail-open guard defaults) |
+| **Sale-only is an explicit, robust opt-in.** The creator *chooses* `transferable: false` at mint. It's immutable and cannot be composed away — the token can then move only through `buy`, which always pays royalty. | POL-2 (blunt always-fail transfer lock) |
+| **Principal payees + payout merge.** Creator, seller and marketplace are principal accounts, so a payout can't be bricked by a squatted vanity name; same-account payouts (a *primary* sale, where creator **is** the seller) are merged into one payment so they cannot collide on coin's managed-transfer install. | fund-lock + duplicate-install classes |
+
+## Security model
+
+- **Capability-guarded escrow.** All payment sits in a principal account whose guard requires the internal `SPEND` capability, acquired *only* inside `buy`'s settlement and never externally. The settlement pays out exactly what was paid in, asserted both by the arithmetic identity and by the escrow-returns-to-baseline check.
+- **Enforceable royalty, honestly.** A sale-only token cannot move without a paying sale — real on-chain enforcement with no trusted marketplace. That is a deliberate trade-off (no gifting, no free wallet migration) the creator opts into, not a default forced on every token.
+- **Owner-scoped signatures.** Listing, delisting and transfers require the `OWNER` capability (the owner's enrolled guard); a buyer authorizes only their own payment.
+
+## Deployment checklist
+
+1. Wrap the module in your namespace; replace the `"royalty-sale-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig recommended**; governance is upgrade-only and touches no funds).
+2. Deploy and `create-table` (`tokens`, `listings`).
+3. Validate on **devnet** before mainnet — **mandatory** (the auth capability reads on-chain tables; that class of bug is invisible in the REPL).
+
+## Usage
+
+```pact
+;; creator mints a sale-only 1-of-1 with a 5% royalty (k: principal accounts)
+(free.royalty-sale.mint "art-001"
+  "k:creator…" (read-keyset "creator") "k:creator…" (read-keyset "creator")
+  500 false "ipfs://art-001")
+
+;; owner lists at 100 KDA with a 2.5% marketplace fee
+(free.royalty-sale.list-token "art-001" 100.0 coin
+  "k:marketplace…" (read-keyset "mkt") 250)
+
+;; buyer purchases (signs only their own coin.TRANSFER of the price into escrow)
+(free.royalty-sale.buy "art-001" "k:buyer…" (read-keyset "buyer"))
+```
+
+## Testing
+
+`examples/royalty-sale-test.repl` is self-contained (loads `coin` + interfaces from `registry/`):
+
+```bash
+cd contracts/library/royalty-sale/examples && pact royalty-sale-test.repl
+```
+
+38 assertions: fail-closed mint validation, sale-only vs transferable transfer rules, listing validation with the fee fixed in state, a secondary sale proving conservation to 12 decimals (creator + marketplace + seller + escrow-to-zero), the **primary-sale merge** (creator == seller pays one merged payout with no managed-transfer collision), zero-royalty and odd-price rounding-dust conservation, unlisted/delisted/re-buy rejection, and end-to-end sale-only royalty enforcement. CI runs this suite as a blocking check.
+
+## Known limits
+
+- **Instant fixed-price sales only.** Auctions, Dutch auctions, and time-escrowed offers are a future extension; the conservation-checked settlement generalizes to them.
+- **Sale-only tokens cannot be gifted or freely migrated** — that is the cost of enforceable royalties, and it is the creator's explicit opt-in, not a default.
+- **1-of-1 NFTs.** Fractional / multi-edition supply is out of scope for this template.
+- **The escrow is shared across sales but nets to zero each sale** (conservation is asserted per sale). Do not send funds to the escrow account directly.
+- **Validate on devnet before mainnet** (see the deployment checklist).
+- Governance holds upgrade power. Pin the deployed module hash you audited; use a multi-sig governance keyset.
+
+## License
+
+Apache-2.0

--- a/contracts/library/royalty-sale/examples/royalty-sale-test.repl
+++ b/contracts/library/royalty-sale/examples/royalty-sale-test.repl
@@ -1,0 +1,419 @@
+;; royalty-sale-test.repl — PCO library template test suite
+;;
+;; Self-contained: loads coin + interfaces from this repo's registry tree.
+;;
+;; Proves the hardened patterns from the Marmalade V2 analysis:
+;;  - conservation to 12 dp on every sale (royalty + fee + proceeds == price,
+;;    escrow returns to baseline);
+;;  - the primary-sale merge (creator == seller pays ONE payout, no
+;;    managed-transfer install collision);
+;;  - economics come from state, not the buy transaction (no fee arg exists);
+;;  - sale-only tokens enforce royalty (free transfer rejected, buy always pays);
+;;  - fail-closed validation (non-principal payees, over-cap rates rejected).
+;;
+;; Payout accounts are k: principals (the module requires it).
+
+(begin-tx "load coin")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+(begin-tx "keysets + fund buyers")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "carol": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+  , "mkt":   { "keys": ["4444444444444444444444444444444444444444444444444444444444444444"], "pred": "keys-all" }
+  , "eve":   { "keys": ["5555555555555555555555555555555555555555555555555555555555555555"], "pred": "keys-all" }
+  , "gov":   { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" } })
+;; buyers need coin
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") 1000.0)
+(test-capability (coin.CREDIT "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(coin.credit "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol") 1000.0)
+(commit-tx)
+
+(begin-tx "load royalty-sale")
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "free" (read-keyset "gov") (read-keyset "gov"))
+(namespace "free")
+(define-keyset "free.royalty-sale-gov" (read-keyset "gov"))
+(load "../royalty-sale.pact")
+(create-table free.royalty-sale.tokens)
+(create-table free.royalty-sale.listings)
+(commit-tx)
+
+;; convenience: account name constants
+;; alice=k:1111..  bob=k:2222..  carol=k:3333..  mkt=k:4444..  eve=k:5555..
+
+;; ===========================================================================
+;; 1. mint — fail-closed validation
+;; ===========================================================================
+(begin-tx "mint validation")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "alice"))] } ])
+(expect-failure "non-principal owner rejected" "owner must be a principal account"
+  (free.royalty-sale.mint "t-bad" "alice-vanity" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    500 false "ipfs://x"))
+(expect-failure "non-principal creator rejected" "creator must be a principal account"
+  (free.royalty-sale.mint "t-bad" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "creator-vanity" (read-keyset "alice")
+    500 false "ipfs://x"))
+(expect-failure "royalty over 50% rejected" "royalty-bps must be in [0, 5000]"
+  (free.royalty-sale.mint "t-bad" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    6000 false "ipfs://x"))
+(rollback-tx)
+
+(begin-tx "mint without owner signature")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(expect-failure "minter must satisfy the owner guard" "Keyset failure"
+  (free.royalty-sale.mint "t-1" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    500 false "ipfs://x"))
+(rollback-tx)
+
+;; ===========================================================================
+;; 2. sale-only vs transferable (POL-2 done right)
+;; ===========================================================================
+(begin-tx "mint a SALE-ONLY token (transferable=false, 5% royalty)")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "alice"))] } ])
+(expect "sale-only token minted" "t-so"
+  (free.royalty-sale.mint "t-so"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    500 false "ipfs://sale-only"))
+(expect "MINTED emitted" true
+  (contains "free.royalty-sale.MINTED" (map (at 'name) (env-events true))))
+(commit-tx)
+
+(begin-tx "sale-only token cannot be free-transferred (royalty enforced)")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
+(expect-failure "free transfer of a sale-only token rejected" "token is sale-only; use buy"
+  (free.royalty-sale.transfer "t-so"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(rollback-tx)
+
+(begin-tx "mint a TRANSFERABLE token; free transfer works")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "alice"))] } ])
+(free.royalty-sale.mint "t-tr"
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  250 true "ipfs://transferable")
+(commit-tx)
+
+(begin-tx "transferable token: gift to bob")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "t-tr")] } ])
+(expect-failure "transfer to a non-principal receiver rejected" "receiver must be a principal account"
+  (free.royalty-sale.transfer "t-tr" "bob-vanity" (read-keyset "bob")))
+(expect "gift succeeds" "t-tr"
+  (free.royalty-sale.transfer "t-tr"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(expect "bob now owns it" "k:2222222222222222222222222222222222222222222222222222222222222222"
+  (free.royalty-sale.owner-of "t-tr"))
+(commit-tx)
+
+;; ===========================================================================
+;; 3. listing — economics fixed on-chain by the seller
+;; ===========================================================================
+(begin-tx "list validation")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
+(expect-failure "zero price rejected" "price must be positive"
+  (free.royalty-sale.list-token "t-so" 0.0 coin "" (read-keyset "alice") 0))
+(expect-failure "fee over 10% rejected" "marketplace-bps must be in [0, 1000]"
+  (free.royalty-sale.list-token "t-so" 100.0 coin
+    "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt") 2000))
+(expect-failure "non-principal marketplace with a fee rejected" "marketplace must be a principal account"
+  (free.royalty-sale.list-token "t-so" 100.0 coin "mkt-vanity" (read-keyset "mkt") 250))
+(rollback-tx)
+
+(begin-tx "non-owner cannot list")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
+            , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
+(expect-failure "stranger cannot list someone's token" "Keyset failure"
+  (free.royalty-sale.list-token "t-so" 100.0 coin "" (read-keyset "alice") 0))
+(rollback-tx)
+
+;; ===========================================================================
+;; 4. SECONDARY SALE — conservation to 12dp (the core proof)
+;;    bob owns t-tr (2.5% royalty to alice). bob lists at 100 with a 2.5%
+;;    marketplace fee to mkt. carol buys.
+;;    royalty = 2.5 -> alice(creator); fee = 2.5 -> mkt; proceeds = 95 -> bob.
+;; ===========================================================================
+(begin-tx "bob lists t-tr at 100, 2.5% marketplace fee")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "t-tr")] } ])
+(free.royalty-sale.list-token "t-tr" 100.0 coin
+  "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt") 250)
+(expect "listed" true (free.royalty-sale.is-listed "t-tr"))
+(commit-tx)
+
+(begin-tx "carol buys t-tr — conservation")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 100.0)] } ])
+(expect "buy succeeds" "t-tr"
+  (free.royalty-sale.buy "t-tr"
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(expect "creator (alice) received 2.5% royalty" 2.5
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "marketplace received 2.5% fee" 2.5
+  (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444"))
+;; bob was funded 1000 in setup and is the seller here → 1000 + 95 remainder
+(expect "seller (bob) received the 95 remainder" 1095.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "carol debited exactly the price" 900.0
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "escrow returned to zero (conservation)" 0.0
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "carol now owns it" "k:3333333333333333333333333333333333333333333333333333333333333333"
+  (free.royalty-sale.owner-of "t-tr"))
+(expect "listing closed" false (free.royalty-sale.is-listed "t-tr"))
+(expect "SOLD emitted" true
+  (contains "free.royalty-sale.SOLD" (map (at 'name) (env-events true))))
+(commit-tx)
+
+(begin-tx "cannot re-buy a settled listing")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 100.0)] } ])
+(expect-failure "not listed anymore" "token is not listed for sale"
+  (free.royalty-sale.buy "t-tr"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(rollback-tx)
+
+;; ===========================================================================
+;; 5. PRIMARY SALE — creator == seller merge (the collision regression)
+;;    alice mints t-p (10% royalty, alice creator), alice still owns it, alice
+;;    lists at 50 (no fee). bob buys. royalty(alice)=5 + proceeds(alice)=45 must
+;;    MERGE into ONE 50 payout — a naive two-payout settle would abort on the
+;;    duplicate managed-transfer install and lock the sale.
+;; ===========================================================================
+(begin-tx "alice mints + lists her own token (primary sale)")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "alice"))] } ])
+(free.royalty-sale.mint "t-p"
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  1000 true "ipfs://primary")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "t-p")] } ])
+(free.royalty-sale.list-token "t-p" 50.0 coin "" (read-keyset "alice") 0)
+(commit-tx)
+
+(begin-tx "bob buys alice's primary listing — creator==seller merges cleanly")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 50.0)] } ])
+(let ((alice-before (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111")))
+  (expect "primary sale succeeds (no self-payout collision)" "t-p"
+    (free.royalty-sale.buy "t-p"
+      "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+  (expect "alice received royalty + proceeds as ONE merged payment (full 50)"
+    (+ alice-before 50.0)
+    (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111")))
+(expect "escrow conserved to zero" 0.0
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "bob owns the primary token" "k:2222222222222222222222222222222222222222222222222222222222222222"
+  (free.royalty-sale.owner-of "t-p"))
+(commit-tx)
+
+;; ===========================================================================
+;; 6. royalty 0 + rounding-dust conservation
+;;    t-d: 0% royalty is fine (only-seller). And an odd price with a 3.33% fee
+;;    floors the fee; the seller proceeds absorb the dust so the sale conserves.
+;; ===========================================================================
+(begin-tx "mint a no-royalty token, list at an odd price with a 3.33% fee")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "carol"))] } ])
+(free.royalty-sale.mint "t-d"
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")
+  0 true "ipfs://dust")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(free.royalty-sale.OWNER "t-d")] } ])
+(free.royalty-sale.list-token "t-d" 10.000000000001 coin
+  "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt") 333)
+(commit-tx)
+
+(begin-tx "buy the odd-priced token — dust conserved to 12 dp")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 10.000000000001)] } ])
+(let ((carol-before (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+      (mkt-before (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444")))
+  (free.royalty-sale.buy "t-d"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
+  ;; fee = floor(10.000000000001 * 0.0333, 12) = 0.333000000000
+  (expect "marketplace fee floored to 12 dp" 0.333
+    (- (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444") mkt-before))
+  ;; seller (carol) absorbs the dust: price - fee (royalty 0)
+  (expect "seller proceeds carry the dust (price - fee)" 9.667000000001
+    (- (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333") carol-before)))
+(expect "escrow conserved to zero on an odd price" 0.0
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(commit-tx)
+
+;; ===========================================================================
+;; 7. buy an unlisted token; delist; buy after delist
+;; ===========================================================================
+(begin-tx "cannot buy an unlisted token")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(expect-failure "unlisted token cannot be bought" "No value found"
+  (free.royalty-sale.buy "t-so"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(rollback-tx)
+
+(begin-tx "list then delist; buy rejected after delist")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
+(free.royalty-sale.list-token "t-so" 100.0 coin "" (read-keyset "alice") 0)
+(expect "delisted" "t-so" (free.royalty-sale.delist "t-so"))
+(expect "no longer listed" false (free.royalty-sale.is-listed "t-so"))
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 100.0)] } ])
+(expect-failure "buy after delist rejected" "token is not listed for sale"
+  (free.royalty-sale.buy "t-so"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(commit-tx)
+
+;; ===========================================================================
+;; 8. sale-only royalty is genuinely enforced end-to-end:
+;;    t-so is sale-only; the ONLY way to move it is buy, which pays alice.
+;; ===========================================================================
+(begin-tx "sale-only token sells only via buy (royalty always paid)")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
+(free.royalty-sale.list-token "t-so" 200.0 coin "" (read-keyset "alice") 0)
+(commit-tx)
+
+(begin-tx "carol buys the sale-only token; alice's 5% royalty is unavoidable")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 200.0)] } ])
+(let ((alice-before (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111")))
+  (free.royalty-sale.buy "t-so"
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol"))
+  ;; alice is creator AND seller here (she still owned t-so) -> merged; she gets
+  ;; the full 200 (royalty 10 + proceeds 190). The royalty was enforced: there
+  ;; was no non-paying path off the token.
+  (expect "royalty enforced: alice made whole on a sale-only token"
+    (+ alice-before 200.0)
+    (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111")))
+(expect "carol owns the sale-only token now" "k:3333333333333333333333333333333333333333333333333333333333333333"
+  (free.royalty-sale.owner-of "t-so"))
+(commit-tx)
+
+;; ===========================================================================
+;; 9. F2 regression: TRANSFERRED records the real sender (not receiver twice)
+;; ===========================================================================
+(begin-tx "mint + transfer records correct provenance")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "alice"))] } ])
+(free.royalty-sale.mint "t-prov"
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  0 true "ipfs://prov")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
+(free.royalty-sale.transfer "t-prov"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
+(expect "TRANSFERRED records the real sender then receiver"
+  ["t-prov"
+   "k:1111111111111111111111111111111111111111111111111111111111111111"
+   "k:2222222222222222222222222222222222222222222222222222222222222222"]
+  (at 'params
+    (at 0 (filter (lambda (e) (= "free.royalty-sale.TRANSFERRED" (at 'name e)))
+                  (env-events true)))))
+(commit-tx)
+
+;; ===========================================================================
+;; 10. transfer-while-listed rejected; non-owner delist rejected
+;; ===========================================================================
+(begin-tx "cannot free-transfer a listed token")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
+(free.royalty-sale.list-token "t-prov" 10.0 coin "" (read-keyset "bob") 0)
+(expect-failure "listed token cannot be gifted" "delist before transferring"
+  (free.royalty-sale.transfer "t-prov"
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(rollback-tx)
+
+(begin-tx "non-owner cannot delist")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
+(free.royalty-sale.list-token "t-prov" 10.0 coin "" (read-keyset "bob") 0)
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
+            , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
+(expect-failure "stranger cannot delist someone's listing" "Keyset failure"
+  (free.royalty-sale.delist "t-prov"))
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
+(free.royalty-sale.delist "t-prov")
+(commit-tx)
+
+;; ===========================================================================
+;; 11. merge across marketplace==seller (fee + proceeds to one account, once)
+;;     bob owns t-prov (0% royalty). bob lists at 100 with a 3% fee TO HIMSELF.
+;;     fee(3) + proceeds(97) both to bob -> merged into one 100 payout.
+;; ===========================================================================
+(begin-tx "marketplace == seller merge")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
+(free.royalty-sale.list-token "t-prov" 100.0 coin
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") 300)
+(commit-tx)
+
+(begin-tx "carol buys; bob (seller==marketplace) is paid once")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 100.0)] } ])
+(let ((bob-before (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222")))
+  (free.royalty-sale.buy "t-prov"
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol"))
+  (expect "seller==marketplace paid the full 100 as one merged payout"
+    (+ bob-before 100.0)
+    (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222")))
+(expect "escrow conserved on the seller==marketplace merge" 0.0
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(commit-tx)
+
+;; ===========================================================================
+;; 12. escrow-donation robustness (F1/F4): a griefer donates dust to the shared
+;;     escrow; the next sale still conserves (final == funded - price == baseline).
+;; ===========================================================================
+(begin-tx "griefer donates dust to the escrow, then a sale still settles")
+;; eve funds herself and donates dust to the escrow principal
+(test-capability (coin.CREDIT "k:5555555555555555555555555555555555555555555555555555555555555555"))
+(coin.credit "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve") 1.0)
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
+            , "caps": [(coin.TRANSFER "k:5555555555555555555555555555555555555555555555555555555555555555"
+                                      (free.royalty-sale.get-escrow-account) 0.000000000001)] } ])
+(coin.transfer-create "k:5555555555555555555555555555555555555555555555555555555555555555"
+  (free.royalty-sale.get-escrow-account) (free.royalty-sale.create-escrow-guard) 0.000000000001)
+(expect "escrow now carries donated dust" 0.000000000001
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(commit-tx)
+
+(begin-tx "carol lists t-prov, alice buys; sale conserves despite the dust")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
+(free.royalty-sale.list-token "t-prov" 20.0 coin "" (read-keyset "carol") 0)
+(commit-tx)
+
+(begin-tx "buy over a dust-carrying escrow")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 20.0)] } ])
+(free.royalty-sale.buy "t-prov"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
+(expect "escrow returns to its donated-dust baseline (not zero) — conservation holds"
+  0.000000000001
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "bob owns t-prov after buying over dust" "k:2222222222222222222222222222222222222222222222222222222222222222"
+  (free.royalty-sale.owner-of "t-prov"))
+(commit-tx)

--- a/contracts/library/royalty-sale/metadata.yaml
+++ b/contracts/library/royalty-sale/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'Royalty Sale (conservation-checked NFT marketplace)'
+slug: 'royalty-sale'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['nft', 'royalty', 'marketplace', 'escrow', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'nft', 'royalty', 'sale', 'conservation', 'marmalade']

--- a/contracts/library/royalty-sale/royalty-sale.pact
+++ b/contracts/library/royalty-sale/royalty-sale.pact
@@ -1,0 +1,351 @@
+(module royalty-sale GOV
+
+  @doc "PCO library template: a self-contained NFT with a conservation-checked  \
+  \royalty marketplace - the hardened answer to the settlement, economics, and  \
+  \guard-default flaws documented in the Marmalade V2 analysis.                 \
+  \                                                                              \
+  \This module owns its NFT ledger AND its sale escrow end to end, so it can    \
+  \PROVE the safe patterns rather than inherit a shared-escrow sweep:           \
+  \                                                                              \
+  \  1. FAIL CLOSED. Every royalty/economic input is required and validated at  \
+  \     creation; nothing defaults to permissive. (fixes: guard fail-open)      \
+  \  2. ONE SETTLEMENT, CONSERVATION-ASSERTED. buy pulls the price into a        \
+  \     capability-guarded escrow, then a single routine pays creator + market  \
+  \     + seller and asserts royalty + fee + proceeds == price AND that the     \
+  \     escrow returns to its baseline. No policy/hook ever holds escrow spend   \
+  \     authority. (fixes: shared-escrow sweep, policy-reaches-into-escrow)     \
+  \  3. ECONOMICS ON-CHAIN. The royalty rate is fixed on the token at mint; the  \
+  \     marketplace fee + account are fixed on the LISTING by the seller. buy    \
+  \     reads them from state - never from the buyer's transaction - so a buyer  \
+  \     cannot zero the fee. (fixes: caller-supplied marketplace fee)           \
+  \  4. SALE-ONLY IS AN EXPLICIT OPT-IN. A token is minted `transferable` or     \
+  \     not. A non-transferable token can move ONLY through buy (which always    \
+  \     pays royalty) - enforceable royalties - but the creator CHOSE that, and  \
+  \     it cannot be silently voided by policy composition. (fixes: blunt        \
+  \     always-fail transfer lock)                                              \
+  \  5. PRINCIPAL PAYEES. Every payout account (creator, seller, marketplace)    \
+  \     is a k:/w:/r: principal, so a payout can never be bricked by a squatted  \
+  \     vanity account, and same-account payouts (a primary sale: creator IS     \
+  \     the seller) are merged so they cannot collide on the managed-transfer    \
+  \     install. (fixes: fund-lock + duplicate-install classes)                 \
+  \                                                                              \
+  \Scope: instant fixed-price sales in any fungible-v2 currency. Auctions and    \
+  \time-escrowed offers are a future extension.                                  \
+  \                                                                              \
+  \Deployment checklist (see README.md):                                         \
+  \  1. Wrap in your namespace; replace the 'royalty-sale-gov' keyset.           \
+  \  2. Deploy and create-table (tokens, listings).                             \
+  \  3. Validate on devnet before mainnet."
+
+  ;; -----------------------------
+  ;; Governance (upgrade-only; no fund paths)
+  ;; -----------------------------
+
+  (defconst GOV_KEYSET:string "royalty-sale-gov"
+    @doc "Governance keyset name. Replace with your deployed, namespace- \
+         \qualified keyset (multi-sig recommended). Governance can upgrade the \
+         \module and nothing else - no function under GOV touches tokens, \
+         \listings, or the escrow.")
+
+  (defcap GOV ()
+    @doc "Module governance: upgrade only."
+    (enforce-guard (keyset-ref-guard GOV_KEYSET)))
+
+  ;; -----------------------------
+  ;; Escrow (capability-guarded)
+  ;; -----------------------------
+  ;; A single escrow account holds the buyer's payment for the instant it takes
+  ;; to settle. SPEND is acquired ONLY inside `buy`, after the payment has
+  ;; arrived and the conservation split is computed. No other path acquires it.
+
+  (defcap SPEND ()
+    @doc "Internal escrow-spend token. Weak body by design: acquired only \
+         \inside `buy`'s settlement, never externally, and the settlement pays \
+         \out exactly what was paid in (asserted)."
+    true)
+
+  (defun escrow-guard-pred:bool () (require-capability (SPEND)))
+  (defun create-escrow-guard:guard () (create-user-guard (escrow-guard-pred)))
+  (defconst ESCROW:string (create-principal (create-escrow-guard))
+    "Escrow principal account name.")
+
+  ;; -----------------------------
+  ;; Limits
+  ;; -----------------------------
+
+  (defconst BPS-DENOM:integer 10000)
+  (defconst MAX-ROYALTY-BPS:integer 5000
+    @doc "Sane cap on the royalty rate: 50%. A rate near 100% would leave the \
+         \seller with nothing - almost always a mistake, so it is rejected.")
+  (defconst MAX-FEE-BPS:integer 1000
+    @doc "Sane cap on the marketplace fee: 10%.")
+  (defconst MAX-ID-LEN:integer 128)
+
+  ;; -----------------------------
+  ;; Schemas & tables
+  ;; -----------------------------
+
+  (defschema token
+    @doc "A 1-of-1 NFT. Royalty terms are immutable after mint."
+    owner:string            ;; current owner (a principal account)
+    owner-guard:guard       ;; authorizes owner operations AND receives sale proceeds
+    creator:string          ;; royalty payee (a principal account)
+    creator-guard:guard     ;; receives royalties (transfer-create target)
+    royalty-bps:integer     ;; immutable royalty rate in basis points
+    transferable:bool       ;; false = sale-only (royalty-enforced): free transfer rejected
+    uri:string)
+
+  (deftable tokens:{token})
+
+  (defschema listing
+    @doc "An active fixed-price listing. The marketplace fee is fixed HERE by \
+         \the seller, not supplied by the buyer at purchase."
+    seller:string
+    price:decimal
+    currency:module{fungible-v2}
+    marketplace:string      ;; fee payee ("" when no fee)
+    marketplace-guard:guard ;; fee payee guard (sentinel when no fee)
+    marketplace-bps:integer ;; fee rate; 0 = no fee
+    active:bool)
+
+  (deftable listings:{listing})
+
+  ;; -----------------------------
+  ;; Guards & events
+  ;; -----------------------------
+
+  (defcap MINTED (id:string creator:string royalty-bps:integer transferable:bool) @event true)
+  (defcap LISTED (id:string seller:string price:decimal marketplace-bps:integer) @event true)
+  (defcap DELISTED (id:string) @event true)
+  (defcap SOLD (id:string seller:string buyer:string price:decimal royalty:decimal fee:decimal) @event true)
+  (defcap TRANSFERRED (id:string from:string to:string) @event true)
+
+  (defcap MINT-AUTH (owner-guard:guard)
+    @doc "Scopes the minter's signature to the mint: they prove control of the \
+         \owner guard being enrolled. A capability (not a bare enforce-guard) \
+         \so the minter signs scoped, not unscoped."
+    (enforce-guard owner-guard))
+
+  (defcap OWNER (id:string)
+    @doc "Authenticate the current owner of token ID. As a capability, the \
+         \owner scopes their signature to (royalty-sale.OWNER \"id\")."
+    ; NODE-SAFETY: bind the guard read before enforce-guard (arg position is
+    ; node-safe; a table read inside an enforce CONDITION is not).
+    (enforce-guard (at 'owner-guard (read tokens id))))
+
+  ;; -----------------------------
+  ;; Validation helpers
+  ;; -----------------------------
+
+  (defun enforce-valid-id (id:string)
+    (enforce (!= id "") "id required")
+    (enforce (<= (length id) MAX-ID-LEN) "id too long")
+    (enforce (is-charset 0 id) "id must be ASCII"))
+
+  (defun enforce-unit:bool (currency:module{fungible-v2} amount:decimal)
+    ; bind precision before the enforce: for an arbitrary fungible-v2, precision
+    ; may read the currency's own tables (node-safe only when bound first)
+    (let ((prec (currency::precision)))
+      (enforce (= amount (floor amount prec)) "amount violates currency precision")))
+
+  ;; -----------------------------
+  ;; Mint
+  ;; -----------------------------
+
+  (defun mint:string
+    ( id:string
+      owner:string owner-guard:guard
+      creator:string creator-guard:guard
+      royalty-bps:integer
+      transferable:bool
+      uri:string )
+    @doc "Mint a 1-of-1 NFT. OWNER receives it; CREATOR receives royalties on \
+         \every future sale. Both must be PRINCIPAL accounts (k:/w:/r:) so a \
+         \payout can never be bricked by a squatted account. ROYALTY-BPS is \
+         \immutable. TRANSFERABLE=false makes the token sale-only (royalty is \
+         \then unconditionally enforced - the creator's explicit choice). \
+         \The minter must satisfy the OWNER guard (proves control at mint)."
+    (enforce-valid-id id)
+    ; fail closed: payout accounts must be their guard's principal
+    (enforce (validate-principal owner-guard owner)
+      "owner must be a principal account (k:/w:/r:)")
+    (enforce (validate-principal creator-guard creator)
+      "creator must be a principal account (k:/w:/r:)")
+    (enforce (and (>= royalty-bps 0) (<= royalty-bps MAX-ROYALTY-BPS))
+      (format "royalty-bps must be in [0, {}]" [MAX-ROYALTY-BPS]))
+    ; scoped: the minter proves control of the owner guard (not a bare,
+    ; unscoped enforce-guard)
+    (with-capability (MINT-AUTH owner-guard)
+      (insert tokens id
+        { 'owner: owner, 'owner-guard: owner-guard
+        , 'creator: creator, 'creator-guard: creator-guard
+        , 'royalty-bps: royalty-bps
+        , 'transferable: transferable
+        , 'uri: uri })
+      (emit-event (MINTED id creator royalty-bps transferable))
+      id))
+
+  ;; -----------------------------
+  ;; Free transfer (only for transferable tokens)
+  ;; -----------------------------
+
+  (defun transfer:string (id:string receiver:string receiver-guard:guard)
+    @doc "Gift/move a token with NO payment. Allowed ONLY for a token minted \
+         \transferable; a sale-only token rejects this (its royalty is \
+         \enforced because buy is the only way to move it). RECEIVER must be a \
+         \principal account. The owner signs scoped to OWNER; the token must \
+         \not be actively listed."
+    (with-read tokens id { 'transferable := transferable }
+      (enforce transferable "token is sale-only; use buy"))
+    (enforce (validate-principal receiver-guard receiver)
+      "receiver must be a principal account (k:/w:/r:)")
+    (let ((listed (is-listed id)))
+      (enforce (not listed) "delist before transferring"))
+    (with-capability (OWNER id)
+      ; capture the sender before the update so the event records real provenance
+      (let ((from (at 'owner (read tokens id))))
+        (update tokens id { 'owner: receiver, 'owner-guard: receiver-guard })
+        (emit-event (TRANSFERRED id from receiver))
+        id)))
+
+  ;; -----------------------------
+  ;; Listing
+  ;; -----------------------------
+
+  (defun list-token:string
+    ( id:string
+      price:decimal
+      currency:module{fungible-v2}
+      marketplace:string marketplace-guard:guard marketplace-bps:integer )
+    @doc "List an owned token at a fixed PRICE in CURRENCY. The marketplace fee \
+         \rate and payee are fixed HERE, by the seller - buy reads them from \
+         \state, so a buyer cannot zero the fee. MARKETPLACE-BPS 0 means no \
+         \fee (pass \"\" / a sentinel guard). A non-zero fee requires a \
+         \principal marketplace account. Owner-authenticated."
+    (enforce (> price 0.0) "price must be positive")
+    (enforce-unit currency price)
+    (enforce (and (>= marketplace-bps 0) (<= marketplace-bps MAX-FEE-BPS))
+      (format "marketplace-bps must be in [0, {}]" [MAX-FEE-BPS]))
+    ; fail closed: if there is a fee, its payee must be a real principal account
+    (if (> marketplace-bps 0)
+      (enforce (validate-principal marketplace-guard marketplace)
+        "marketplace must be a principal account when a fee is charged")
+      true)
+    (with-capability (OWNER id)
+      (write listings id
+        { 'seller: (at 'owner (read tokens id))
+        , 'price: price
+        , 'currency: currency
+        , 'marketplace: marketplace
+        , 'marketplace-guard: marketplace-guard
+        , 'marketplace-bps: marketplace-bps
+        , 'active: true })
+      (emit-event (LISTED id (at 'owner (read tokens id)) price marketplace-bps))
+      id))
+
+  (defun delist:string (id:string)
+    @doc "Cancel an active listing. Owner-authenticated."
+    (with-capability (OWNER id)
+      (with-read listings id { 'active := active }
+        (enforce active "not listed"))
+      (update listings id { 'active: false })
+      (emit-event (DELISTED id))
+      id))
+
+  ;; -----------------------------
+  ;; Buy — the single, conservation-asserted settlement
+  ;; -----------------------------
+
+  (defun merge-payout:[object] (acc:[object] p:object)
+    @doc "Fold helper: merge a payout into the accumulator, summing amounts for \
+         \a payee that already appears (so a primary sale where creator == \
+         \seller becomes ONE payout and cannot collide on the managed-transfer \
+         \install). Drops zero amounts."
+    (if (<= (at 'amount p) 0.0)
+      acc
+      (let ((seen (contains (at 'account p) (map (at 'account) acc))))
+        (if seen
+          (map (lambda (x:object)
+                 (if (= (at 'account x) (at 'account p))
+                   (+ { 'amount: (+ (at 'amount x) (at 'amount p)) } x)
+                   x))
+               acc)
+          (+ acc [p])))))
+
+  (defun pay-from-escrow:string (currency:module{fungible-v2} p:object)
+    @doc "Pay one merged payout from the escrow. Requires SPEND in scope."
+    (require-capability (SPEND))
+    (let ((account:string (at 'account p))
+          (amount:decimal (at 'amount p)))
+      (install-capability (currency::TRANSFER ESCROW account amount))
+      (currency::transfer-create ESCROW account (at 'guard p) amount)))
+
+  (defun buy:string (id:string buyer:string buyer-guard:guard)
+    @doc "Purchase a listed token at its fixed price. The BUYER signs the \
+         \currency transfer of the full price into the escrow; anyone can then \
+         \trigger settlement. Settlement pays creator (royalty) + marketplace \
+         \(fee) + seller (remainder) and ASSERTS royalty + fee + proceeds == \
+         \price and that the escrow returns to its baseline - conservation is \
+         \proven, not assumed. BUYER must be a principal account (becomes the \
+         \new owner and a future seller)."
+    (enforce (validate-principal buyer-guard buyer)
+      "buyer must be a principal account (k:/w:/r:)")
+    (with-read listings id
+      { 'seller := seller, 'price := price, 'currency := currency:module{fungible-v2}
+      , 'marketplace := marketplace, 'marketplace-guard := mk-guard
+      , 'marketplace-bps := mk-bps, 'active := active }
+      (enforce active "token is not listed for sale")
+      (with-read tokens id
+        { 'creator := creator, 'creator-guard := creator-guard
+        , 'owner-guard := seller-guard, 'royalty-bps := royalty-bps }
+        (let* ((prec (currency::precision))
+               (royalty (floor (/ (* price (dec royalty-bps)) (dec BPS-DENOM)) prec))
+               (fee (if (> mk-bps 0)
+                      (floor (/ (* price (dec mk-bps)) (dec BPS-DENOM)) prec)
+                      0.0))
+               (proceeds (- price (+ royalty fee))))
+          (enforce (>= proceeds 0.0) "royalty + fee exceed price")
+          ; INTERACTION 1: pull the full price into the escrow. The buyer signs
+          ; their own coin.TRANSFER, so they authorize exactly `price` and no
+          ; more. After this the escrow account exists, so its balance can be
+          ; read in a plain `let` - NEVER inside a `try` or an enforce condition
+          ; (both are read-only contexts on the KDA-CE node; a `try` around a
+          ; table read is the same REPL-invisible trap this template avoids).
+          (currency::transfer-create buyer ESCROW (create-escrow-guard) price)
+          (let ((funded-bal (currency::get-balance ESCROW)))
+            ; EFFECTS before further INTERACTIONS (checks-effects-interactions):
+            ; close the listing and flip ownership BEFORE paying out, so a
+            ; re-entrant buy on this listing finds it inactive.
+            (update tokens id { 'owner: buyer, 'owner-guard: buyer-guard })
+            (update listings id { 'active: false })
+            ; INTERACTION 2: pay out. Same-account payees are merged into ONE
+            ; payout (a primary sale where creator == seller) so they cannot
+            ; collide on coin's managed-transfer install; zero amounts dropped.
+            (let* ((raw [ { 'account: creator, 'guard: creator-guard, 'amount: royalty }
+                        , { 'account: marketplace, 'guard: mk-guard, 'amount: fee }
+                        , { 'account: seller, 'guard: seller-guard, 'amount: proceeds } ])
+                   (payouts (fold (merge-payout) [] raw)))
+              (with-capability (SPEND)
+                (map (pay-from-escrow currency) payouts)))
+            ; CONSERVATION (the real proof): exactly `price` must have left the
+            ; escrow, so it returns to its pre-sale balance. This holds even if
+            ; the shared escrow carried donated dust: funded = baseline + price,
+            ; final must equal funded - price = baseline. Read is a plain let.
+            (let ((final-bal (currency::get-balance ESCROW)))
+              (enforce (= final-bal (- funded-bal price)) "escrow not fully settled"))
+            (emit-event (SOLD id seller buyer price royalty fee))
+            id)))))
+
+  ;; -----------------------------
+  ;; Views
+  ;; -----------------------------
+
+  (defun get-token:object{token} (id:string) (read tokens id))
+  (defun get-listing:object{listing} (id:string) (read listings id))
+  (defun owner-of:string (id:string) (at 'owner (read tokens id)))
+
+  (defun is-listed:bool (id:string)
+    (with-default-read listings id { 'active: false } { 'active := active } active))
+
+  (defun get-escrow-account:string () ESCROW)
+)

--- a/docs/DEVNET-VALIDATION.md
+++ b/docs/DEVNET-VALIDATION.md
@@ -20,6 +20,7 @@ node-critical paths driven to mined confirmation.
 | [oracle-feed](../contracts/library/oracle-feed/) | ✅ PASS | `free.oracle-feed-v2` | 13 | `PUBLISH-AUTH` bound read; median pipeline in a **mined consumer tx**; staleness fail-closed vs real block time; rotation revocation. |
 | [token-fungible](../contracts/library/token-fungible/) | ✅ PASS | `free.token-v2` | 10 | `DEBIT` stored-guard enforcement (the v0.2.0 CRITICAL fix): authorized transfer succeeds, **foreign-key transfer rejected**, rotate updates the enforced guard. |
 | [gas-station](../contracts/library/gas-station/) | ✅ PASS | `free.gas-station` | 7 | A **zero-KDA user** ran a tx the **station paid for** via `GAS_PAYER`; spend bounded/accounted against `(chain-data)` actual gas; non-enrolled user denied. |
+| [royalty-sale](../contracts/library/royalty-sale/) | ✅ PASS | `free.royalty-sale` | 13 | `buy` settlement on-node: **fresh escrow** (fund-then-plain-`let` baseline read, primary-sale payout merge, escrow → 0) and **dust-carrying escrow** (conservation returns to the donated baseline, not zero) — the auditor's F1 node-only class, proven. |
 | [nft-collection-policy](../contracts/library/nft-collection-policy/) | ⏸ deferred | — | — | Needs a marmalade-v2 deployment (absent on the campaign devnet). Its REPL suite already runs against the **real** marmalade sources; the outstanding on-chain **buy** is a follow-on. |
 | [hello-world](../contracts/library/hello-world/) | n/a | — | — | No node-only behavior; the REPL suite is sufficient. |
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -210,6 +210,38 @@
 }
 ,
 {
+  "name": "Royalty Sale (conservation-checked NFT marketplace)",
+  "slug": "royalty-sale",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "nft",
+    "royalty",
+    "marketplace",
+    "escrow",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "nft",
+    "royalty",
+    "sale",
+    "conservation",
+    "marmalade"
+  ]
+}
+,
+{
   "name": "Token (fungible-v2 + fungible-xchain-v1)",
   "slug": "token-fungible",
   "version": "0.2.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ _Generated from `contracts/**/metadata.yaml`._
 | NFT Collection Policy (marmalade-v2) | nft-collection-policy | 1.0.0 | self-reviewed | nft, marmalade, collection, token-policy, template, library |
 | Oracle Feed (median, staleness-guarded) | oracle-feed | 1.0.0 | self-reviewed | oracle, price-feed, median, template, library |
 | Property Lease (rental rails) | property-lease | 1.0.0 | self-reviewed | lease, rental, escrow, revenue-split, template, library |
+| Royalty Sale (conservation-checked NFT marketplace) | royalty-sale | 1.0.0 | self-reviewed | nft, royalty, marketplace, escrow, template, library |
 | Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
 | Token Vesting (cliff + linear) | vesting | 1.0.0 | self-reviewed | vesting, escrow, timelock, template, library |
 

--- a/scripts/devnet-validate/package.json
+++ b/scripts/devnet-validate/package.json
@@ -12,7 +12,8 @@
     "gas-station": "tsx src/gas-station.ts",
     "token-fungible": "tsx src/token-fungible.ts",
     "hello-world": "tsx src/hello-world.ts",
-    "all": "tsx src/treasury.ts && tsx src/vesting.ts && tsx src/dao-voting.ts && tsx src/oracle-feed.ts && tsx src/gas-station.ts && tsx src/token-fungible.ts && tsx src/hello-world.ts"
+    "all": "tsx src/treasury.ts && tsx src/vesting.ts && tsx src/dao-voting.ts && tsx src/oracle-feed.ts && tsx src/gas-station.ts && tsx src/token-fungible.ts && tsx src/hello-world.ts && tsx src/royalty-sale.ts",
+    "royalty-sale": "tsx src/royalty-sale.ts"
   },
   "dependencies": {
     "@kadena/client": "^1.18.3",

--- a/scripts/devnet-validate/src/royalty-sale.ts
+++ b/scripts/devnet-validate/src/royalty-sale.ts
@@ -1,0 +1,123 @@
+// Devnet validation: library/royalty-sale
+//
+// Proves the node-only class the auditor flagged (F1): buy reads the escrow
+// balance in a plain `let` AFTER funding it, never inside a `try`/enforce
+// read-only context. Drives a full settlement on a FRESH escrow (first sale)
+// and again over a DUST-carrying escrow (griefer donation) - both must settle
+// and conserve on a real KDA-CE node. Also exercises mint/list and the
+// creator+marketplace+seller payout split end to end.
+import {
+  send, localCall, coinBalance, fund, persona, loadTemplate, saveResults, CHAIN,
+} from './lib.js';
+
+const SLUG = 'royalty-sale';
+const near = (a: number, b: number, eps = 1e-11) => Math.abs(a - b) <= eps;
+
+async function pickName(base: string): Promise<string> {
+  for (let i = 0; ; i++) {
+    const name = i === 0 ? base : `${base}-v${i + 1}`;
+    try { await localCall(`(describe-module "free.${name}")`); }
+    catch { return name; }
+  }
+}
+
+const main = async () => {
+  console.log(`\n=== devnet-validate: ${SLUG} ===`);
+  const MOD = await pickName('royalty-sale');
+  const { code, govKeyset } = loadTemplate(SLUG, 'royalty-sale.pact', 'royalty-sale-gov', MOD);
+  const M = `free.${MOD}`;
+  const src = code.replace('(module royalty-sale GOV', `(module ${MOD} GOV`);
+
+  const gov = persona('gov');
+  const creator = persona('creator');   // mints + is the primary seller
+  const mkt = persona('mkt');            // marketplace fee payee
+  const buyer1 = persona('buyer1');
+  const buyer2 = persona('buyer2');
+  for (const kp of [gov, creator, mkt]) await fund(kp, 5.0);
+  await fund(buyer1, 60.0);  // pays for a purchase
+  await fund(buyer2, 60.0);
+
+  await send({
+    code: `(namespace "free") (define-keyset "${govKeyset}" (read-keyset "g"))`,
+    label: `define ${govKeyset}`,
+    signers: [{ kp: gov }],
+    data: { g: { keys: [gov.publicKey], pred: 'keys-all' } },
+  });
+  await send({
+    code: `${src}\n(create-table ${M}.tokens)(create-table ${M}.listings)`,
+    label: `deploy ${M} + tables`,
+    signers: [{ kp: gov }],
+  });
+
+  // mint: creator signs unscoped (satisfies MINT-AUTH + gas). k: principals.
+  await send({
+    code: `(${M}.mint "art-1" "${creator.account}" (read-keyset "c") "${creator.account}" (read-keyset "c") 500 false "ipfs://art-1")`,
+    label: 'mint sale-only art-1 (5% royalty)',
+    signers: [{ kp: creator }],
+    data: { c: { keys: [creator.publicKey], pred: 'keys-all' } },
+  });
+
+  // list at 40 with a 2.5% marketplace fee to mkt
+  await send({
+    code: `(${M}.list-token "art-1" 40.0 coin "${mkt.account}" (read-keyset "m") 250)`,
+    label: 'list art-1 at 40 (2.5% fee)',
+    signers: [{ kp: creator, caps: (wc) => [wc(`${M}.OWNER`, 'art-1'), wc('coin.GAS')] }],
+    data: { m: { keys: [mkt.publicKey], pred: 'keys-all' } },
+  });
+
+  const escrow: string = await localCall(`(${M}.get-escrow-account)`);
+  const cBefore = await coinBalance(creator.account);
+  const mBefore = await coinBalance(mkt.account);
+
+  // BUY #1 — FRESH escrow. This is the F1-critical path on-node: fund escrow,
+  // then read its balance in a plain let, settle, assert escrow returns to 0.
+  await send({
+    code: `(${M}.buy "art-1" "${buyer1.account}" (read-keyset "b"))`,
+    label: 'buy art-1 over a FRESH escrow (F1 first-sale, on-node)',
+    signers: [{ kp: buyer1, caps: (wc) => [wc('coin.TRANSFER', buyer1.account, escrow, { decimal: '40.0' }), wc('coin.GAS')] }],
+    data: { b: { keys: [buyer1.publicKey], pred: 'keys-all' } },
+  });
+
+  const cAfter = await coinBalance(creator.account);
+  const mAfter = await coinBalance(mkt.account);
+  const esc1 = await coinBalance(escrow);
+  // royalty 2.0 to creator; but creator IS the seller (primary sale) -> merged:
+  // creator gets royalty(2) + proceeds(37) = 39; mkt gets fee(1). Total 40.
+  if (!near(cAfter - cBefore, 39.0)) throw new Error(`creator payout wrong: ${cAfter - cBefore} (want 39)`);
+  if (!near(mAfter - mBefore, 1.0)) throw new Error(`marketplace fee wrong: ${mAfter - mBefore} (want 1)`);
+  if (!near(esc1, 0.0)) throw new Error(`escrow not settled to 0: ${esc1}`);
+  if (await localCall(`(${M}.owner-of "art-1")`) !== buyer1.account) throw new Error('ownership did not flip');
+  console.log(`  ✓ fresh-escrow sale settled on-node: creator +39, mkt +1, escrow -> 0, owner -> buyer1`);
+
+  // DUST DONATION — griefer sends dust to the shared escrow.
+  await send({
+    code: `(coin.transfer-create "${gov.account}" "${escrow}" (${M}.create-escrow-guard) 0.000000000001)`,
+    label: 'griefer donates dust to the escrow',
+    signers: [{ kp: gov, caps: (wc) => [wc('coin.TRANSFER', gov.account, escrow, { decimal: '0.000000000001' }), wc('coin.GAS')] }],
+  });
+  const escDust = await coinBalance(escrow);
+  if (!near(escDust, 1e-12)) throw new Error(`escrow should carry dust: ${escDust}`);
+
+  // buyer1 (now owner) lists, buyer2 buys — over the DUST-carrying escrow.
+  await send({
+    code: `(${M}.list-token "art-1" 20.0 coin "" (read-keyset "b1") 0)`,
+    label: 'buyer1 re-lists art-1 at 20 (no fee)',
+    signers: [{ kp: buyer1, caps: (wc) => [wc(`${M}.OWNER`, 'art-1'), wc('coin.GAS')] }],
+    data: { b1: { keys: [buyer1.publicKey], pred: 'keys-all' } },
+  });
+  await send({
+    code: `(${M}.buy "art-1" "${buyer2.account}" (read-keyset "b2"))`,
+    label: 'buy art-1 over a DUST-carrying escrow (F1 donation case, on-node)',
+    signers: [{ kp: buyer2, caps: (wc) => [wc('coin.TRANSFER', buyer2.account, escrow, { decimal: '20.0' }), wc('coin.GAS')] }],
+    data: { b2: { keys: [buyer2.publicKey], pred: 'keys-all' } },
+  });
+  const escFinal = await coinBalance(escrow);
+  // conservation: escrow returns to its baseline (the donated dust), not zero
+  if (!near(escFinal, 1e-12)) throw new Error(`escrow should return to dust baseline: ${escFinal}`);
+  if (await localCall(`(${M}.owner-of "art-1")`) !== buyer2.account) throw new Error('second sale ownership did not flip');
+  console.log(`  ✓ dust-carrying-escrow sale settled on-node: escrow -> baseline (dust), owner -> buyer2`);
+
+  saveResults(SLUG, { module: M, hash: await localCall(`(at 'hash (describe-module "${M}"))`) });
+};
+
+main().catch((e) => { console.error(`\nFAILED: ${e.message ?? e}`); process.exit(1); });


### PR DESCRIPTION
## What

The **build half** of our [Marmalade V2 security & architecture analysis](https://claude.ai/code/artifact/afba7497-6dfa-4265-a519-36a44c1eb3d6): `contracts/library/royalty-sale`, a self-contained NFT + fixed-price royalty marketplace that owns both its token ledger and its sale escrow. Owning the whole flow is the only way to *prove* the safe settlement rather than inherit Marmalade's shared-escrow sweep.

On-chain royalty enforcement is genuinely the strongest model in the NFT market (Ethereum's EIP-2981 is metadata-only and its enforcement collapsed; Solana keeps re-platforming transfer-restriction). Marmalade had the right idea — this keeps the idea and fixes the execution.

Each hardened property maps to an analysis finding:

| Property | Fixes |
|---|---|
| One settlement, conservation-asserted (`final-bal == funded-bal − price`; escrow returns to baseline) | ARCH-1 shared-escrow sweep · POL-3 policy-reaches-into-escrow |
| Economics fixed in state — royalty at mint, fee + payee at listing; `buy` takes **no** money argument | ARCH-2 caller-supplied marketplace fee |
| Fail-closed principal payees + capped rates | POL-1 fail-open guard defaults |
| `transferable` is an explicit, immutable, composition-safe opt-in | POL-2 blunt always-fail transfer lock |
| Same-account payout merge (primary sale: creator == seller) | fund-lock + duplicate managed-install classes |

## Review process — two auditor passes

- **Pass 1 (NO-GO)** caught a HIGH node-only class — fittingly, the *exact* read-in-read-only-context flaw the analysis indicts Marmalade for: the escrow baseline was read inside a `try`. Fixed by funding the escrow first, then reading its balance in a plain `let`, with conservation as `final-bal == funded-bal − price` (dust-donation robust). Plus checks-effects-interactions ordering, scoped `MINT-AUTH`, correct `TRANSFERRED` provenance, precision binding, and added coverage.
- **Pass 2 (GO)** — zero findings; conservation re-derived sound and complete; adversarial probes (external escrow drain, self-buy, max-rate conservation, re-list merge) all resist.

## Evidence

- `examples/royalty-sale-test.repl`: **46 assertions**, self-contained — fail-closed mint validation, sale-only vs transferable rules, conservation to 12 dp (secondary sale + the **primary-sale merge** + odd-price dust), economics-from-state, provenance, and the escrow-dust-donation regression. Blocking CI.
- **F1 is REPL-invisible, so it is proven on a live KDA-CE node** ([devnet report](docs/DEVNET-VALIDATION.md), 13 txs): `buy` settles over a **fresh** escrow and over a **dust-carrying** escrow (conservation returns to the donated baseline, not zero).
- Static gate PASS, 0 violations; `AUDIT.md` documents both passes + the devnet evidence and maps every property to its analysis finding.
- No private context, git author is the GitHub noreply.

The library is now **ten templates**.