### PR TITLE
test(library): full-marketplace economic simulation for royalty-sale

### DIFF
--- a/contracts/library/royalty-sale/AUDIT.md
+++ b/contracts/library/royalty-sale/AUDIT.md
@@ -130,3 +130,8 @@ pact royalty-sale-test.repl        # 46 assertions
 # on-node (F1):
 cd ../../../../scripts/devnet-validate && npm run royalty-sale
 ```
+
+The economic follow-up — a full-marketplace simulation (resale chain,
+multi-currency, adversarial sweep, global conservation) — is documented in
+[SIMULATION.md](SIMULATION.md) (`examples/royalty-sale-market-sim.repl` +
+`npm run royalty-sale-sim`).

--- a/contracts/library/royalty-sale/README.md
+++ b/contracts/library/royalty-sale/README.md
@@ -60,7 +60,9 @@ Each hardened property maps directly to a finding in the analysis:
 cd contracts/library/royalty-sale/examples && pact royalty-sale-test.repl
 ```
 
-38 assertions: fail-closed mint validation, sale-only vs transferable transfer rules, listing validation with the fee fixed in state, a secondary sale proving conservation to 12 decimals (creator + marketplace + seller + escrow-to-zero), the **primary-sale merge** (creator == seller pays one merged payout with no managed-transfer collision), zero-royalty and odd-price rounding-dust conservation, unlisted/delisted/re-buy rejection, and end-to-end sale-only royalty enforcement. CI runs this suite as a blocking check.
+46 assertions: fail-closed mint validation, sale-only vs transferable transfer rules, listing validation with the fee fixed in state, a secondary sale proving conservation to 12 decimals (creator + marketplace + seller + escrow-to-zero), the **primary-sale merge** (creator == seller pays one merged payout with no managed-transfer collision), zero-royalty and odd-price rounding-dust conservation, unlisted/delisted/re-buy rejection, and end-to-end sale-only royalty enforcement. CI runs this suite as a blocking check.
+
+`examples/royalty-sale-market-sim.repl` is the full-marketplace economic simulation (also self-contained, also a blocking CI suite): 149 assertions driving two artists, four collectors, two marketplaces, and an adversary through a 4-hop resale chain (royalty accrues to the original creator on every hop, exactly rate x volume), a sale in a second non-coin fungible-v2 currency, every payout-merge case, a front-run/dust/wash-trade adversarial sweep, global conservation of every unit funded, and an event-log replay of all ownership history. Results in [SIMULATION.md](SIMULATION.md); the on-node counterpart is `scripts/devnet-validate` -> `npm run royalty-sale-sim`.
 
 ## Known limits
 

--- a/contracts/library/royalty-sale/SIMULATION.md
+++ b/contracts/library/royalty-sale/SIMULATION.md
@@ -1,0 +1,179 @@
+# SIMULATION — library/royalty-sale, full-marketplace run
+
+## Summary
+
+| Field | Value |
+|---|---|
+| **Module** | `royalty-sale` 1.0.0 |
+| **Date** | 2026-07-06 |
+| **REPL simulation** | `examples/royalty-sale-market-sim.repl` — 149 assertions (121 positive, 28 adversarial rejections), all green |
+| **Devnet simulation** | `scripts/devnet-validate` → `npm run royalty-sale-sim` — **32 txs mined to confirmation** on a live KDA-CE node (`recap-development`); deployed as `free.royalty-market` (hash `5qDbxh_0Apk86rJ6NU8EbBSFfKDht4d_VmkwrcQJRec`) with `free.sim-tok` as the second currency; request keys in `scripts/devnet-validate/results/royalty-sale-market-sim.json` |
+| **Static gate** | `pact-static-check.sh` PASS, 0 violations |
+| **Verdict** | **HOLDS UP.** Conservation, royalty accrual, fee integrity, and every adversarial rejection proven in the REPL and on-node. No code defect found. |
+
+This is the economic follow-up to `AUDIT.md`: the audit proved the settlement
+is *safe*; this run proves a whole marketplace *works* on it — creation,
+primary sales, a multi-hop secondary market, two competing marketplaces, a
+second currency, gifts, and a hostile user — with every unit of money accounted
+for to 12 decimal places.
+
+## The marketplace that was simulated
+
+Ten participants: two artists (alice, dana), four collectors (bob, carol,
+frank, gina), two marketplaces (mkt1 at 2.5%, mkt2 at 5%), one adversary
+(eve), one governance key. Six tokens spanning the royalty spectrum:
+
+| Token | Creator | Royalty | Transferable | Story |
+|---|---|---|---|---|
+| `gift-0` | alice | 0% | yes | gifted twice (provenance events) |
+| `art-25` | alice | 2.5% | yes | primary sale, creator==seller merge |
+| `chain-1` | alice | 5% | **sale-only** | the headline resale chain (6 sales) |
+| `art-max` | alice | 50% (cap) | yes | list → delist → relist → sale at max royalty |
+| `dna-tok` | dana | 2.5% | yes | sold twice in a **non-coin** fungible-v2 |
+| `fr-1` | **bob** (creator **alice**) | 2.5% | yes | minter ≠ creator; front-run + dust + wash-trade cases |
+
+## Headline: the resale chain
+
+`chain-1` (5% royalty, sale-only) moved creator→A→B→C→D and then twice more,
+through both marketplaces:
+
+| Sale | Seller → Buyer | Price | Fee (bps → payee) | Royalty → alice | Seller nets |
+|---|---|---|---|---|---|
+| S2 | alice → bob | 100.0 | 2.5 (mkt1) | 5.0 | 92.5 (merged with royalty: one 97.5 payout) |
+| S3 | bob → carol | 160.0 | 8.0 (mkt2) | 8.0 | 144.0 |
+| S4 | carol → frank | 80.0 | 2.0 (mkt1) | 4.0 | 74.0 |
+| S5 | frank → gina | 250.0 | — | 12.5 | 237.5 |
+| S6 | gina → bob | 60.0 | 6.0 (**alice as marketplace**) | 3.0 | 51.0 |
+| S7 | bob → carol | 50.0 | 1.5 (**bob as marketplace**) | 2.5 | 46.0 + 1.5 merged |
+
+Proven, both in the REPL and reconstructed from the SOLD event log alone:
+
+- **Royalty on every hop**: cumulative creator royalty over the 4-hop chain is
+  **29.5 == 5% × 590 volume, exactly**; over the token's 6-sale lifetime,
+  **35.0 == 5% × 700, exactly**. The rate travels with the token, not the seller.
+- **Every seller nets price − royalty − fee**, exactly.
+- **Sale-only is airtight**: the free-transfer path was rejected for the
+  creator (before hop 1) and for the owner (after 6 ownership changes). `buy`
+  — which always pays the royalty — is the only way the token ever moved.
+- Payout merges never collide on the managed-transfer install:
+  creator==seller (S2), marketplace==creator (S6), marketplace==seller (S7)
+  each arrive as ONE merged payment.
+
+The devnet run replays the 4-hop chain on-node with fresh personas, plus a
+fifth sale settled over a dust-carrying escrow: 5 sales, 630.0 volume,
+creator royalty **31.5 == 5% × 630** — every settlement mined and conserved
+on a live KDA-CE node.
+
+## Multi-currency (the marketplace is not coin-only)
+
+`dna-tok` sold twice in the library `token-fungible` (a non-coin fungible-v2):
+primary 500.0 TOKEN via mkt2 (dana, creator==seller, merged 475.0; fee 25.0),
+secondary 200.0 TOKEN (royalty 5.0 → dana, proceeds 195.0). Dana's cumulative
+TOKEN royalty: **17.5 == 2.5% × 700**, exact. Token-side escrow settled to 0
+both times; coin balances untouched by token sales. The devnet run repeats
+both sales on-node — the settlement path (dynamic `precision`, managed
+`TRANSFER` install, escrow guard) is node-proven for a second fungible, which
+the original F1 validation (coin-only) did not cover.
+
+## Global accounting (the economics hold)
+
+Coin side — 10 sales, prices summing to **940.0**:
+
+| Aggregate | Value |
+|---|---|
+| Royalties (all to alice — she created every coin-side token) | 55.25 |
+| Marketplace fees (mkt1 5.5, mkt2 9.5, alice-as-mkt 6.0, bob-as-mkt 1.5) | 22.5 |
+| Seller proceeds | 862.25 |
+| **Sum** | **940.0 — every unit the buyers paid in** |
+
+- **Exact final balance of every participant asserted** (alice 215.25,
+  bob 1137.75, carol 713.5, frank 1157.5, gina 801.0, dana 70.0, mkt1 15.5,
+  mkt2 19.5, eve 1.999999999999, escrow 0.000000000001).
+- **Global conservation**: the sum of ALL balances == the 4132.0 funded at
+  setup, to 12 dp — the marketplace neither minted nor destroyed a single
+  unit. Token side: all balances sum to the 1300.0 minted.
+- **Escrow returns to its baseline after every one of the 12 sales**
+  (0 for the first nine; the donated-dust baseline after the griefing case).
+- **Event-log reconstruction**: ownership history replayed from
+  SOLD/TRANSFERRED events alone matches `owner-of` state for all six tokens,
+  and the royalty/fee/volume totals recomputed from events match the balance
+  deltas. (The REPL's event log resets each transaction, so the suite ingests
+  each sale's events into a `sim-indexer` fixture table — exactly what an
+  off-chain indexer does.)
+
+## Adversarial sweep (all rejected, REPL + the starred ones re-proven on-node)
+
+| Attack | Result |
+|---|---|
+| Non-owner lists / delists* / transfers (eve, scoped to `OWNER`) | `Keyset failure` |
+| Broke buyer (balance 2 vs price 40)* | `Insufficient funds` (currency debit) |
+| Buyer under-scopes the price (fee/price evasion — buy has NO money argument) | `TRANSFER exceeded` |
+| **Front-run: seller reprices after the buyer signed*** | buy aborts (`TRANSFER exceeded`); buyer's balance untouched — a buyer can never be made to pay more than they signed |
+| Escrow self-buy (buyer == escrow account) | `sender cannot be the receiver of a transfer` |
+| Non-principal owner / creator / marketplace / receiver / buyer | `… must be a principal account` |
+| Royalty > 50% or negative; fee > 10% or negative | range enforce |
+| Zero / negative / over-precision price | `price must be positive` / precision enforce |
+| Transfer of a listed token; transfer of a sale-only token* | `delist before transferring` / `token is sale-only; use buy` |
+| Re-buy of a settled listing; buy after delist; buy of never-listed id | `token is not listed for sale` / missing row |
+| Duplicate mint of an existing id | insert rejected (1-of-1 holds) |
+| **Escrow dust-griefing*** (donate 1e-12, then sell) | next sale settles; escrow returns to the donated **baseline**, not zero |
+| Wash trade (self-buy at price 20) | allowed but costs the full royalty (0.5 to the creator) — volume faking is not free |
+
+## Gas vs the 150k KDA-CE ceiling
+
+Devnet (node-true, from the 32 mined txs of this simulation — authoritative):
+
+| Operation | Gas (observed) | Headroom vs 150,000 |
+|---|---|---|
+| deploy module + 2 tables (one-time) | 12,440 | 12× |
+| mint | 203 | ~740× |
+| list-token | 327–357 | ~420× |
+| **buy** (7 settlements incl. 3-way splits, non-coin currency, dust baseline) | **704–868** | **~170×** |
+| dust donation (plain transfer-create) | 234 | — |
+| **maximum across the whole run** | **12,440** | **12×** |
+
+REPL table-model figures agree on the ordering (mint 124, list 278, buy 785,
+transfer 256, delist 119). Every mined tx ran under `gasLimit 150000`;
+per-step gas and request keys are recorded in
+`scripts/devnet-validate/results/royalty-sale-market-sim.json`.
+
+## Observations (no code changes required)
+
+1. **`MINTED` does not carry the initial owner** (params: id, creator,
+   royalty-bps, transferable). An indexer can replay every ownership *change*
+   from events, but the owner between mint and first move is only visible via
+   `get-token`. Immaterial to the economics; worth knowing when building an
+   indexer. Similarly, `LISTED`/`SOLD` carry the fee *rate/amount* but not the
+   fee payee account.
+2. **The "(k:/w:/r:)" wording is narrower than the check**: `validate-principal`
+   also admits other principal classes (e.g. `u:`). Any principal's payout
+   still settles correctly (the guard travels with it), so this is
+   documentation looseness, not a hole — the escrow self-buy case proves the
+   interesting instance is rejected by the currency itself.
+3. **Wash trading is possible but taxed**: a self-buy pays the full royalty
+   and fee. On-chain identity cannot prevent Sybil wash trades; the economics
+   at least make them cost `royalty + fee` per fake sale.
+4. **Rounding favors the seller** (royalty/fee are floored at the currency's
+   precision): a 1e-12-priced sale pays zero royalty. Bounded by one
+   precision-unit per sale — negligible against any real price.
+5. README says "38 assertions" for the original suite; the suite has 46. Stale
+   count, cosmetic.
+
+## Verdict
+
+**GO — the marketplace holds up end-to-end.** Every economic invariant the
+template claims was exercised under realistic multi-party conditions and held
+exactly: conservation per sale and globally, immutable creator royalties on
+every hop of a resale chain, seller-fixed fees a buyer cannot influence,
+sale-only royalty enforcement with no non-paying exit, currency-agnostic
+settlement, and dust-robust escrow baselines — in the REPL and mined on a live
+KDA-CE node. Gas is two orders of magnitude under the ceiling.
+
+## Reproduce
+
+```bash
+cd contracts/library/royalty-sale/examples
+pact royalty-sale-market-sim.repl          # 149 assertions
+# on-node (requires a devnet on :8090):
+cd ../../../../scripts/devnet-validate && npm run royalty-sale-sim
+```

--- a/contracts/library/royalty-sale/examples/royalty-sale-market-sim.repl
+++ b/contracts/library/royalty-sale/examples/royalty-sale-market-sim.repl
@@ -1,0 +1,929 @@
+;; royalty-sale-market-sim.repl — full-marketplace economic simulation
+;;
+;; Runs a realistic NFT marketplace end to end on the royalty-sale template and
+;; PROVES the economics, not just the API:
+;;
+;;   - CATALOG: two artists mint six tokens across the royalty spectrum
+;;     (0% / 2.5% / 5% / 50%-max bps), sale-only and transferable.
+;;   - RESALE CHAIN (headline): creator->A->B->C->D on a sale-only 5% token,
+;;     through two marketplaces at different fee rates. The ORIGINAL creator
+;;     collects the royalty on EVERY hop; the cumulative accrual is asserted
+;;     equal to rate x SUM(prices) exactly, and each seller nets
+;;     price - royalty - fee.
+;;   - FEES: fee fixed on the listing by the seller; marketplace==creator and
+;;     marketplace==seller payout merges; a buyer CANNOT underpay (their scoped
+;;     TRANSFER cap is the price - underscoping aborts the sale).
+;;   - MULTI-CURRENCY: a full primary + secondary sale in a NON-coin
+;;     fungible-v2 (the library token-fungible template) - royalties accrue in
+;;     that currency; the marketplace is currency-agnostic.
+;;   - LIFECYCLE: gift with correct provenance events, sale-only has no
+;;     non-paying exit, list -> delist -> relist -> buy, settled listings die.
+;;   - ADVERSARIAL: every path rejected (non-owner ops, insufficient funds,
+;;     under-scoped caps, front-run price change, escrow self-buy,
+;;     non-principals, over-cap rates, over-precision, dust griefing).
+;;   - ACCOUNTING: exact final balance of EVERY participant; global
+;;     conservation (sum of all balances == sum funded, to 12 dp); ownership
+;;     history and royalty totals RECONSTRUCTED from SOLD/TRANSFERRED events
+;;     and matched against state.
+;;   - GAS: mint / list / buy / transfer / delist measured under the table
+;;     model against the 150k KDA-CE ceiling (devnet run has the node-true
+;;     numbers; see scripts/devnet-validate).
+;;
+;; Self-contained: loads coin + the token-fungible template from this repo.
+;; NOTE: (env-events false) is used throughout (never true) so the FULL event
+;; log survives to the accounting act. Adversarial txs contain only failing
+;; ops, so the log holds exactly the committed marketplace history.
+
+;; ===========================================================================
+;; ACT 0 — world setup: currencies, module, personas, funding
+;; ===========================================================================
+
+(begin-tx "load coin (currency #1)")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+(begin-tx "load token-fungible (currency #2, NON-coin fungible-v2)")
+(env-data { "token-gov": ["9999999999999999999999999999999999999999999999999999999999999999"] })
+(define-keyset "token-gov" (read-keyset "token-gov"))
+(load "../../token-fungible/token.pact")
+(create-table token-table)
+(commit-tx)
+
+;; The cast. All payout accounts are k: principals (the module requires it).
+;;   alice k:1111.. artist #1 (creator of the headline collection)
+;;   dana  k:aaaa.. artist #2 (creator of the token-currency piece)
+;;   bob   k:2222.. collector A     carol k:3333.. collector B
+;;   frank k:6666.. collector C     gina  k:7777.. collector D
+;;   mkt1  k:4444.. marketplace #1  mkt2  k:8888.. marketplace #2
+;;   eve   k:5555.. adversary       gov   k:9999.. governance
+(begin-tx "personas + funding")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "carol": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+  , "mkt1":  { "keys": ["4444444444444444444444444444444444444444444444444444444444444444"], "pred": "keys-all" }
+  , "eve":   { "keys": ["5555555555555555555555555555555555555555555555555555555555555555"], "pred": "keys-all" }
+  , "frank": { "keys": ["6666666666666666666666666666666666666666666666666666666666666666"], "pred": "keys-all" }
+  , "gina":  { "keys": ["7777777777777777777777777777777777777777777777777777777777777777"], "pred": "keys-all" }
+  , "mkt2":  { "keys": ["8888888888888888888888888888888888888888888888888888888888888888"], "pred": "keys-all" }
+  , "gov":   { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "dana":  { "keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"], "pred": "keys-all" } })
+;; coin funding — TOTAL 4132.0 (the global-conservation constant)
+(test-capability (coin.CREDIT "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(coin.credit "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 10.0)
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") 1000.0)
+(test-capability (coin.CREDIT "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(coin.credit "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol") 1000.0)
+(test-capability (coin.CREDIT "k:4444444444444444444444444444444444444444444444444444444444444444"))
+(coin.credit "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 10.0)
+(test-capability (coin.CREDIT "k:5555555555555555555555555555555555555555555555555555555555555555"))
+(coin.credit "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve") 2.0)
+(test-capability (coin.CREDIT "k:6666666666666666666666666666666666666666666666666666666666666666"))
+(coin.credit "k:6666666666666666666666666666666666666666666666666666666666666666" (read-keyset "frank") 1000.0)
+(test-capability (coin.CREDIT "k:7777777777777777777777777777777777777777777777777777777777777777"))
+(coin.credit "k:7777777777777777777777777777777777777777777777777777777777777777" (read-keyset "gina") 1000.0)
+(test-capability (coin.CREDIT "k:8888888888888888888888888888888888888888888888888888888888888888"))
+(coin.credit "k:8888888888888888888888888888888888888888888888888888888888888888" (read-keyset "mkt2") 10.0)
+(test-capability (coin.CREDIT "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+(coin.credit "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (read-keyset "dana") 100.0)
+;; token (currency #2) funding: gov mints to the two token-side buyers.
+;; TOTAL 1300.0 (the token-side conservation constant)
+(env-sigs [ { "key": "9999999999999999999999999999999999999999999999999999999999999999", "caps": [] } ])
+(token.mint "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol") 1000.0)
+(token.mint "k:6666666666666666666666666666666666666666666666666666666666666666" (read-keyset "frank") 300.0)
+(commit-tx)
+
+(begin-tx "deploy royalty-sale")
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "free" (read-keyset "gov") (read-keyset "gov"))
+(namespace "free")
+(define-keyset "free.royalty-sale-gov" (read-keyset "gov"))
+(load "../royalty-sale.pact")
+(create-table free.royalty-sale.tokens)
+(create-table free.royalty-sale.listings)
+(commit-tx)
+
+;; REPL-only fixture: the REPL event log RESETS at each transaction, so the
+;; accounting act cannot read the whole history from (env-events) directly.
+;; This little indexer persists each sale tx's SOLD / TRANSFERRED events into
+;; a table — exactly what an off-chain marketplace indexer does — and ACT 8
+;; reconstructs ownership + royalty totals from it, from events alone.
+(begin-tx "load sim-indexer (event-history accumulator)")
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-keyset "sim-gov" (read-keyset "gov"))
+(module sim-indexer GOV
+  (defcap GOV () (enforce-guard (keyset-ref-guard "sim-gov")))
+  (defconst SOLD-EV:string "free.royalty-sale.SOLD")
+  (defconst MOVED-EV:string "free.royalty-sale.TRANSFERRED")
+  (defschema move
+    seq:integer name:string token:string from:string to:string
+    price:decimal royalty:decimal fee:decimal)
+  (deftable moves:{move})
+  (defun record (e)
+    (let* ((p (at 'params e))
+           (sold (= SOLD-EV (at 'name e)))
+           (n (length (keys moves))))
+      (insert moves (format "{}" [n])
+        { 'seq: n
+        , 'name: (if sold "SOLD" "TRANSFERRED")
+        , 'token: (at 0 p), 'from: (at 1 p), 'to: (at 2 p)
+        , 'price: (if sold (at 3 p) 0.0)
+        , 'royalty: (if sold (at 4 p) 0.0)
+        , 'fee: (if sold (at 5 p) 0.0) })))
+  (defun ingest (evs)
+    (map (record)
+         (filter (lambda (e) (contains (at 'name e) [SOLD-EV MOVED-EV])) evs)))
+  (defun all-moves:[object{move}] ()
+    (sort ['seq] (select moves (lambda (r) true))))
+  (defun moves-for:[object{move}] (token:string)
+    (sort ['seq] (select moves (lambda (r) (= token (at 'token r))))))
+  (defun all-sold:[object{move}] ()
+    (sort ['seq] (select moves (lambda (r) (= "SOLD" (at 'name r))))))
+  (defun last-owner:string (token:string)
+    (let ((ms (moves-for token)))
+      (at 'to (at (- (length ms) 1) ms))))
+  (defun sales-of:integer (token:string)
+    (length (filter (lambda (m) (= "SOLD" (at 'name m))) (moves-for token))))
+  (defun royalty-of:decimal (token:string)
+    (fold (+) 0.0 (map (lambda (m) (at 'royalty m)) (moves-for token))))
+  (defun volume-of:decimal (token:string)
+    (fold (+) 0.0 (map (lambda (m) (at 'price m)) (moves-for token))))
+)
+(create-table moves)
+(commit-tx)
+
+;; ===========================================================================
+;; ACT 1 — CREATION & CATALOG
+;;   alice mints: gift-0 (0%, transferable), art-25 (2.5%, transferable),
+;;                chain-1 (5%, SALE-ONLY), art-max (50% max, transferable)
+;;   dana mints:  dna-tok (2.5%, transferable — sold in currency #2)
+;;   bob mints:   fr-1 (owner bob, CREATOR alice, 2.5% — minter != creator)
+;; ===========================================================================
+
+(begin-tx "mint validation — fail closed")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "alice"))] } ])
+(expect-failure "empty id rejected" "id required"
+  (free.royalty-sale.mint "" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 0 true "u"))
+(expect-failure "non-ASCII id rejected" "id must be ASCII"
+  (free.royalty-sale.mint "café" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 0 true "u"))
+(expect-failure "over-cap royalty (60%) rejected" "royalty-bps must be in [0, 5000]"
+  (free.royalty-sale.mint "t-bad" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 6000 true "u"))
+(expect-failure "negative royalty rejected" "royalty-bps must be in [0, 5000]"
+  (free.royalty-sale.mint "t-bad" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") -1 true "u"))
+(expect-failure "non-principal owner rejected" "owner must be a principal account"
+  (free.royalty-sale.mint "t-bad" "alice-vanity" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 250 true "u"))
+(expect-failure "non-principal creator rejected" "creator must be a principal account"
+  (free.royalty-sale.mint "t-bad" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "creator-vanity" (read-keyset "alice") 250 true "u"))
+(rollback-tx)
+
+(begin-tx "the catalog: alice mints four, dana one, bob one (creator alice)")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "alice"))] } ])
+(expect "gift-0 minted (0% royalty, transferable)" "gift-0"
+  (free.royalty-sale.mint "gift-0"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    0 true "ipfs://gift-0"))
+(expect "art-25 minted (2.5% royalty)" "art-25"
+  (free.royalty-sale.mint "art-25"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    250 true "ipfs://art-25"))
+(expect "chain-1 minted (5% royalty, SALE-ONLY)" "chain-1"
+  (free.royalty-sale.mint "chain-1"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    500 false "ipfs://chain-1"))
+(expect "art-max minted (50% royalty — the cap)" "art-max"
+  (free.royalty-sale.mint "art-max"
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    5000 true "ipfs://art-max"))
+(env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "dana"))] } ])
+(expect "dna-tok minted by dana (2.5% royalty)" "dna-tok"
+  (free.royalty-sale.mint "dna-tok"
+    "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (read-keyset "dana")
+    "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (read-keyset "dana")
+    250 true "ipfs://dna-tok"))
+;; minter != creator: bob mints to himself, enrolling ALICE as royalty payee
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "bob"))] } ])
+(expect "fr-1 minted by bob with alice as creator" "fr-1"
+  (free.royalty-sale.mint "fr-1"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    250 true "ipfs://fr-1"))
+(expect "six MINTED events on the log" 6
+  (length (filter (lambda (e) (= "free.royalty-sale.MINTED" (at 'name e))) (env-events false))))
+(commit-tx)
+
+(begin-tx "duplicate id rejected (1-of-1 is enforced)")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "eve"))] } ])
+(expect-failure "re-minting an existing id fails" "Value already found while in Insert mode"
+  (free.royalty-sale.mint "chain-1"
+    "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve")
+    "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve")
+    0 true "ipfs://steal"))
+(rollback-tx)
+
+;; ===========================================================================
+;; ACT 2 — PRIMARY SALE (creator == seller merge) + buyer-side attacks
+;;   S1: alice lists art-25 at 40 via mkt1 (2.5%). bob buys.
+;;   royalty 1.0 + proceeds 38.0 merge into ONE 39.0 payout to alice; mkt1 +1.0
+;; ===========================================================================
+
+(begin-tx "S1 list: alice lists art-25 at 40.0, mkt1 fee 2.5%")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "art-25")] } ])
+(free.royalty-sale.list-token "art-25" 40.0 coin
+  "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 250)
+(expect "art-25 listed" true (free.royalty-sale.is-listed "art-25"))
+(commit-tx)
+
+(begin-tx "ATTACK: buyer under-scopes the price (fee/price evasion)")
+;; buy has NO money argument — the only lever a buyer has is their TRANSFER
+;; cap. Scoping it below the listed price must abort the whole sale.
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 39.0)] } ])
+(expect-failure "under-scoped TRANSFER cap cannot buy a 40.0 listing" "TRANSFER exceeded"
+  (free.royalty-sale.buy "art-25"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(rollback-tx)
+
+(begin-tx "ATTACK: broke buyer (eve, balance 2.0) cannot buy a 40.0 listing")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
+            , "caps": [(coin.TRANSFER "k:5555555555555555555555555555555555555555555555555555555555555555"
+                                      (free.royalty-sale.get-escrow-account) 40.0)] } ])
+(expect-failure "insufficient balance rejected by the currency" "Insufficient funds"
+  (free.royalty-sale.buy "art-25"
+    "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve")))
+(rollback-tx)
+
+(begin-tx "ATTACK: escrow self-buy (buyer == escrow account)")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(expect-failure "the escrow cannot buy for itself" "sender cannot be the receiver of a transfer"
+  (free.royalty-sale.buy "art-25"
+    (free.royalty-sale.get-escrow-account) (free.royalty-sale.create-escrow-guard)))
+(rollback-tx)
+
+(begin-tx "ATTACK: non-principal buyer rejected")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(expect-failure "vanity buyer account rejected" "buyer must be a principal account"
+  (free.royalty-sale.buy "art-25" "eve-vanity" (read-keyset "eve")))
+(rollback-tx)
+
+(begin-tx "S1 buy: bob buys art-25 — creator==seller pays out as ONE transfer")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 40.0)] } ])
+(expect "S1 settles" "art-25"
+  (free.royalty-sale.buy "art-25"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(expect "alice: 10 + royalty 1.0 + proceeds 38.0 merged = 49.0" 49.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "mkt1: 10 + fee 1.0 = 11.0" 11.0
+  (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444"))
+(expect "bob debited exactly the price: 960.0" 960.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "escrow settled to zero" 0.0
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "bob owns art-25" "k:2222222222222222222222222222222222222222222222222222222222222222"
+  (free.royalty-sale.owner-of "art-25"))
+(expect "listing closed" false (free.royalty-sale.is-listed "art-25"))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "settled listing cannot be re-bought")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 40.0)] } ])
+(expect-failure "re-buy of settled S1 rejected" "token is not listed for sale"
+  (free.royalty-sale.buy "art-25"
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(rollback-tx)
+
+;; ===========================================================================
+;; ACT 3 — THE RESALE CHAIN (the headline feature)
+;;   chain-1: 5% royalty, SALE-ONLY, creator alice.
+;;   S2 alice->bob   100.0  mkt1 2.5%   royalty  5.0  fee 2.5  proceeds  92.5
+;;   S3 bob->carol   160.0  mkt2 5.0%   royalty  8.0  fee 8.0  proceeds 144.0
+;;   S4 carol->frank  80.0  mkt1 2.5%   royalty  4.0  fee 2.0  proceeds  74.0
+;;   S5 frank->gina  250.0  no fee      royalty 12.5  fee 0.0  proceeds 237.5
+;;   Cumulative royalty to alice: 29.5 == 5% x (100+160+80+250) == 5% x 590
+;; ===========================================================================
+
+(begin-tx "sale-only: chain-1 has NO non-paying exit")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
+(expect-failure "creator cannot even gift a sale-only token" "token is sale-only; use buy"
+  (free.royalty-sale.transfer "chain-1"
+    "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(rollback-tx)
+
+(begin-tx "S2: alice -> bob at 100.0 (mkt1 2.5%)")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
+(free.royalty-sale.list-token "chain-1" 100.0 coin
+  "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 250)
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 100.0)] } ])
+(free.royalty-sale.buy "chain-1"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
+(expect "hop 1: alice merged royalty(5)+proceeds(92.5): 49 + 97.5 = 146.5" 146.5
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "hop 1: mkt1 fee 2.5: 11 + 2.5 = 13.5" 13.5
+  (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444"))
+(expect "hop 1: bob paid 100: 860.0" 860.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "hop 1: escrow -> 0" 0.0 (coin.get-balance (free.royalty-sale.get-escrow-account)))
+;; exact SOLD event: (id seller buyer price royalty fee)
+(let* ((sold (filter (lambda (e) (and (= "free.royalty-sale.SOLD" (at 'name e))
+                                      (= "chain-1" (at 0 (at 'params e)))))
+                     (env-events false)))
+       (last (at (- (length sold) 1) sold)))
+  (expect "hop 1 SOLD event carries the exact economics"
+    ["chain-1"
+     "k:1111111111111111111111111111111111111111111111111111111111111111"
+     "k:2222222222222222222222222222222222222222222222222222222222222222"
+     100.0 5.0 2.5]
+    (at 'params last)))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "S3: bob -> carol at 160.0 (mkt2 5%) — royalty flows to ALICE, not bob")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
+(free.royalty-sale.list-token "chain-1" 160.0 coin
+  "k:8888888888888888888888888888888888888888888888888888888888888888" (read-keyset "mkt2") 500)
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 160.0)] } ])
+(free.royalty-sale.buy "chain-1"
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol"))
+(expect "hop 2: creator alice +8 royalty although bob sold: 154.5" 154.5
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "hop 2: seller bob nets price-royalty-fee = 144: 1004.0" 1004.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "hop 2: mkt2 fee 8: 18.0" 18.0
+  (coin.get-balance "k:8888888888888888888888888888888888888888888888888888888888888888"))
+(expect "hop 2: carol paid 160: 840.0" 840.0
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "hop 2: escrow -> 0" 0.0 (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "S4: carol -> frank at 80.0 (mkt1 2.5%)")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
+(free.royalty-sale.list-token "chain-1" 80.0 coin
+  "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 250)
+(env-sigs [ { "key": "6666666666666666666666666666666666666666666666666666666666666666"
+            , "caps": [(coin.TRANSFER "k:6666666666666666666666666666666666666666666666666666666666666666"
+                                      (free.royalty-sale.get-escrow-account) 80.0)] } ])
+(free.royalty-sale.buy "chain-1"
+  "k:6666666666666666666666666666666666666666666666666666666666666666" (read-keyset "frank"))
+(expect "hop 3: alice +4 royalty: 158.5" 158.5
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "hop 3: seller carol nets 74: 914.0" 914.0
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "hop 3: mkt1 fee 2: 15.5" 15.5
+  (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444"))
+(expect "hop 3: frank paid 80: 920.0" 920.0
+  (coin.get-balance "k:6666666666666666666666666666666666666666666666666666666666666666"))
+(expect "hop 3: escrow -> 0" 0.0 (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "S5: frank -> gina at 250.0 (no marketplace)")
+(env-sigs [ { "key": "6666666666666666666666666666666666666666666666666666666666666666", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
+(free.royalty-sale.list-token "chain-1" 250.0 coin "" (read-keyset "frank") 0)
+(env-sigs [ { "key": "7777777777777777777777777777777777777777777777777777777777777777"
+            , "caps": [(coin.TRANSFER "k:7777777777777777777777777777777777777777777777777777777777777777"
+                                      (free.royalty-sale.get-escrow-account) 250.0)] } ])
+(free.royalty-sale.buy "chain-1"
+  "k:7777777777777777777777777777777777777777777777777777777777777777" (read-keyset "gina"))
+(expect "hop 4: alice +12.5 royalty: 171.0" 171.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "hop 4: seller frank nets 237.5: 1157.5" 1157.5
+  (coin.get-balance "k:6666666666666666666666666666666666666666666666666666666666666666"))
+(expect "hop 4: gina paid 250: 750.0" 750.0
+  (coin.get-balance "k:7777777777777777777777777777777777777777777777777777777777777777"))
+(expect "hop 4: escrow -> 0" 0.0 (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "RESALE-CHAIN TALLY: creator royalty == rate x SUM(prices), exactly")
+;; Reconstructed from the ingested SOLD events — the data an indexer would use.
+(let ((roy (sim-indexer.royalty-of "chain-1"))
+      (vol (sim-indexer.volume-of "chain-1")))
+  (expect "four hops sold" 4 (sim-indexer.sales-of "chain-1"))
+  (expect "chain volume is 590.0" 590.0 vol)
+  (expect "creator royalty accrued on EVERY hop: 29.5" 29.5 roy)
+  (expect "royalty == 5% x volume, to 12 dp" (floor (* 0.05 vol) 12) roy))
+;; alice's balance agrees: 10 start + 39 (S1) + 92.5 (S2 proceeds) + 29.5 royalty
+(expect "alice's on-ledger balance matches the tally: 171.0" 171.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(commit-tx)
+
+;; ===========================================================================
+;; ACT 4 — FEE MERGES: marketplace==creator, then marketplace==seller
+;;   S6 gina -> bob at 60.0, marketplace = ALICE (creator) at 10%:
+;;      royalty 3 + fee 6 merge into ONE 9.0 payout to alice; gina +51.
+;;   S7 bob -> carol at 50.0, marketplace = BOB (seller) at 3%:
+;;      fee 1.5 + proceeds 46 merge into ONE 47.5 payout to bob; alice +2.5.
+;; ===========================================================================
+
+(begin-tx "S6: marketplace == creator (fee and royalty merge to alice)")
+(env-sigs [ { "key": "7777777777777777777777777777777777777777777777777777777777777777", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
+(free.royalty-sale.list-token "chain-1" 60.0 coin
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 1000)
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 60.0)] } ])
+(free.royalty-sale.buy "chain-1"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
+(expect "alice got royalty 3 + fee 6 as ONE merged payout: 180.0" 180.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "gina nets 51: 801.0" 801.0
+  (coin.get-balance "k:7777777777777777777777777777777777777777777777777777777777777777"))
+(expect "bob paid 60: 944.0" 944.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "escrow -> 0" 0.0 (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "S7: marketplace == seller (fee and proceeds merge to bob)")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
+(free.royalty-sale.list-token "chain-1" 50.0 coin
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") 300)
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 50.0)] } ])
+(free.royalty-sale.buy "chain-1"
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol"))
+(expect "bob got fee 1.5 + proceeds 46 as ONE merged payout: 991.5" 991.5
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "alice's royalty still lands: 182.5" 182.5
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "carol paid 50: 864.0" 864.0
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "escrow -> 0" 0.0 (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "carol now owns chain-1" "k:3333333333333333333333333333333333333333333333333333333333333333"
+  (free.royalty-sale.owner-of "chain-1"))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "sale-only STILL has no exit after six ownership changes")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
+(expect-failure "carol cannot gift chain-1 either" "token is sale-only; use buy"
+  (free.royalty-sale.transfer "chain-1"
+    "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve")))
+(rollback-tx)
+
+;; ===========================================================================
+;; ACT 5 — MULTI-CURRENCY: full primary + secondary sale in currency #2
+;;   (the library token-fungible — a NON-coin fungible-v2)
+;;   T1 dana -> carol  500.0 token, mkt2 5%: royalty 12.5, fee 25, proceeds 462.5
+;;      (creator==seller merge: dana +475 in ONE payout)
+;;   T2 carol -> frank 200.0 token, no fee:  royalty 5 -> dana, proceeds 195
+;;   Royalty accrues in the LISTING currency — the marketplace is
+;;   currency-agnostic.
+;; ===========================================================================
+
+(begin-tx "T1: dana lists dna-tok at 500.0 TOKEN (mkt2 5%); carol buys with token")
+(env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "caps": [(free.royalty-sale.OWNER "dna-tok")] } ])
+(free.royalty-sale.list-token "dna-tok" 500.0 token
+  "k:8888888888888888888888888888888888888888888888888888888888888888" (read-keyset "mkt2") 500)
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(token.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                       (free.royalty-sale.get-escrow-account) 500.0)] } ])
+(expect "T1 settles in the non-coin currency" "dna-tok"
+  (free.royalty-sale.buy "dna-tok"
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(expect "dana (creator==seller) merged payout in TOKEN: 475.0" 475.0
+  (token.get-balance "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+(expect "mkt2 fee in TOKEN: 25.0" 25.0
+  (token.get-balance "k:8888888888888888888888888888888888888888888888888888888888888888"))
+(expect "carol paid 500 TOKEN: 500.0" 500.0
+  (token.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "token-side escrow settled to zero" 0.0
+  (token.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "carol's COIN was untouched by the token sale: 864.0" 864.0
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "T2: carol resells dna-tok at 200.0 TOKEN — dana's royalty accrues in token")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [(free.royalty-sale.OWNER "dna-tok")] } ])
+(free.royalty-sale.list-token "dna-tok" 200.0 token "" (read-keyset "carol") 0)
+(env-sigs [ { "key": "6666666666666666666666666666666666666666666666666666666666666666"
+            , "caps": [(token.TRANSFER "k:6666666666666666666666666666666666666666666666666666666666666666"
+                                       (free.royalty-sale.get-escrow-account) 200.0)] } ])
+(free.royalty-sale.buy "dna-tok"
+  "k:6666666666666666666666666666666666666666666666666666666666666666" (read-keyset "frank"))
+(expect "dana's secondary royalty in TOKEN (475 + 5): 480.0" 480.0
+  (token.get-balance "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+(expect "carol nets 195 TOKEN: 695.0" 695.0
+  (token.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "frank paid 200 TOKEN: 100.0" 100.0
+  (token.get-balance "k:6666666666666666666666666666666666666666666666666666666666666666"))
+(expect "token-side escrow -> 0" 0.0
+  (token.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "frank owns dna-tok" "k:6666666666666666666666666666666666666666666666666666666666666666"
+  (free.royalty-sale.owner-of "dna-tok"))
+(sim-indexer.ingest (env-events false))
+;; the same 2.5% rate, enforced in whatever currency the listing chose
+(let ((roy (sim-indexer.royalty-of "dna-tok"))
+      (vol (sim-indexer.volume-of "dna-tok")))
+  (expect "dana's cumulative TOKEN royalty == 2.5% x 700 volume" (floor (* 0.025 vol) 12) roy)
+  (expect "which is 17.5 TOKEN" 17.5 roy))
+(commit-tx)
+
+;; ===========================================================================
+;; ACT 6 — TRANSFERS & LIFECYCLE
+;;   gift-0 gifted alice -> carol -> dana (free, provenance events exact);
+;;   art-max: list -> delist -> (buy rejected) -> relist -> S8 dana buys at 30
+;;   with the 50%-MAX royalty: royalty 15 + proceeds 13.5 merge to alice (28.5),
+;;   mkt2 fee 1.5.
+;; ===========================================================================
+
+(begin-tx "gift chain: alice -> carol -> dana, events carry true provenance")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "gift-0")] } ])
+(free.royalty-sale.transfer "gift-0"
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol"))
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(free.royalty-sale.OWNER "gift-0")] } ])
+(free.royalty-sale.transfer "gift-0"
+  "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (read-keyset "dana"))
+(expect "dana owns gift-0" "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  (free.royalty-sale.owner-of "gift-0"))
+(let ((moves (filter (lambda (e) (and (= "free.royalty-sale.TRANSFERRED" (at 'name e))
+                                      (= "gift-0" (at 0 (at 'params e)))))
+                     (env-events false))))
+  (expect "two TRANSFERRED events" 2 (length moves))
+  (expect "first hop: alice -> carol"
+    ["gift-0"
+     "k:1111111111111111111111111111111111111111111111111111111111111111"
+     "k:3333333333333333333333333333333333333333333333333333333333333333"]
+    (at 'params (at 0 moves)))
+  (expect "second hop: carol -> dana"
+    ["gift-0"
+     "k:3333333333333333333333333333333333333333333333333333333333333333"
+     "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+    (at 'params (at 1 moves))))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+(begin-tx "art-max: list -> delist; a buy after delist must fail")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "art-max")] } ])
+(free.royalty-sale.list-token "art-max" 20.0 coin "" (read-keyset "alice") 0)
+(expect "listed" true (free.royalty-sale.is-listed "art-max"))
+(expect "delisted" "art-max" (free.royalty-sale.delist "art-max"))
+(expect "no longer listed" false (free.royalty-sale.is-listed "art-max"))
+(env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            , "caps": [(coin.TRANSFER "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                                      (free.royalty-sale.get-escrow-account) 20.0)] } ])
+(expect-failure "buy after delist rejected" "token is not listed for sale"
+  (free.royalty-sale.buy "art-max"
+    "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (read-keyset "dana")))
+(commit-tx)
+
+(begin-tx "delist an inactive listing / a never-listed token")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "art-max"), (free.royalty-sale.OWNER "gift-0")] } ])
+(expect-failure "double delist rejected" "not listed"
+  (free.royalty-sale.delist "art-max"))
+(rollback-tx)
+
+(begin-tx "S8: relist art-max at 30.0 (mkt2 5%); dana buys at the 50%-MAX royalty")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "art-max")] } ])
+(free.royalty-sale.list-token "art-max" 30.0 coin
+  "k:8888888888888888888888888888888888888888888888888888888888888888" (read-keyset "mkt2") 500)
+(env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            , "caps": [(coin.TRANSFER "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                                      (free.royalty-sale.get-escrow-account) 30.0)] } ])
+(free.royalty-sale.buy "art-max"
+  "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (read-keyset "dana"))
+;; 50% royalty: 15.0; fee 5% = 1.5; proceeds 13.5. alice is creator AND seller.
+(expect "alice merged 15 + 13.5 = 28.5: 211.0" 211.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "mkt2 + 1.5: 19.5" 19.5
+  (coin.get-balance "k:8888888888888888888888888888888888888888888888888888888888888888"))
+(expect "dana paid 30 coin: 70.0" 70.0
+  (coin.get-balance "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+(expect "escrow -> 0" 0.0 (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "dana owns art-max" "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  (free.royalty-sale.owner-of "art-max"))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+;; ===========================================================================
+;; ACT 7 — ADVERSARIAL SWEEP (against LIVE listings from the real flow)
+;; ===========================================================================
+
+(begin-tx "listing validation — fail closed")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "art-25")] } ])
+(expect-failure "zero price rejected" "price must be positive"
+  (free.royalty-sale.list-token "art-25" 0.0 coin "" (read-keyset "bob") 0))
+(expect-failure "negative price rejected" "price must be positive"
+  (free.royalty-sale.list-token "art-25" -5.0 coin "" (read-keyset "bob") 0))
+(expect-failure "over-precision price rejected (13 dp on a 12 dp currency)"
+  "amount violates currency precision"
+  (free.royalty-sale.list-token "art-25" 1.0000000000001 coin "" (read-keyset "bob") 0))
+(expect-failure "fee over 10% rejected" "marketplace-bps must be in [0, 1000]"
+  (free.royalty-sale.list-token "art-25" 10.0 coin
+    "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 1001))
+(expect-failure "negative fee rejected" "marketplace-bps must be in [0, 1000]"
+  (free.royalty-sale.list-token "art-25" 10.0 coin
+    "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") -1))
+(expect-failure "non-principal fee payee rejected" "marketplace must be a principal account"
+  (free.royalty-sale.list-token "art-25" 10.0 coin "mkt-vanity" (read-keyset "mkt1") 250))
+(rollback-tx)
+
+(begin-tx "non-owner cannot list / transfer someone else's token")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
+            , "caps": [(free.royalty-sale.OWNER "art-25")] } ])
+(expect-failure "eve cannot list bob's art-25" "Keyset failure"
+  (free.royalty-sale.list-token "art-25" 1.0 coin "" (read-keyset "eve") 0))
+(expect-failure "eve cannot transfer bob's art-25" "Keyset failure"
+  (free.royalty-sale.transfer "art-25"
+    "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve")))
+(rollback-tx)
+
+(begin-tx "buying an unlisted token fails on the missing listing row")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(expect-failure "gift-0 was never listed" "No value found"
+  (free.royalty-sale.buy "gift-0"
+    "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve")))
+(rollback-tx)
+
+;; --- the front-run: seller changes the price after the buyer committed ----
+(begin-tx "bob lists fr-1 at 100.0 — a buyer will commit to THIS price")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "fr-1")] } ])
+(free.royalty-sale.list-token "fr-1" 100.0 coin "" (read-keyset "bob") 0)
+(commit-tx)
+
+(begin-tx "non-owner cannot delist a live listing")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
+            , "caps": [(free.royalty-sale.OWNER "fr-1")] } ])
+(expect-failure "eve cannot delist bob's live fr-1 listing" "Keyset failure"
+  (free.royalty-sale.delist "fr-1"))
+(rollback-tx)
+
+(begin-tx "cannot free-transfer a LISTED token")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "fr-1")] } ])
+(expect-failure "listed fr-1 cannot be gifted out from under the listing"
+  "delist before transferring"
+  (free.royalty-sale.transfer "fr-1"
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(rollback-tx)
+
+(begin-tx "FRONT-RUN: bob repriced to 150 after carol signed for 100")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "fr-1")] } ])
+(free.royalty-sale.list-token "fr-1" 150.0 coin "" (read-keyset "bob") 0)
+(commit-tx)
+
+(begin-tx "carol's stale-price buy aborts — she can never pay more than she signed")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 100.0)] } ])
+(expect-failure "the repriced listing exceeds carol's signed cap" "TRANSFER exceeded"
+  (free.royalty-sale.buy "fr-1"
+    "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(expect "carol's balance untouched by the failed buy: 864.0" 864.0
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "bob still owns fr-1" "k:2222222222222222222222222222222222222222222222222222222222222222"
+  (free.royalty-sale.owner-of "fr-1"))
+(rollback-tx)
+
+;; --- escrow dust griefing --------------------------------------------------
+(begin-tx "eve donates dust straight to the shared escrow")
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
+            , "caps": [(coin.TRANSFER "k:5555555555555555555555555555555555555555555555555555555555555555"
+                                      (free.royalty-sale.get-escrow-account) 0.000000000001)] } ])
+(coin.transfer-create "k:5555555555555555555555555555555555555555555555555555555555555555"
+  (free.royalty-sale.get-escrow-account) (free.royalty-sale.create-escrow-guard) 0.000000000001)
+(expect "escrow carries eve's dust" 0.000000000001
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(commit-tx)
+
+(begin-tx "S9: carol accepts the 150 price — sale settles OVER the dust")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 150.0)] } ])
+(free.royalty-sale.buy "fr-1"
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol"))
+;; fr-1 creator is ALICE (bob merely minted it): 2.5% of 150 = 3.75
+(expect "alice's royalty on bob's mint: 182.5 -> ... -> 214.75" 214.75
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "bob nets 146.25: 1137.75" 1137.75
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "carol paid 150: 714.0" 714.0
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "escrow returns to the DUST baseline, not zero — conservation held"
+  0.000000000001
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(expect "carol owns fr-1" "k:3333333333333333333333333333333333333333333333333333333333333333"
+  (free.royalty-sale.owner-of "fr-1"))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+;; --- wash trade: self-buy is legal but COSTS the royalty --------------------
+(begin-tx "S10: carol wash-trades fr-1 to herself — the royalty is unavoidable")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(free.royalty-sale.OWNER "fr-1")] } ])
+(free.royalty-sale.list-token "fr-1" 20.0 coin "" (read-keyset "carol") 0)
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+            , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
+                                      (free.royalty-sale.get-escrow-account) 20.0)] } ])
+(free.royalty-sale.buy "fr-1"
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol"))
+(expect "wash trade cost carol exactly the 0.5 royalty: 713.5" 713.5
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "the royalty went to the creator: 215.25" 215.25
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "carol still owns fr-1" "k:3333333333333333333333333333333333333333333333333333333333333333"
+  (free.royalty-sale.owner-of "fr-1"))
+(expect "escrow back at the dust baseline" 0.000000000001
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(sim-indexer.ingest (env-events false))
+(commit-tx)
+
+;; ===========================================================================
+;; ACT 8 — GLOBAL ACCOUNTING & EVENT-LOG RECONSTRUCTION
+;;   10 coin sales: prices 40+100+160+80+250+60+50+30+150+20      = 940.0
+;;   royalties (all to alice)  1+5+8+4+12.5+3+2.5+15+3.75+0.5     =  55.25
+;;   fees 1+2.5+8+2+0+6+1.5+1.5+0+0                               =  22.5
+;;   proceeds                                                      = 862.25
+;;   2 token sales: prices 500+200 = 700; royalty 17.5; fee 25; proceeds 657.5
+;; ===========================================================================
+
+(begin-tx "exact final balance of EVERY participant (coin)")
+(expect "alice  (artist #1)   215.25" 215.25
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "bob    (collector A) 1137.75" 1137.75
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "carol  (collector B) 713.5" 713.5
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "frank  (collector C) 1157.5" 1157.5
+  (coin.get-balance "k:6666666666666666666666666666666666666666666666666666666666666666"))
+(expect "gina   (collector D) 801.0" 801.0
+  (coin.get-balance "k:7777777777777777777777777777777777777777777777777777777777777777"))
+(expect "dana   (artist #2)   70.0" 70.0
+  (coin.get-balance "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+(expect "mkt1   (fees 1+2.5+2) 15.5" 15.5
+  (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444"))
+(expect "mkt2   (fees 8+1.5)  19.5" 19.5
+  (coin.get-balance "k:8888888888888888888888888888888888888888888888888888888888888888"))
+(expect "eve    (2 - dust)    1.999999999999" 1.999999999999
+  (coin.get-balance "k:5555555555555555555555555555555555555555555555555555555555555555"))
+(expect "escrow (eve's dust)  0.000000000001" 0.000000000001
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+;; GLOBAL CONSERVATION: the marketplace neither minted nor destroyed a single
+;; unit — every coin funded in ACT 0 is accounted for, to 12 dp.
+(let ((total (fold (+) 0.0
+        [ (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111")
+        , (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222")
+        , (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333")
+        , (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444")
+        , (coin.get-balance "k:5555555555555555555555555555555555555555555555555555555555555555")
+        , (coin.get-balance "k:6666666666666666666666666666666666666666666666666666666666666666")
+        , (coin.get-balance "k:7777777777777777777777777777777777777777777777777777777777777777")
+        , (coin.get-balance "k:8888888888888888888888888888888888888888888888888888888888888888")
+        , (coin.get-balance "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        , (coin.get-balance (free.royalty-sale.get-escrow-account)) ])))
+  (expect "GLOBAL COIN CONSERVATION: sum of all balances == 4132.0 funded" 4132.0 total))
+(commit-tx)
+
+(begin-tx "exact final balance of every participant (token / currency #2)")
+(expect "dana  480.0 (475 primary + 5 secondary royalty)" 480.0
+  (token.get-balance "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+(expect "carol 695.0" 695.0
+  (token.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "frank 100.0" 100.0
+  (token.get-balance "k:6666666666666666666666666666666666666666666666666666666666666666"))
+(expect "mkt2  25.0" 25.0
+  (token.get-balance "k:8888888888888888888888888888888888888888888888888888888888888888"))
+(let ((total (fold (+) 0.0
+        [ (token.get-balance "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        , (token.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333")
+        , (token.get-balance "k:6666666666666666666666666666666666666666666666666666666666666666")
+        , (token.get-balance "k:8888888888888888888888888888888888888888888888888888888888888888")
+        , (token.get-balance (free.royalty-sale.get-escrow-account)) ])))
+  (expect "GLOBAL TOKEN CONSERVATION: sum == 1300.0 minted" 1300.0 total))
+(commit-tx)
+
+(begin-tx "event-log reconstruction matches on-chain state")
+;; Everything below is computed ONLY from the ingested SOLD / TRANSFERRED
+;; events (both carry the new owner at params index 2) — the exact data an
+;; off-chain indexer has — and must agree with the live tables.
+(let* ((sold (sim-indexer.all-sold))
+       (all (sim-indexer.all-moves)))
+  (expect "12 sales settled in the simulation" 12 (length sold))
+  (expect "2 free transfers" 2 (- (length all) (length sold)))
+  ;; ownership history replayed from events == live table state, per token
+  (expect "replayed owner of gift-0"  (free.royalty-sale.owner-of "gift-0")  (sim-indexer.last-owner "gift-0"))
+  (expect "replayed owner of art-25"  (free.royalty-sale.owner-of "art-25")  (sim-indexer.last-owner "art-25"))
+  (expect "replayed owner of chain-1" (free.royalty-sale.owner-of "chain-1") (sim-indexer.last-owner "chain-1"))
+  (expect "replayed owner of art-max" (free.royalty-sale.owner-of "art-max") (sim-indexer.last-owner "art-max"))
+  (expect "replayed owner of dna-tok" (free.royalty-sale.owner-of "dna-tok") (sim-indexer.last-owner "dna-tok"))
+  (expect "replayed owner of fr-1"    (free.royalty-sale.owner-of "fr-1")    (sim-indexer.last-owner "fr-1"))
+  ;; the creator's total accrual, reconstructed the way an indexer would:
+  (let* ((coin-sold (filter (lambda (m) (!= "dna-tok" (at 'token m))) sold))
+         (roy (fold (+) 0.0 (map (lambda (m) (at 'royalty m)) coin-sold)))
+         (fees (fold (+) 0.0 (map (lambda (m) (at 'fee m)) coin-sold)))
+         (vol (fold (+) 0.0 (map (lambda (m) (at 'price m)) coin-sold))))
+    (expect "coin-side volume from events: 940.0" 940.0 vol)
+    (expect "alice's royalty from events: 55.25 (she created every coin-side token)" 55.25 roy)
+    (expect "fees from events: 22.5" 22.5 fees)
+    ;; (no "royalty+fee+proceeds==price" assert here: proceeds is DEFINED as
+    ;; the difference — that identity is tautological (audit F7). The real
+    ;; conservation proof is the balance table + escrow baseline above.)
+    ;; the full-chain-1 lifetime tally (6 sales incl. the ACT-4 merges):
+    (expect "chain-1 lifetime: 6 sales" 6 (sim-indexer.sales-of "chain-1"))
+    (expect "chain-1 lifetime volume: 700.0" 700.0 (sim-indexer.volume-of "chain-1"))
+    (expect "chain-1 lifetime royalty == 5% x 700 == 35.0, exactly" 35.0
+      (sim-indexer.royalty-of "chain-1"))))
+(commit-tx)
+
+;; ===========================================================================
+;; ACT 9 — GAS under the table model, against the 150k KDA-CE ceiling.
+;;   Measured LAST, on a marketplace already carrying 7 tokens and 6 listing
+;;   rows. Devnet numbers (node-true) live in scripts/devnet-validate.
+;; ===========================================================================
+
+(env-gasmodel "table")
+(env-gaslimit 150000)
+
+(begin-tx "gas: mint")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.royalty-sale.MINT-AUTH (read-keyset "bob"))] } ])
+(env-gas 0)
+(free.royalty-sale.mint "gas-1"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  250 true "ipfs://gas-1")
+(let ((g (env-gas)))
+  (print (format "GAS mint: {}" [g]))
+  (expect "mint under the 150k ceiling" true (< g 150000)))
+(commit-tx)
+
+(begin-tx "gas: list-token")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(free.royalty-sale.OWNER "gas-1")] } ])
+(env-gas 0)
+(free.royalty-sale.list-token "gas-1" 60.0 coin
+  "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 250)
+(let ((g (env-gas)))
+  (print (format "GAS list-token: {}" [g]))
+  (expect "list-token under the 150k ceiling" true (< g 150000)))
+(commit-tx)
+
+(begin-tx "gas: buy (worst case — 3 distinct payouts: creator, marketplace, seller)")
+(env-sigs [ { "key": "6666666666666666666666666666666666666666666666666666666666666666"
+            , "caps": [(coin.TRANSFER "k:6666666666666666666666666666666666666666666666666666666666666666"
+                                      (free.royalty-sale.get-escrow-account) 60.0)] } ])
+(env-gas 0)
+(free.royalty-sale.buy "gas-1"
+  "k:6666666666666666666666666666666666666666666666666666666666666666" (read-keyset "frank"))
+(let ((g (env-gas)))
+  (print (format "GAS buy (3-way split): {}" [g]))
+  (expect "buy under the 150k ceiling" true (< g 150000)))
+;; even the gas probe conserves: escrow back to the ACT-7 dust baseline
+(expect "gas-act sale conserved over the dust baseline" 0.000000000001
+  (coin.get-balance (free.royalty-sale.get-escrow-account)))
+(commit-tx)
+
+(begin-tx "gas: transfer + delist")
+(env-sigs [ { "key": "6666666666666666666666666666666666666666666666666666666666666666"
+            , "caps": [(free.royalty-sale.OWNER "gas-1")] } ])
+(env-gas 0)
+(free.royalty-sale.transfer "gas-1"
+  "k:7777777777777777777777777777777777777777777777777777777777777777" (read-keyset "gina"))
+(let ((g (env-gas)))
+  (print (format "GAS transfer: {}" [g]))
+  (expect "transfer under the 150k ceiling" true (< g 150000)))
+(env-sigs [ { "key": "7777777777777777777777777777777777777777777777777777777777777777"
+            , "caps": [(free.royalty-sale.OWNER "gas-1")] } ])
+(free.royalty-sale.list-token "gas-1" 5.0 coin "" (read-keyset "gina") 0)
+(env-gas 0)
+(free.royalty-sale.delist "gas-1")
+(let ((g (env-gas)))
+  (print (format "GAS delist: {}" [g]))
+  (expect "delist under the 150k ceiling" true (< g 150000)))
+(commit-tx)
+
+(print "royalty-sale-market-sim: all acts settled, conserved, and reconstructed.")

--- a/scripts/devnet-validate/package.json
+++ b/scripts/devnet-validate/package.json
@@ -12,8 +12,9 @@
     "gas-station": "tsx src/gas-station.ts",
     "token-fungible": "tsx src/token-fungible.ts",
     "hello-world": "tsx src/hello-world.ts",
-    "all": "tsx src/treasury.ts && tsx src/vesting.ts && tsx src/dao-voting.ts && tsx src/oracle-feed.ts && tsx src/gas-station.ts && tsx src/token-fungible.ts && tsx src/hello-world.ts && tsx src/royalty-sale.ts",
-    "royalty-sale": "tsx src/royalty-sale.ts"
+    "all": "tsx src/treasury.ts && tsx src/vesting.ts && tsx src/dao-voting.ts && tsx src/oracle-feed.ts && tsx src/gas-station.ts && tsx src/token-fungible.ts && tsx src/hello-world.ts && tsx src/royalty-sale.ts && tsx src/royalty-sale-market-sim.ts",
+    "royalty-sale": "tsx src/royalty-sale.ts",
+    "royalty-sale-sim": "tsx src/royalty-sale-market-sim.ts"
   },
   "dependencies": {
     "@kadena/client": "^1.18.3",

--- a/scripts/devnet-validate/src/royalty-sale-market-sim.ts
+++ b/scripts/devnet-validate/src/royalty-sale-market-sim.ts
@@ -1,0 +1,295 @@
+// Devnet marketplace simulation: library/royalty-sale
+//
+// The REPL suite (examples/royalty-sale-market-sim.repl) proves the economics
+// deterministically; THIS run proves the settlement's node-only behavior on a
+// live KDA-CE node, where table reads in read-only contexts diverge from the
+// REPL (the F1 class). Mined to confirmation:
+//
+//   - a 4-hop RESALE CHAIN (creator->A->B->C->D) on a sale-only 5% token
+//     through two marketplaces at different fee rates - the creator's royalty
+//     accrues on EVERY hop and each settlement conserves on-node;
+//   - a full primary + secondary sale in a NON-coin fungible-v2 (the library
+//     token-fungible template) - node evidence that the settlement path
+//     (precision read, managed-TRANSFER install, escrow guard) is
+//     currency-agnostic, which the F1 run (coin-only) did not cover;
+//   - adversarial rejections ON-NODE: non-owner delist, front-run repricing
+//     against a committed buyer cap, broke buyer, sale-only transfer;
+//   - escrow dust-griefing: the next sale settles to the donated baseline;
+//   - per-tx gas recorded against the 150k ceiling (GAS_LIMIT enforces it).
+import {
+  send, sendExpectFail, localCall, coinBalance, fund, persona, ksData,
+  loadTemplate, saveResults, recordSteps,
+} from './lib.js';
+
+const SLUG = 'royalty-sale-market-sim';
+const near = (a: number, b: number, eps = 1e-11) => Math.abs(a - b) <= eps;
+// balances of accounts that paid gas in KDA drift by gasUsed * 1e-8 (< 0.002)
+const nearGas = (a: number, b: number) => a <= b + 1e-11 && b - a <= 0.01;
+const assert = (cond: boolean, msg: string) => {
+  if (!cond) throw new Error(`ASSERT FAILED: ${msg}`);
+  console.log(`  ✓ ${msg}`);
+};
+
+async function pickName(base: string): Promise<string> {
+  for (let i = 0; ; i++) {
+    const name = i === 0 ? base : `${base}-v${i + 1}`;
+    try { await localCall(`(describe-module "free.${name}")`); }
+    catch { return name; }
+  }
+}
+
+const main = async () => {
+  console.log(`\n=== devnet marketplace simulation: ${SLUG} ===`);
+  const MOD = await pickName('royalty-market');
+  const TOK = await pickName('sim-tok');
+  const M = `free.${MOD}`;
+  const T = `free.${TOK}`;
+
+  const rs = loadTemplate('royalty-sale', 'royalty-sale.pact', 'royalty-sale-gov', MOD);
+  const rsSrc = rs.code.replace('(module royalty-sale GOV', `(module ${MOD} GOV`);
+  const tk = loadTemplate('token-fungible', 'token.pact', 'token-gov', TOK);
+  const tkSrc = tk.code.replace('(module token GOV', `(module ${TOK} GOV`);
+
+  // the cast — same roles as the REPL sim
+  const gov = persona('gov');
+  const alice = persona('alice');   // creator of chain-1
+  const dana = persona('dana');     // creator of dna-tok (token-currency artist)
+  const bob = persona('bob');       // collector A
+  const carol = persona('carol');   // collector B
+  const frank = persona('frank');   // collector C
+  const gina = persona('gina');     // collector D
+  const mkt1 = persona('mkt1');     // marketplace #1 (2.5%)
+  const mkt2 = persona('mkt2');     // marketplace #2 (5%)
+  const eve = persona('eve');       // adversary
+  await fund(gov, 5.0); await fund(alice, 5.0); await fund(dana, 5.0);
+  await fund(bob, 120.0); await fund(carol, 210.0); await fund(frank, 120.0);
+  await fund(gina, 300.0); await fund(mkt1, 2.0); await fund(mkt2, 2.0);
+  await fund(eve, 3.0);
+
+  // ---- deploy both templates under free/ ----------------------------------
+  await send({
+    code: `(namespace "free") (define-keyset "${rs.govKeyset}" (read-keyset "g")) (define-keyset "${tk.govKeyset}" (read-keyset "g"))`,
+    label: 'define governance keysets',
+    signers: [{ kp: gov }],
+    data: ksData('g', gov),
+  });
+  await send({
+    code: `${rsSrc}\n(create-table ${M}.tokens)(create-table ${M}.listings)`,
+    label: `deploy ${M} + tables`,
+    signers: [{ kp: gov }],
+  });
+  await send({
+    code: `${tkSrc}\n(create-table ${T}.token-table)`,
+    label: `deploy ${T} (currency #2) + table`,
+    signers: [{ kp: gov }],
+  });
+  const escrow: string = await localCall(`(${M}.get-escrow-account)`);
+  console.log(`  escrow: ${escrow}`);
+
+  // ---- catalog -------------------------------------------------------------
+  await send({
+    code: `(${M}.mint "chain-1" "${alice.account}" (read-keyset "a") "${alice.account}" (read-keyset "a") 500 false "ipfs://chain-1")`,
+    label: 'alice mints chain-1 (5% royalty, SALE-ONLY)',
+    signers: [{ kp: alice }],
+    data: ksData('a', alice),
+  });
+  await send({
+    code: `(${M}.mint "dna-tok" "${dana.account}" (read-keyset "d") "${dana.account}" (read-keyset "d") 250 true "ipfs://dna-tok")`,
+    label: 'dana mints dna-tok (2.5% royalty)',
+    signers: [{ kp: dana }],
+    data: ksData('d', dana),
+  });
+
+  // =====================================================================
+  // THE RESALE CHAIN (coin): alice -> bob -> carol -> frank -> gina
+  //   hop1 100.0 mkt1 2.5% | hop2 160.0 mkt2 5% | hop3 80.0 mkt1 2.5% | hop4 250.0 no fee
+  //   creator royalty 5% on EVERY hop: 5 + 8 + 4 + 12.5 = 29.5 = 5% x 590
+  // =====================================================================
+  type Hop = { seller: typeof alice; buyer: typeof alice; price: number; mkt?: typeof alice; mktName?: string; bps: number; };
+  const hops: Hop[] = [
+    { seller: alice, buyer: bob, price: 100.0, mkt: mkt1, mktName: 'mkt1', bps: 250 },
+    { seller: bob, buyer: carol, price: 160.0, mkt: mkt2, mktName: 'mkt2', bps: 500 },
+    { seller: carol, buyer: frank, price: 80.0, mkt: mkt1, mktName: 'mkt1', bps: 250 },
+    { seller: frank, buyer: gina, price: 250.0, bps: 0 },
+  ];
+  const aliceStart = await coinBalance(alice.account);
+  let royaltyAccrued = 0;
+  let volume = 0;
+  for (const [i, h] of hops.entries()) {
+    const n = i + 1;
+    const listCode = h.mkt
+      ? `(${M}.list-token "chain-1" ${h.price.toFixed(1)} coin "${h.mkt.account}" (read-keyset "m") ${h.bps})`
+      : `(${M}.list-token "chain-1" ${h.price.toFixed(1)} coin "" (read-keyset "m") 0)`;
+    await send({
+      code: listCode,
+      label: `hop ${n}: list chain-1 at ${h.price} (${h.mkt ? `${h.mktName} ${h.bps} bps` : 'no fee'})`,
+      signers: [{ kp: h.seller, caps: (wc) => [wc(`${M}.OWNER`, 'chain-1'), wc('coin.GAS')] }],
+      data: ksData('m', h.mkt ?? h.seller),
+    });
+    const royalty = (h.price * 500) / 10000;
+    const fee = (h.price * h.bps) / 10000;
+    const proceeds = h.price - royalty - fee;
+    const sBefore = await coinBalance(h.seller.account);
+    const aBefore = await coinBalance(alice.account);
+    const mBefore = h.mkt ? await coinBalance(h.mkt.account) : 0;
+    await send({
+      code: `(${M}.buy "chain-1" "${h.buyer.account}" (read-keyset "b"))`,
+      label: `hop ${n}: ${h.seller.account.slice(0, 10)}… sells to ${h.buyer.account.slice(0, 10)}… for ${h.price}`,
+      signers: [{ kp: h.buyer, caps: (wc) => [wc('coin.TRANSFER', h.buyer.account, escrow, { decimal: h.price.toFixed(1) }), wc('coin.GAS')] }],
+      data: ksData('b', h.buyer),
+    });
+    royaltyAccrued += royalty;
+    volume += h.price;
+    const esc = await coinBalance(escrow);
+    assert(near(esc, 0), `hop ${n}: escrow settled to 0 on-node`);
+    if (i === 0) {
+      // primary hop: creator == seller — royalty + proceeds arrive MERGED
+      assert(near(await coinBalance(alice.account) - aBefore, royalty + proceeds),
+        `hop 1: creator==seller merged payout ${royalty + proceeds}`);
+    } else {
+      assert(near(await coinBalance(alice.account) - aBefore, royalty),
+        `hop ${n}: creator royalty ${royalty} reached alice (seller was someone else)`);
+      assert(near(await coinBalance(h.seller.account) - sBefore, proceeds),
+        `hop ${n}: seller netted price - royalty - fee = ${proceeds}`);
+    }
+    if (h.mkt) {
+      assert(near(await coinBalance(h.mkt.account) - mBefore, fee),
+        `hop ${n}: ${h.mktName} fee ${fee} accrued`);
+    }
+    const owner = await localCall(`(${M}.owner-of "chain-1")`);
+    assert(owner === h.buyer.account, `hop ${n}: ownership flipped to the buyer`);
+  }
+  assert(near(royaltyAccrued, 29.5) && near(volume * 0.05, royaltyAccrued),
+    `RESALE CHAIN: creator royalty 29.5 == 5% x ${volume} volume, on-node`);
+  assert(nearGas(await coinBalance(alice.account), aliceStart + 122.0),
+    `alice's cumulative take from the chain is 122.0 (97.5 primary + 24.5 royalties), minus gas`);
+
+  // =====================================================================
+  // MULTI-CURRENCY: primary + secondary sale in the NON-coin fungible
+  // (token balances have NO gas noise — assertions are exact to 12 dp)
+  // =====================================================================
+  await send({
+    code: `(${T}.mint "${carol.account}" (read-keyset "c") 1000.0)(${T}.mint "${frank.account}" (read-keyset "f") 300.0)`,
+    label: `governance mints 1300 ${TOK} to carol + frank`,
+    signers: [{ kp: gov }],
+    data: { ...ksData('c', carol), ...ksData('f', frank) },
+  });
+  await send({
+    code: `(${M}.list-token "dna-tok" 500.0 ${T} "${mkt2.account}" (read-keyset "m") 500)`,
+    label: `dana lists dna-tok at 500.0 ${TOK} (mkt2 5%)`,
+    signers: [{ kp: dana, caps: (wc) => [wc(`${M}.OWNER`, 'dna-tok'), wc('coin.GAS')] }],
+    data: ksData('m', mkt2),
+  });
+  await send({
+    code: `(${M}.buy "dna-tok" "${carol.account}" (read-keyset "b"))`,
+    label: `carol buys dna-tok with ${TOK} (NON-coin settlement, on-node)`,
+    signers: [{ kp: carol, caps: (wc) => [wc(`${T}.TRANSFER`, carol.account, escrow, { decimal: '500.0' }), wc('coin.GAS')] }],
+    data: ksData('b', carol),
+  });
+  const tokBal = (acct: string) => localCall(`(${T}.get-balance "${acct}")`).then(Number).catch(() => 0);
+  assert(near(await tokBal(dana.account), 475.0), `dana (creator==seller) merged 475.0 ${TOK}`);
+  assert(near(await tokBal(mkt2.account), 25.0), `mkt2 fee 25.0 ${TOK}`);
+  assert(near(await tokBal(carol.account), 500.0), `carol paid exactly 500.0 ${TOK}`);
+  assert(near(await tokBal(escrow), 0.0), `token-side escrow settled to 0 on-node`);
+
+  await send({
+    code: `(${M}.list-token "dna-tok" 200.0 ${T} "" (read-keyset "m") 0)`,
+    label: `carol re-lists dna-tok at 200.0 ${TOK} (no fee)`,
+    signers: [{ kp: carol, caps: (wc) => [wc(`${M}.OWNER`, 'dna-tok'), wc('coin.GAS')] }],
+    data: ksData('m', carol),
+  });
+  await send({
+    code: `(${M}.buy "dna-tok" "${frank.account}" (read-keyset "b"))`,
+    label: `frank buys dna-tok — dana's royalty accrues in ${TOK}`,
+    signers: [{ kp: frank, caps: (wc) => [wc(`${T}.TRANSFER`, frank.account, escrow, { decimal: '200.0' }), wc('coin.GAS')] }],
+    data: ksData('b', frank),
+  });
+  assert(near(await tokBal(dana.account), 480.0), `dana's secondary royalty landed: 480.0 ${TOK}`);
+  assert(near(await tokBal(carol.account), 695.0), `carol netted 195.0 ${TOK}`);
+  assert(near(await tokBal(frank.account), 100.0), `frank paid exactly 200.0 ${TOK}`);
+  assert(near(await tokBal(escrow), 0.0), `token-side escrow -> 0 again`);
+  const tokSum = (await tokBal(dana.account)) + (await tokBal(carol.account))
+    + (await tokBal(frank.account)) + (await tokBal(mkt2.account)) + (await tokBal(escrow));
+  assert(near(tokSum, 1300.0), `GLOBAL ${TOK} CONSERVATION: all balances sum to the 1300 minted`);
+
+  // =====================================================================
+  // ADVERSARIAL, ON-NODE (each rejection mined against the live node)
+  // =====================================================================
+  // gina (current owner) lists chain-1 at 30 — a buyer will commit to this
+  await send({
+    code: `(${M}.list-token "chain-1" 30.0 coin "" (read-keyset "m") 0)`,
+    label: 'gina lists chain-1 at 30.0',
+    signers: [{ kp: gina, caps: (wc) => [wc(`${M}.OWNER`, 'chain-1'), wc('coin.GAS')] }],
+    data: ksData('m', gina),
+  });
+  await sendExpectFail({
+    code: `(${M}.delist "chain-1")`,
+    label: 'eve (non-owner) tries to delist the live listing',
+    signers: [{ kp: eve, caps: (wc) => [wc(`${M}.OWNER`, 'chain-1'), wc('coin.GAS')] }],
+  }, 'Keyset failure');
+  await sendExpectFail({
+    code: `(${M}.transfer "chain-1" "${eve.account}" (read-keyset "e"))`,
+    label: 'sale-only token cannot be free-transferred (no non-paying exit)',
+    signers: [{ kp: gina, caps: (wc) => [wc(`${M}.OWNER`, 'chain-1'), wc('coin.GAS')] }],
+    data: ksData('e', eve),
+  }, 'sale-only');
+  // FRONT-RUN: gina reprices to 40 AFTER carol signed a 30-cap
+  await send({
+    code: `(${M}.list-token "chain-1" 40.0 coin "" (read-keyset "m") 0)`,
+    label: 'FRONT-RUN: gina reprices the live listing to 40.0',
+    signers: [{ kp: gina, caps: (wc) => [wc(`${M}.OWNER`, 'chain-1'), wc('coin.GAS')] }],
+    data: ksData('m', gina),
+  });
+  await sendExpectFail({
+    code: `(${M}.buy "chain-1" "${carol.account}" (read-keyset "b"))`,
+    label: 'carol\'s stale 30-cap buy aborts — she cannot be made to overpay',
+    signers: [{ kp: carol, caps: (wc) => [wc('coin.TRANSFER', carol.account, escrow, { decimal: '30.0' }), wc('coin.GAS')] }],
+    data: ksData('b', carol),
+  }, 'TRANSFER exceeded');
+  await sendExpectFail({
+    code: `(${M}.buy "chain-1" "${eve.account}" (read-keyset "b"))`,
+    label: 'broke buyer (eve, 3 KDA) cannot settle the 40.0 listing',
+    signers: [{ kp: eve, caps: (wc) => [wc('coin.TRANSFER', eve.account, escrow, { decimal: '40.0' }), wc('coin.GAS')] }],
+    data: ksData('b', eve),
+  }, 'Insufficient funds');
+
+  // DUST GRIEFING + final settle over the dust baseline (F1 regression)
+  await send({
+    code: `(coin.transfer-create "${eve.account}" "${escrow}" (${M}.create-escrow-guard) 0.000000000001)`,
+    label: 'eve donates dust to the shared escrow',
+    signers: [{ kp: eve, caps: (wc) => [wc('coin.TRANSFER', eve.account, escrow, { decimal: '0.000000000001' }), wc('coin.GAS')] }],
+  });
+  const aliceBefore = await coinBalance(alice.account);
+  const ginaBefore = await coinBalance(gina.account);
+  await send({
+    code: `(${M}.buy "chain-1" "${carol.account}" (read-keyset "b"))`,
+    label: 'carol accepts the 40.0 price — sale settles OVER the dust',
+    signers: [{ kp: carol, caps: (wc) => [wc('coin.TRANSFER', carol.account, escrow, { decimal: '40.0' }), wc('coin.GAS')] }],
+    data: ksData('b', carol),
+  });
+  assert(near(await coinBalance(escrow), 1e-12), 'escrow returned to the DUST baseline (not zero) — conservation held on-node');
+  assert(near(await coinBalance(alice.account) - aliceBefore, 2.0), 'creator royalty 2.0 on the 5th chain-1 sale');
+  assert(near(await coinBalance(gina.account) - ginaBefore, 38.0), 'gina netted 38.0');
+  assert(await localCall(`(${M}.owner-of "chain-1")`) === carol.account, 'carol owns chain-1');
+
+  // =====================================================================
+  // GAS: every mined tx above ran under GAS_LIMIT 150000 or it would have
+  // failed. Report the per-operation numbers.
+  // =====================================================================
+  const steps = recordSteps();
+  const maxGas = Math.max(...steps.map((s) => s.gas));
+  const buys = steps.filter((s) => /sells to|buys|settles OVER|carol buys/.test(s.label));
+  console.log(`\n  gas: max ${maxGas} / 150000 ceiling; buy txs: ${buys.map((s) => s.gas).join(', ')}`);
+  assert(maxGas < 150000, `every operation cleared the 150k ceiling (max ${maxGas})`);
+
+  saveResults(SLUG, {
+    module: M,
+    tokenModule: T,
+    hash: await localCall(`(at 'hash (describe-module "${M}"))`),
+    chain1: { sales: 5, volume: volume + 40.0, creatorRoyalty: royaltyAccrued + 2.0, ratePct: 5 },
+    dnaTok: { sales: 2, volume: 700.0, creatorRoyaltyToken: 17.5, ratePct: 2.5 },
+    maxGas,
+  });
+};
+
+main().catch((e) => { console.error(`\nFAILED: ${e.message ?? e}`); process.exit(1); });


### PR DESCRIPTION
## What this is

The economic follow-up to the royalty-sale audit (#31): a **full end-to-end marketplace simulation** proving the template holds up as a real marketplace — creation, primary sales, a multi-hop secondary market, marketplace fees, a second currency, gifts, and a hostile user — with every unit of money accounted for to 12 dp. Test/simulation only: **no changes to royalty-sale.pact** (no defect found).

## REPL simulation — `examples/royalty-sale-market-sim.repl` (149 assertions, blocking CI)

- **Catalog**: 2 artists, 6 tokens across the royalty spectrum (0% / 2.5% / 5% / 50%-max), sale-only + transferable, incl. a minter ≠ creator enrollment.
- **Resale chain (headline)**: creator→A→B→C→D on a sale-only 5% token through two marketplaces at different fee rates, then two more sales. Creator royalty accrues on **every** hop: 4-hop tally **29.5 == 5% × 590**, lifetime **35.0 == 5% × 700**, exact; every seller nets price − royalty − fee, exact.
- **Fees**: fixed on the listing by the seller; a buyer cannot underpay (under-scoped TRANSFER cap aborts the sale — `buy` has no money argument); marketplace==creator and marketplace==seller merges pay as one transfer.
- **Multi-currency**: primary + secondary sale in the library **token-fungible** (non-coin fungible-v2); royalty accrues in that currency (**17.5 == 2.5% × 700** TOKEN); escrow settles per-currency.
- **Global accounting**: exact final balance of every participant; sum of all balances == amount funded (coin 4132.0, token 1300.0); escrow returns to baseline after all 12 sales; ownership history **replayed from SOLD/TRANSFERRED events** matches state for all 6 tokens (via a `sim-indexer` fixture, since the REPL event log resets per tx).
- **Adversarial (28 rejections)**: non-owner list/delist/transfer, broke buyer, under-scoped cap, **front-run repricing after the buyer signed**, escrow self-buy, non-principals everywhere, over-cap royalty/fee, over-precision/zero/negative price, transfer-of-listed, sale-only exits, re-buy of settled listings, duplicate mint, **dust griefing** (next sale settles to the donated baseline), wash trade (legal but costs the full royalty).
- **Gas act**: mint/list/buy/transfer/delist measured under the table model, all far under 150k.

## Devnet simulation — `npm run royalty-sale-sim` (32 txs mined on a live KDA-CE node)

Replays the node-relevant core with fresh personas: the 4-hop resale chain (every settlement conserved on-node), the **non-coin currency settlement** — new node evidence the F1 run (coin-only) didn't cover — plus mined rejections (non-owner delist, front-run stale-cap buy, broke buyer, sale-only transfer) and the dust-baseline case. Deployed as `free.royalty-market` + `free.sim-tok`, hash `5qDbxh_0Apk86rJ6NU8EbBSFfKDht4d_VmkwrcQJRec`.

**Gas vs the 150k ceiling**: max across the run 12,440 (one-time deploy); mint 203, list 327–357, worst buy **868** (~170× headroom).

## Report

`contracts/library/royalty-sale/SIMULATION.md` — full ledger, per-hop economics, adversarial matrix, gas table, and four INFO-level observations (MINTED lacks the initial owner / fee payee not in events; principal-prefix doc wording; floor-rounding favors the seller; wash trades are taxed, not blocked). **Verdict: GO.**

Static gate: PASS, 0 violations. Existing 46-assertion suite untouched and green; README/AUDIT pointers updated (stale "38 assertions" corrected to 46).