### PR TITLE
feat(standards): Kadena NFT interface standard v1 (ADR-018) + royalty-sale adoption

### DIFF
--- a/contracts/library/royalty-sale/examples/royalty-sale-market-sim.repl
+++ b/contracts/library/royalty-sale/examples/royalty-sale-market-sim.repl
@@ -97,6 +97,11 @@
 (token.mint "k:6666666666666666666666666666666666666666666666666666666666666666" (read-keyset "frank") 300.0)
 (commit-tx)
 
+(begin-tx "load NFT standard interfaces")
+(load "../../../standards/nft-asset-v1.pact")
+(load "../../../standards/nft-market-v1.pact")
+(commit-tx)
+
 (begin-tx "deploy royalty-sale")
 (env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
 (define-namespace "free" (read-keyset "gov") (read-keyset "gov"))
@@ -242,7 +247,7 @@
 
 (begin-tx "S1 list: alice lists art-25 at 40.0, mkt1 fee 2.5%")
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "art-25")] } ])
-(free.royalty-sale.list-token "art-25" 40.0 coin
+(free.royalty-sale.list-token-with-fee "art-25" 40.0 coin
   "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 250)
 (expect "art-25 listed" true (free.royalty-sale.is-listed "art-25"))
 (commit-tx)
@@ -330,7 +335,7 @@
 
 (begin-tx "S2: alice -> bob at 100.0 (mkt1 2.5%)")
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
-(free.royalty-sale.list-token "chain-1" 100.0 coin
+(free.royalty-sale.list-token-with-fee "chain-1" 100.0 coin
   "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 250)
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
@@ -360,7 +365,7 @@
 
 (begin-tx "S3: bob -> carol at 160.0 (mkt2 5%) — royalty flows to ALICE, not bob")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
-(free.royalty-sale.list-token "chain-1" 160.0 coin
+(free.royalty-sale.list-token-with-fee "chain-1" 160.0 coin
   "k:8888888888888888888888888888888888888888888888888888888888888888" (read-keyset "mkt2") 500)
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
             , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
@@ -381,7 +386,7 @@
 
 (begin-tx "S4: carol -> frank at 80.0 (mkt1 2.5%)")
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
-(free.royalty-sale.list-token "chain-1" 80.0 coin
+(free.royalty-sale.list-token-with-fee "chain-1" 80.0 coin
   "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 250)
 (env-sigs [ { "key": "6666666666666666666666666666666666666666666666666666666666666666"
             , "caps": [(coin.TRANSFER "k:6666666666666666666666666666666666666666666666666666666666666666"
@@ -402,7 +407,7 @@
 
 (begin-tx "S5: frank -> gina at 250.0 (no marketplace)")
 (env-sigs [ { "key": "6666666666666666666666666666666666666666666666666666666666666666", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
-(free.royalty-sale.list-token "chain-1" 250.0 coin "" (read-keyset "frank") 0)
+(free.royalty-sale.list-token-with-fee "chain-1" 250.0 coin "" (read-keyset "frank") 0)
 (env-sigs [ { "key": "7777777777777777777777777777777777777777777777777777777777777777"
             , "caps": [(coin.TRANSFER "k:7777777777777777777777777777777777777777777777777777777777777777"
                                       (free.royalty-sale.get-escrow-account) 250.0)] } ])
@@ -441,7 +446,7 @@
 
 (begin-tx "S6: marketplace == creator (fee and royalty merge to alice)")
 (env-sigs [ { "key": "7777777777777777777777777777777777777777777777777777777777777777", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
-(free.royalty-sale.list-token "chain-1" 60.0 coin
+(free.royalty-sale.list-token-with-fee "chain-1" 60.0 coin
   "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 1000)
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
@@ -460,7 +465,7 @@
 
 (begin-tx "S7: marketplace == seller (fee and proceeds merge to bob)")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.royalty-sale.OWNER "chain-1")] } ])
-(free.royalty-sale.list-token "chain-1" 50.0 coin
+(free.royalty-sale.list-token-with-fee "chain-1" 50.0 coin
   "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") 300)
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
             , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
@@ -499,7 +504,7 @@
 
 (begin-tx "T1: dana lists dna-tok at 500.0 TOKEN (mkt2 5%); carol buys with token")
 (env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "caps": [(free.royalty-sale.OWNER "dna-tok")] } ])
-(free.royalty-sale.list-token "dna-tok" 500.0 token
+(free.royalty-sale.list-token-with-fee "dna-tok" 500.0 token
   "k:8888888888888888888888888888888888888888888888888888888888888888" (read-keyset "mkt2") 500)
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
             , "caps": [(token.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
@@ -522,7 +527,7 @@
 
 (begin-tx "T2: carol resells dna-tok at 200.0 TOKEN — dana's royalty accrues in token")
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [(free.royalty-sale.OWNER "dna-tok")] } ])
-(free.royalty-sale.list-token "dna-tok" 200.0 token "" (read-keyset "carol") 0)
+(free.royalty-sale.list-token-with-fee "dna-tok" 200.0 token "" (read-keyset "carol") 0)
 (env-sigs [ { "key": "6666666666666666666666666666666666666666666666666666666666666666"
             , "caps": [(token.TRANSFER "k:6666666666666666666666666666666666666666666666666666666666666666"
                                        (free.royalty-sale.get-escrow-account) 200.0)] } ])
@@ -585,7 +590,7 @@
 (begin-tx "art-max: list -> delist; a buy after delist must fail")
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
             , "caps": [(free.royalty-sale.OWNER "art-max")] } ])
-(free.royalty-sale.list-token "art-max" 20.0 coin "" (read-keyset "alice") 0)
+(free.royalty-sale.list-token-with-fee "art-max" 20.0 coin "" (read-keyset "alice") 0)
 (expect "listed" true (free.royalty-sale.is-listed "art-max"))
 (expect "delisted" "art-max" (free.royalty-sale.delist "art-max"))
 (expect "no longer listed" false (free.royalty-sale.is-listed "art-max"))
@@ -607,7 +612,7 @@
 (begin-tx "S8: relist art-max at 30.0 (mkt2 5%); dana buys at the 50%-MAX royalty")
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
             , "caps": [(free.royalty-sale.OWNER "art-max")] } ])
-(free.royalty-sale.list-token "art-max" 30.0 coin
+(free.royalty-sale.list-token-with-fee "art-max" 30.0 coin
   "k:8888888888888888888888888888888888888888888888888888888888888888" (read-keyset "mkt2") 500)
 (env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             , "caps": [(coin.TRANSFER "k:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -635,27 +640,27 @@
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(free.royalty-sale.OWNER "art-25")] } ])
 (expect-failure "zero price rejected" "price must be positive"
-  (free.royalty-sale.list-token "art-25" 0.0 coin "" (read-keyset "bob") 0))
+  (free.royalty-sale.list-token-with-fee "art-25" 0.0 coin "" (read-keyset "bob") 0))
 (expect-failure "negative price rejected" "price must be positive"
-  (free.royalty-sale.list-token "art-25" -5.0 coin "" (read-keyset "bob") 0))
+  (free.royalty-sale.list-token-with-fee "art-25" -5.0 coin "" (read-keyset "bob") 0))
 (expect-failure "over-precision price rejected (13 dp on a 12 dp currency)"
   "amount violates currency precision"
-  (free.royalty-sale.list-token "art-25" 1.0000000000001 coin "" (read-keyset "bob") 0))
+  (free.royalty-sale.list-token-with-fee "art-25" 1.0000000000001 coin "" (read-keyset "bob") 0))
 (expect-failure "fee over 10% rejected" "marketplace-bps must be in [0, 1000]"
-  (free.royalty-sale.list-token "art-25" 10.0 coin
+  (free.royalty-sale.list-token-with-fee "art-25" 10.0 coin
     "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 1001))
 (expect-failure "negative fee rejected" "marketplace-bps must be in [0, 1000]"
-  (free.royalty-sale.list-token "art-25" 10.0 coin
+  (free.royalty-sale.list-token-with-fee "art-25" 10.0 coin
     "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") -1))
 (expect-failure "non-principal fee payee rejected" "marketplace must be a principal account"
-  (free.royalty-sale.list-token "art-25" 10.0 coin "mkt-vanity" (read-keyset "mkt1") 250))
+  (free.royalty-sale.list-token-with-fee "art-25" 10.0 coin "mkt-vanity" (read-keyset "mkt1") 250))
 (rollback-tx)
 
 (begin-tx "non-owner cannot list / transfer someone else's token")
 (env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
             , "caps": [(free.royalty-sale.OWNER "art-25")] } ])
 (expect-failure "eve cannot list bob's art-25" "Keyset failure"
-  (free.royalty-sale.list-token "art-25" 1.0 coin "" (read-keyset "eve") 0))
+  (free.royalty-sale.list-token-with-fee "art-25" 1.0 coin "" (read-keyset "eve") 0))
 (expect-failure "eve cannot transfer bob's art-25" "Keyset failure"
   (free.royalty-sale.transfer "art-25"
     "k:5555555555555555555555555555555555555555555555555555555555555555" (read-keyset "eve")))
@@ -672,7 +677,7 @@
 (begin-tx "bob lists fr-1 at 100.0 — a buyer will commit to THIS price")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(free.royalty-sale.OWNER "fr-1")] } ])
-(free.royalty-sale.list-token "fr-1" 100.0 coin "" (read-keyset "bob") 0)
+(free.royalty-sale.list-token-with-fee "fr-1" 100.0 coin "" (read-keyset "bob") 0)
 (commit-tx)
 
 (begin-tx "non-owner cannot delist a live listing")
@@ -694,7 +699,7 @@
 (begin-tx "FRONT-RUN: bob repriced to 150 after carol signed for 100")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(free.royalty-sale.OWNER "fr-1")] } ])
-(free.royalty-sale.list-token "fr-1" 150.0 coin "" (read-keyset "bob") 0)
+(free.royalty-sale.list-token-with-fee "fr-1" 150.0 coin "" (read-keyset "bob") 0)
 (commit-tx)
 
 (begin-tx "carol's stale-price buy aborts — she can never pay more than she signed")
@@ -746,7 +751,7 @@
 (begin-tx "S10: carol wash-trades fr-1 to herself — the royalty is unavoidable")
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
             , "caps": [(free.royalty-sale.OWNER "fr-1")] } ])
-(free.royalty-sale.list-token "fr-1" 20.0 coin "" (read-keyset "carol") 0)
+(free.royalty-sale.list-token-with-fee "fr-1" 20.0 coin "" (read-keyset "carol") 0)
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
             , "caps": [(coin.TRANSFER "k:3333333333333333333333333333333333333333333333333333333333333333"
                                       (free.royalty-sale.get-escrow-account) 20.0)] } ])
@@ -885,7 +890,7 @@
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(free.royalty-sale.OWNER "gas-1")] } ])
 (env-gas 0)
-(free.royalty-sale.list-token "gas-1" 60.0 coin
+(free.royalty-sale.list-token-with-fee "gas-1" 60.0 coin
   "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt1") 250)
 (let ((g (env-gas)))
   (print (format "GAS list-token: {}" [g]))
@@ -918,7 +923,7 @@
   (expect "transfer under the 150k ceiling" true (< g 150000)))
 (env-sigs [ { "key": "7777777777777777777777777777777777777777777777777777777777777777"
             , "caps": [(free.royalty-sale.OWNER "gas-1")] } ])
-(free.royalty-sale.list-token "gas-1" 5.0 coin "" (read-keyset "gina") 0)
+(free.royalty-sale.list-token-with-fee "gas-1" 5.0 coin "" (read-keyset "gina") 0)
 (env-gas 0)
 (free.royalty-sale.delist "gas-1")
 (let ((g (env-gas)))

--- a/contracts/library/royalty-sale/examples/royalty-sale-test.repl
+++ b/contracts/library/royalty-sale/examples/royalty-sale-test.repl
@@ -35,6 +35,12 @@
 (coin.credit "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol") 1000.0)
 (commit-tx)
 
+;; NFT standard interfaces (royalty-sale implements nft-asset-v1 + nft-market-v1)
+(begin-tx "load NFT standard interfaces")
+(load "../../../standards/nft-asset-v1.pact")
+(load "../../../standards/nft-market-v1.pact")
+(commit-tx)
+
 (begin-tx "load royalty-sale")
 (env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
 (define-namespace "free" (read-keyset "gov") (read-keyset "gov"))
@@ -124,19 +130,19 @@
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
             , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
 (expect-failure "zero price rejected" "price must be positive"
-  (free.royalty-sale.list-token "t-so" 0.0 coin "" (read-keyset "alice") 0))
+  (free.royalty-sale.list-token-with-fee "t-so" 0.0 coin "" (read-keyset "alice") 0))
 (expect-failure "fee over 10% rejected" "marketplace-bps must be in [0, 1000]"
-  (free.royalty-sale.list-token "t-so" 100.0 coin
+  (free.royalty-sale.list-token-with-fee "t-so" 100.0 coin
     "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt") 2000))
 (expect-failure "non-principal marketplace with a fee rejected" "marketplace must be a principal account"
-  (free.royalty-sale.list-token "t-so" 100.0 coin "mkt-vanity" (read-keyset "mkt") 250))
+  (free.royalty-sale.list-token-with-fee "t-so" 100.0 coin "mkt-vanity" (read-keyset "mkt") 250))
 (rollback-tx)
 
 (begin-tx "non-owner cannot list")
 (env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
             , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
 (expect-failure "stranger cannot list someone's token" "Keyset failure"
-  (free.royalty-sale.list-token "t-so" 100.0 coin "" (read-keyset "alice") 0))
+  (free.royalty-sale.list-token-with-fee "t-so" 100.0 coin "" (read-keyset "alice") 0))
 (rollback-tx)
 
 ;; ===========================================================================
@@ -148,7 +154,7 @@
 (begin-tx "bob lists t-tr at 100, 2.5% marketplace fee")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(free.royalty-sale.OWNER "t-tr")] } ])
-(free.royalty-sale.list-token "t-tr" 100.0 coin
+(free.royalty-sale.list-token-with-fee "t-tr" 100.0 coin
   "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt") 250)
 (expect "listed" true (free.royalty-sale.is-listed "t-tr"))
 (commit-tx)
@@ -202,7 +208,7 @@
   1000 true "ipfs://primary")
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
             , "caps": [(free.royalty-sale.OWNER "t-p")] } ])
-(free.royalty-sale.list-token "t-p" 50.0 coin "" (read-keyset "alice") 0)
+(free.royalty-sale.list-token-with-fee "t-p" 50.0 coin "" (read-keyset "alice") 0)
 (commit-tx)
 
 (begin-tx "bob buys alice's primary listing — creator==seller merges cleanly")
@@ -235,7 +241,7 @@
   0 true "ipfs://dust")
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
             , "caps": [(free.royalty-sale.OWNER "t-d")] } ])
-(free.royalty-sale.list-token "t-d" 10.000000000001 coin
+(free.royalty-sale.list-token-with-fee "t-d" 10.000000000001 coin
   "k:4444444444444444444444444444444444444444444444444444444444444444" (read-keyset "mkt") 333)
 (commit-tx)
 
@@ -270,7 +276,7 @@
 (begin-tx "list then delist; buy rejected after delist")
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
             , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
-(free.royalty-sale.list-token "t-so" 100.0 coin "" (read-keyset "alice") 0)
+(free.royalty-sale.list-token-with-fee "t-so" 100.0 coin "" (read-keyset "alice") 0)
 (expect "delisted" "t-so" (free.royalty-sale.delist "t-so"))
 (expect "no longer listed" false (free.royalty-sale.is-listed "t-so"))
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
@@ -288,7 +294,7 @@
 (begin-tx "sale-only token sells only via buy (royalty always paid)")
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
             , "caps": [(free.royalty-sale.OWNER "t-so")] } ])
-(free.royalty-sale.list-token "t-so" 200.0 coin "" (read-keyset "alice") 0)
+(free.royalty-sale.list-token-with-fee "t-so" 200.0 coin "" (read-keyset "alice") 0)
 (commit-tx)
 
 (begin-tx "carol buys the sale-only token; alice's 5% royalty is unavoidable")
@@ -337,7 +343,7 @@
 (begin-tx "cannot free-transfer a listed token")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
-(free.royalty-sale.list-token "t-prov" 10.0 coin "" (read-keyset "bob") 0)
+(free.royalty-sale.list-token-with-fee "t-prov" 10.0 coin "" (read-keyset "bob") 0)
 (expect-failure "listed token cannot be gifted" "delist before transferring"
   (free.royalty-sale.transfer "t-prov"
     "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
@@ -346,7 +352,7 @@
 (begin-tx "non-owner cannot delist")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
-(free.royalty-sale.list-token "t-prov" 10.0 coin "" (read-keyset "bob") 0)
+(free.royalty-sale.list-token-with-fee "t-prov" 10.0 coin "" (read-keyset "bob") 0)
 (env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555"
             , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
 (expect-failure "stranger cannot delist someone's listing" "Keyset failure"
@@ -364,7 +370,7 @@
 (begin-tx "marketplace == seller merge")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
             , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
-(free.royalty-sale.list-token "t-prov" 100.0 coin
+(free.royalty-sale.list-token-with-fee "t-prov" 100.0 coin
   "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") 300)
 (commit-tx)
 
@@ -402,7 +408,7 @@
 (begin-tx "carol lists t-prov, alice buys; sale conserves despite the dust")
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
             , "caps": [(free.royalty-sale.OWNER "t-prov")] } ])
-(free.royalty-sale.list-token "t-prov" 20.0 coin "" (read-keyset "carol") 0)
+(free.royalty-sale.list-token-with-fee "t-prov" 20.0 coin "" (read-keyset "carol") 0)
 (commit-tx)
 
 (begin-tx "buy over a dust-carrying escrow")
@@ -416,4 +422,46 @@
   (coin.get-balance (free.royalty-sale.get-escrow-account)))
 (expect "bob owns t-prov after buying over dust" "k:2222222222222222222222222222222222222222222222222222222222222222"
   (free.royalty-sale.owner-of "t-prov"))
+(commit-tx)
+
+;; ===========================================================================
+;; STANDARD SURFACE — the 3-arg nft-market-v1.list-token (no marketplace fee)
+;;   Proves the interface entry point works and get-listing projects onto the
+;;   5-field nft-market-v1.listing (fee-bps 0), independent of the richer
+;;   list-token-with-fee extension exercised above.
+;; ===========================================================================
+(begin-tx "mint t-std to alice (2% royalty to alice)")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [] } ])
+(free.royalty-sale.mint "t-std"
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+  200 true "ipfs://std")
+(commit-tx)
+
+(begin-tx "alice lists t-std via the STANDARD 3-arg list-token")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+            , "caps": [(free.royalty-sale.OWNER "t-std")] } ])
+(free.royalty-sale.list-token "t-std" 100.0 coin)
+(expect "standard listing is active" true (free.royalty-sale.is-listed "t-std"))
+(let ((l (free.royalty-sale.get-listing "t-std")))
+  (expect "projected listing has no fee (fee-bps 0)" 0 (at 'fee-bps l))
+  (expect "projected listing price" 100.0 (at 'price l))
+  (expect "projected listing seller is alice" "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (at 'seller l))
+  (expect "projected listing active" true (at 'active l))
+  ;; the 5-field interface projection carries no marketplace payee/guard —
+  ;; those stay private to the module (accessing them on the projection fails)
+  (expect-failure "projection hides the private marketplace column" "not found"
+    (at 'marketplace l)))
+(commit-tx)
+
+(begin-tx "bob buys t-std over the standard listing; royalty still paid, no fee leg")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+            , "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                                      (free.royalty-sale.get-escrow-account) 100.0)] } ])
+(free.royalty-sale.buy "t-std"
+  "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
+(expect "bob owns t-std" "k:2222222222222222222222222222222222222222222222222222222222222222"
+  (free.royalty-sale.owner-of "t-std"))
 (commit-tx)

--- a/contracts/library/royalty-sale/royalty-sale.pact
+++ b/contracts/library/royalty-sale/royalty-sale.pact
@@ -37,6 +37,13 @@
   \  2. Deploy and create-table (tokens, listings).                             \
   \  3. Validate on devnet before mainnet."
 
+  ;; Conforms to the Kadena NFT standard (contracts/standards/): the asset
+  ;; surface (token, ownership, royalty, event vocabulary) and the fixed-price
+  ;; market surface. No cross-chain (single-chain template) — nft-xchain-v1 is
+  ;; not implemented. See contracts/standards/SPEC.md.
+  (implements nft-asset-v1)
+  (implements nft-market-v1)
+
   ;; -----------------------------
   ;; Governance (upgrade-only; no fund paths)
   ;; -----------------------------
@@ -114,11 +121,16 @@
   ;; Guards & events
   ;; -----------------------------
 
-  (defcap MINTED (id:string creator:string royalty-bps:integer transferable:bool) @event true)
-  (defcap LISTED (id:string seller:string price:decimal marketplace-bps:integer) @event true)
-  (defcap DELISTED (id:string) @event true)
-  (defcap SOLD (id:string seller:string buyer:string price:decimal royalty:decimal fee:decimal) @event true)
-  (defcap TRANSFERRED (id:string from:string to:string) @event true)
+  ;; Event vocabulary — signatures match nft-asset-v1 / nft-market-v1 so one
+  ;; indexer reads this module and any other conforming marketplace uniformly.
+  ;; MINTED carries the initial owner (asset standard S: ownership history is
+  ;; fully event-derivable). LISTED's fee-bps is the platform/marketplace fee
+  ;; rate (here the seller-named marketplace-bps); routing stays private.
+  (defcap MINTED:bool (id:string owner:string creator:string royalty-bps:integer transferable:bool) @event true)
+  (defcap LISTED:bool (id:string seller:string price:decimal fee-bps:integer) @event true)
+  (defcap DELISTED:bool (id:string) @event true)
+  (defcap SOLD:bool (id:string seller:string buyer:string price:decimal royalty:decimal fee:decimal) @event true)
+  (defcap TRANSFERRED:bool (id:string from:string to:string) @event true)
 
   (defcap MINT-AUTH (owner-guard:guard)
     @doc "Scopes the minter's signature to the mint: they prove control of the \
@@ -182,7 +194,7 @@
         , 'royalty-bps: royalty-bps
         , 'transferable: transferable
         , 'uri: uri })
-      (emit-event (MINTED id creator royalty-bps transferable))
+      (emit-event (MINTED id owner creator royalty-bps transferable))
       id))
 
   ;; -----------------------------
@@ -212,20 +224,44 @@
   ;; Listing
   ;; -----------------------------
 
-  (defun list-token:string
+  (defconst NO-MARKETPLACE-GUARD:guard
+    (create-capability-guard (GOV))
+    @doc "Sentinel guard stored on a fee-free listing's unused marketplace \
+         \columns. Never enforced (marketplace-bps 0 => the fee leg is dropped \
+         \by merge-payout), so it can be an inert placeholder.")
+
+  (defun list-token:string (id:string price:decimal currency:module{fungible-v2})
+    @doc "nft-market-v1: list an owned token at a fixed PRICE in CURRENCY with \
+         \NO marketplace fee. For a seller-named marketplace fee, use \
+         \list-token-with-fee (a royalty-sale extension beyond the standard \
+         \surface). Owner-authenticated. Emits LISTED."
+    (list-token-with-fee id price currency "" NO-MARKETPLACE-GUARD 0))
+
+  (defun list-token-with-fee:string
     ( id:string
       price:decimal
       currency:module{fungible-v2}
       marketplace:string marketplace-guard:guard marketplace-bps:integer )
-    @doc "List an owned token at a fixed PRICE in CURRENCY. The marketplace fee \
-         \rate and payee are fixed HERE, by the seller - buy reads them from \
-         \state, so a buyer cannot zero the fee. MARKETPLACE-BPS 0 means no \
-         \fee (pass \"\" / a sentinel guard). A non-zero fee requires a \
-         \principal marketplace account. Owner-authenticated."
+    @doc "royalty-sale extension (beyond nft-market-v1): list at a fixed PRICE \
+         \in CURRENCY with a seller-named marketplace fee. The fee rate and \
+         \payee are fixed HERE, by the seller - buy reads them from state, so a \
+         \buyer cannot zero the fee. MARKETPLACE-BPS 0 means no fee (pass \"\" / \
+         \a sentinel guard). A non-zero fee requires a principal marketplace \
+         \account. Owner-authenticated."
     (enforce (> price 0.0) "price must be positive")
     (enforce-unit currency price)
     (enforce (and (>= marketplace-bps 0) (<= marketplace-bps MAX-FEE-BPS))
       (format "marketplace-bps must be in [0, {}]" [MAX-FEE-BPS]))
+    ; standard S2: a royalty-bearing token must not be listable at a price whose
+    ; floored royalty is zero (a dust price would otherwise be a royalty-free
+    ; ownership change through buy). Bind royalty-bps + precision first, then
+    ; enforce (node-safe ordering — no table read inside the enforce condition).
+    (with-read tokens id { 'royalty-bps := royalty-bps }
+      (if (> royalty-bps 0)
+        (let ((prec (currency::precision)))
+          (enforce (> (floor (/ (* price (dec royalty-bps)) (dec BPS-DENOM)) prec) 0.0)
+            "price too low: royalty rounds to zero"))
+        true))
     ; fail closed: if there is a fee, its payee must be a real principal account
     (if (> marketplace-bps 0)
       (enforce (validate-principal marketplace-guard marketplace)
@@ -340,8 +376,20 @@
   ;; Views
   ;; -----------------------------
 
-  (defun get-token:object{token} (id:string) (read tokens id))
-  (defun get-listing:object{listing} (id:string) (read listings id))
+  ;; nft-asset-v1.token is exactly this module's 7 token columns, so get-token
+  ;; returns the interface schema directly.
+  (defun get-token:object{nft-asset-v1.token} (id:string) (read tokens id))
+
+  ;; nft-market-v1.listing is the currency-agnostic 5-field public projection;
+  ;; the seller-named marketplace payee/guard stay private to this module.
+  ;; fee-bps is the marketplace rate (0 for a standard fee-free listing).
+  (defun get-listing:object{nft-market-v1.listing} (id:string)
+    (with-read listings id
+      { 'seller := seller, 'price := price, 'currency := currency:module{fungible-v2}
+      , 'marketplace-bps := mk-bps, 'active := active }
+      { 'seller: seller, 'price: price, 'currency: currency
+      , 'fee-bps: mk-bps, 'active: active }))
+
   (defun owner-of:string (id:string) (at 'owner (read tokens id)))
 
   (defun is-listed:bool (id:string)

--- a/contracts/standards/SPEC.md
+++ b/contracts/standards/SPEC.md
@@ -1,0 +1,146 @@
+# Kadena NFT Standard v1 — Normative Specification
+
+**Status:** proposed · **Version:** 1 · **Language:** Pact 5.4ce / KDA-CE
+
+Three interfaces define a 1-of-1 NFT with enforceable creator royalties,
+trustless fixed-price sales, and cross-chain portability, such that independent
+marketplaces built by different teams are **compatible**: one wallet, one
+indexer, and one aggregator work across every conforming implementation.
+
+| Interface | File | Role | Required? |
+|---|---|---|---|
+| `nft-asset-v1` | [nft-asset-v1.pact](nft-asset-v1.pact) | the token, ownership, royalty terms, event vocabulary | yes |
+| `nft-market-v1` | [nft-market-v1.pact](nft-market-v1.pact) | fixed-price sale with conservation-asserted escrow | if the token is sellable; requires `nft-asset-v1` |
+| `nft-xchain-v1` | [nft-xchain-v1.pact](nft-xchain-v1.pact) | two-step SPV cross-chain relocation | opt-in; requires `nft-asset-v1` |
+
+Interfaces in Pact **cannot be upgraded** (`CannotUpgradeInterface`). Every
+identifier here is version-suffixed; a breaking change ships as `-v2` and an
+ecosystem migrates, exactly as `fungible-v1` → `fungible-v2` did. Do not treat
+v1 as a draft to be edited in place once anything implements it on a public
+network.
+
+## What "compatible" means in v1
+
+**Compatibility of tooling and semantics, not of custody.** A conforming
+token lives in the module that minted it; a competing marketplace does not take
+custody of it. But because every implementation exposes the same views, emits
+the same events, and obeys the same royalty and settlement rules, external
+software treats them uniformly. This is the `fungible-v2` model — every token
+contract is its own ledger, yet one wallet handles them all. Full asset
+portability across a shared ledger (a token minted in marketplace A, held in
+marketplace B's ledger) is explicitly **not** a v1 goal; if the ecosystem ever
+needs it, that is a v2 track with its own shared-ledger design.
+
+## The rules (normative)
+
+The interface signatures fix the *shape*. These clauses fix the *behavior* a
+signature cannot express. An implementation that matches the signatures but
+violates a clause is **not conforming**. Each clause traces to a failure mode
+observed in a deployed Kadena NFT stack (the Marmalade V2 analysis, 2026-07-06);
+the reference implementation `royalty-sale` and the production implementation
+`smartpacts-gallery` both satisfy all of them.
+
+### S1 — Fail closed on every input
+Guards and account/guard pairs are **required**, never defaulted. A missing or
+malformed guard MUST abort the operation; it MUST NOT degrade to a permissive
+guard. Every account paired with a guard MUST be validated as a principal
+(`validate-principal`) — owner, creator, buyer, receiver, and any fee payee.
+*Rationale:* a deployed guard policy set absent guards to a `true`-body guard
+via `(try GUARD_SUCCESS …)`, making forgetful tokens transferable by anyone.
+Never wrap guard/spec parsing in a `try` that can fall through to permissive.
+
+### S2 — One settlement, conservation-asserted
+A sale MUST settle in a **single** function that computes every cut — royalty,
+fee, seller remainder — explicitly, and MUST assert
+`escrow-in = Σ payouts-out` to the sale currency's full precision. No capability
+that grants spend authority over the escrow MUST span independent hooks or
+policies; there MUST be exactly one point at which conservation is checked. A
+royalty-bearing token MUST NOT be listable at a price whose floored royalty is
+zero (a dust price is otherwise a royalty-free ownership change through `buy`).
+*Rationale:* the deployed manager defined conservation as "whatever survives the
+policy loop," trusting every stacked policy; one hostile policy sharing the
+escrow capability could skim, and the seller silently absorbed the shortfall.
+
+### S3 — Economics live on-chain, never in the buy transaction
+Royalty rate, fee rate, price, and currency MUST be bound to the token or the
+listing at creation/list time and read from state at settlement. No parameter
+that affects the money moved MUST be read from the transaction that triggers the
+payment (no `read-msg` of a fee, rate, or payee inside `buy`). The fee rate a
+sale charges MUST be the rate **snapshotted on the listing**, so a post-listing
+admin rate change never alters a live sale and a buyer cannot zero the fee.
+*Rationale:* the deployed manager read the marketplace fee percentage and payee
+straight from the buyer's payload — any buyer could set the fee to `0.0`.
+*Conformance note:* because no signature can forbid a `read-msg` in a `buy`
+body, S3 is checked **adversarially** — the conformance suite drives `buy` with
+a malicious payload of economic overrides (fee, royalty, price, payee) and
+asserts the settlement split is the state-derived one. A conformance run without
+this negative vector does not establish S3.
+
+### S4 — "Sale-only" is an explicit, robust property
+Royalty enforcement for a token that must never move royalty-free is expressed
+as an explicit token property (`transferable:false`), chosen by the creator at
+mint, not as a blanket transfer ban bolted on by a composed policy. A sale-only
+token MUST reject free `transfer`, and its royalty MUST be enforced at
+**settlement** (S2), not by making all movement impossible. No later action MUST
+be able to silently void the property.
+*Rationale:* the deployed royalty policy enforced royalties by making
+`enforce-transfer` unconditionally fail, which both blocked legitimate gifting
+and could be composed away by a second transfer-enabling policy.
+
+### S5 — Cross-chain moves MUST NOT bypass the royalty
+(Applies to `nft-xchain-v1` implementers.) A cross-chain relocation MUST NOT
+change the beneficial owner of a **sale-only** token: such a token may relocate
+only to its own current owner (same account **and** same guard). A transferable
+token's receiver MUST be a principal account. Listings MUST NOT travel across a
+move. Origin-distinct token ids MUST make a cross-chain arrival unable to
+collide with or overwrite a live token on the target chain.
+*Rationale:* without this, "move to a new owner on another chain" would be a
+royalty-free sale — the exact bypass S2/S4 exist to prevent, reintroduced by the
+transport layer.
+
+### S6 — Cross-chain integrity: no rollback, bless in flight, devnet-proven
+(Applies to `nft-xchain-v1` implementers.) A move is a two-step SPV defpact with
+**no rollback** across the yield: step 0 tombstones the token on the source
+chain and yields its full record; step 1 writes it resident on the target chain.
+An initiated move is completed by continuation only. An upgrade performed while
+moves may be in flight MUST `bless` the prior module hash so pending
+continuations remain valid. Cross-chain behavior MUST be validated on a
+multi-chain devnet with real SPV — SPV is unsupported in the bare REPL, so a
+green cross-chain `.repl` is **not** evidence (it is a false positive).
+
+## Conformance
+
+A module conforms to interface X iff:
+1. it declares `(implements X)` and loads (Pact checks every signature and
+   schema matches exactly — a mismatch fails to load); **and**
+2. it passes the conformance suite for X (see
+   [conformance/README.md](conformance/README.md)), which drives the module
+   **through a `module{X}` reference** — proving the surface is usable
+   polymorphically, not merely name-compatible — and asserts the S-clauses that
+   are REPL-observable (S1–S4, and the same-chain guards of S5); **and**
+3. for `nft-xchain-v1`, it additionally passes a multi-chain devnet run of the
+   SPV round trip (S5 target-side, S6) — the REPL cannot prove this.
+
+The conformance suite is written against the interface, not against any one
+module, and is run against **both** `royalty-sale` (the reference
+implementation) and `smartpacts-gallery` (the production implementation). A
+third-party marketplace demonstrates conformance by passing the same suite.
+
+## Reference and production implementations
+
+- **`royalty-sale`** (`contracts/library/royalty-sale/`) — the MIT reference
+  implementation: minimal, multi-currency, seller-named marketplace fee.
+- **`smartpacts-gallery`** (github.com/SmartPacts/gallery) — the production
+  implementation operated by Smart Pacts: KDA sales, platform fee routed to the
+  SPT revenue account, cross-chain enabled.
+
+Both are conformance-checked members, not the definition. The definition is this
+document plus the three interfaces.
+
+## Non-goals for v1 (candidates for later interfaces)
+
+Auctions and offers/bids; bundles/collections as first-class sale units; lazy
+minting; fractional ownership; a shared cross-marketplace ledger (full
+portability); metadata schema standardization beyond a `uri` string. Each is a
+separate, additive interface so v1 stays small and every clause above stays
+mechanically checkable.

--- a/contracts/standards/conformance/README.md
+++ b/contracts/standards/conformance/README.md
@@ -1,0 +1,45 @@
+# NFT standard — conformance
+
+A candidate module conforms to the Kadena NFT standard (see [../SPEC.md](../SPEC.md)) iff:
+
+1. it declares `(implements nft-asset-v1)` (and `nft-market-v1` / `nft-xchain-v1` as applicable) and
+   **loads** — Pact checks every function/cap/schema signature matches exactly; and
+2. it passes the **conformance suite** below, which drives the module **through a `module{X}`
+   reference** — proving the surface is polymorphically usable, not merely name-compatible; and
+3. for `nft-xchain-v1`, it additionally passes a **multi-chain devnet** run of the SPV round trip
+   (the REPL cannot prove SPV — a green cross-chain `.repl` is a false positive).
+
+## How it works
+
+[`conformance-driver.pact`](conformance-driver.pact) is a module that knows only
+`module{nft-asset-v1}` / `module{nft-market-v1}` — it never names a concrete implementation. Each
+`d-*` function forwards one interface call through the modref. A conformance suite names the
+candidate module **once** (as the modref argument) and makes every assertion through the driver, so
+the assertions are implementation-agnostic. If a suite passes, the candidate is usable through the
+standard by any tool that knows only the interface.
+
+## Suites
+
+| Suite | Candidate | Covers | Run |
+|---|---|---|---|
+| [`royalty-sale-conformance.repl`](royalty-sale-conformance.repl) | `royalty-sale` (reference) | asset + market (S1–S4) | `pact contracts/standards/conformance/royalty-sale-conformance.repl` |
+| `gallery-conformance.repl` (in the gallery repo) | `smartpacts-gallery` (production) | asset + market; xchain on devnet | see the gallery repo |
+
+Both pass the **same** modref-driven assertions — two independently-built marketplaces, one
+interface. That is the "compatible between marketplaces" guarantee, demonstrated rather than claimed.
+
+## Writing a conformance suite for your marketplace
+
+1. Load `coin` + the three interfaces + `conformance-driver`.
+2. Deploy your module (into a namespace — KDA-CE locks root; a module and an interface in the same
+   namespace resolve by bare name).
+3. Name your module **once** and pass it to each `conformance-driver.d-*` call; assert only on the
+   projected interface schemas and the event amounts.
+4. If you implement `nft-xchain-v1`, add a multi-chain devnet run for the SPV round trip.
+
+## Note on the reference implementation
+
+This suite already tightened the reference: `royalty-sale` originally lacked the S2 dust-price
+listing guard (a price whose floored royalty is zero is a royalty-free ownership change). The
+conformance run flagged it; it was fixed in `list-token-with-fee`. A conformance gate that never
+fails is not testing anything.

--- a/contracts/standards/conformance/conformance-driver.pact
+++ b/contracts/standards/conformance/conformance-driver.pact
@@ -1,0 +1,71 @@
+;; conformance-driver — exercises an NFT implementation through interface
+;; modrefs ONLY. It never names royalty-sale or smartpacts-gallery; every call
+;; goes through module{nft-asset-v1} / module{nft-market-v1}. If a driver
+;; function typechecks and runs against a candidate module, that candidate's
+;; surface is polymorphically usable — the whole point of the standard.
+;;
+;; This is test scaffolding, not a library template: it lives under standards/
+;; and is loaded only by the conformance .repl suites.
+
+(module conformance-driver GOV
+  ;; Test scaffolding, not a deployable artifact — but governance is a real
+  ;; keyset (not a `true` body) so the driver holds itself to the same bar the
+  ;; standard demands of implementers. The suite defines `conformance-gov`.
+  (defcap GOV () (enforce-guard (keyset-ref-guard "conformance-gov")))
+
+  ;; --- nft-asset-v1 surface ---
+  (defun d-mint:string
+    ( m:module{nft-asset-v1}
+      id:string owner:string owner-guard:guard
+      creator:string creator-guard:guard
+      royalty-bps:integer transferable:bool uri:string )
+    (m::mint id owner owner-guard creator creator-guard royalty-bps transferable uri))
+
+  (defun d-transfer:string
+    (m:module{nft-asset-v1} id:string receiver:string receiver-guard:guard)
+    (m::transfer id receiver receiver-guard))
+
+  (defun d-get-token:object{nft-asset-v1.token} (m:module{nft-asset-v1} id:string)
+    (m::get-token id))
+
+  (defun d-owner-of:string (m:module{nft-asset-v1} id:string)
+    (m::owner-of id))
+
+  (defun d-is-listed:bool (m:module{nft-asset-v1} id:string)
+    (m::is-listed id))
+
+  ;; project a single field so a suite can assert royalty immutability etc.
+  ;; through the modref without re-declaring the schema inline
+  (defun d-royalty-bps:integer (m:module{nft-asset-v1} id:string)
+    (at 'royalty-bps (m::get-token id)))
+
+  (defun d-transferable:bool (m:module{nft-asset-v1} id:string)
+    (at 'transferable (m::get-token id)))
+
+  ;; --- nft-market-v1 surface ---
+  (defun d-list:string
+    (m:module{nft-market-v1} id:string price:decimal currency:module{fungible-v2})
+    (m::list-token id price currency))
+
+  (defun d-delist:string (m:module{nft-market-v1} id:string)
+    (m::delist id))
+
+  (defun d-buy:string
+    (m:module{nft-market-v1} id:string buyer:string buyer-guard:guard)
+    (m::buy id buyer buyer-guard))
+
+  (defun d-get-listing:object{nft-market-v1.listing} (m:module{nft-market-v1} id:string)
+    (m::get-listing id))
+
+  (defun d-listing-price:decimal (m:module{nft-market-v1} id:string)
+    (at 'price (m::get-listing id)))
+
+  (defun d-listing-fee-bps:integer (m:module{nft-market-v1} id:string)
+    (at 'fee-bps (m::get-listing id)))
+
+  (defun d-listing-active:bool (m:module{nft-market-v1} id:string)
+    (at 'active (m::get-listing id)))
+
+  (defun d-escrow:string (m:module{nft-market-v1})
+    (m::get-escrow-account))
+)

--- a/contracts/standards/conformance/royalty-sale-conformance.repl
+++ b/contracts/standards/conformance/royalty-sale-conformance.repl
@@ -1,0 +1,213 @@
+;; Conformance suite — royalty-sale vs the Kadena NFT standard.
+;;
+;; Every operation goes through conformance-driver, which knows only
+;; module{nft-asset-v1} / module{nft-market-v1}. royalty-sale is named exactly
+;; ONCE per driver call (as the modref argument) and NOWHERE else — the
+;; assertions never touch a royalty-sale-specific function. If this suite
+;; passes, royalty-sale's surface is polymorphically usable through the
+;; standard, which is the whole point.
+;;
+;; Scope: the REPL-observable S-clauses (S1 fail-closed, S2 conservation /
+;; dust-floor, S3 economics-from-state, S4 sale-only). Cross-chain (S5/S6) is
+;; not applicable — royalty-sale does not implement nft-xchain-v1.
+;;
+;; Run: pact contracts/standards/conformance/royalty-sale-conformance.repl
+
+;; --- dependencies ----------------------------------------------------------
+(begin-tx "coin + interfaces + driver")
+(load "../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(load "../nft-asset-v1.pact")
+(load "../nft-market-v1.pact")
+(env-data { "cg": { "keys": ["ck"], "pred": "keys-all" } })
+(define-keyset "conformance-gov" (read-keyset "cg"))
+(load "conformance-driver.pact")
+(commit-tx)
+
+;; --- personas --------------------------------------------------------------
+;; k: principals require the account name to equal the single 64-char key.
+(begin-tx "keysets + funding")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "carol": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+  , "gov":   { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") 1000.0)
+(test-capability (coin.CREDIT "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(coin.credit "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol") 1000.0)
+(commit-tx)
+
+;; --- deploy the CANDIDATE (named here, and only here) ----------------------
+(begin-tx "deploy candidate: royalty-sale")
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "free" (read-keyset "gov") (read-keyset "gov"))
+(namespace "free")
+(define-keyset "free.royalty-sale-gov" (read-keyset "gov"))
+(load "../../library/royalty-sale/royalty-sale.pact")
+(create-table free.royalty-sale.tokens)
+(create-table free.royalty-sale.listings)
+(commit-tx)
+
+;; From here the candidate is referenced ONLY as `free.royalty-sale` passed to
+;; the driver. To retarget this suite at another implementation, change the two
+;; lines above and the modref below — nothing else.
+
+;; ===========================================================================
+;; ASSET SURFACE (nft-asset-v1)
+;; ===========================================================================
+
+;; S1 — mint fails closed on a non-principal owner (through the modref)
+(begin-tx "S1: non-principal owner rejected")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(expect-failure "non-principal owner rejected at mint"
+  "owner must be a principal"
+  (conformance-driver.d-mint free.royalty-sale
+    "c-bad" "alice-not-a-principal" (read-keyset "alice")
+    "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 500 true "ipfs://x"))
+(rollback-tx)
+
+;; mint two tokens through the driver: a sale-only (royalty 5%) and a transferable.
+;; MINT-AUTH requires each minter to control the OWNER guard, so both alice (c-so
+;; owner) and bob (c-tr owner) sign this tx.
+(begin-tx "mint via driver")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] }
+          , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(expect "mint sale-only returns id" "c-so"
+  (conformance-driver.d-mint free.royalty-sale
+    "c-so" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    500 false "ipfs://so"))
+(expect "mint transferable returns id" "c-tr"
+  (conformance-driver.d-mint free.royalty-sale
+    "c-tr" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
+    250 true "ipfs://tr"))
+(commit-tx)
+
+;; views project the interface schema
+(begin-tx "asset views through the modref")
+(expect "owner-of (modref) = alice" "k:1111111111111111111111111111111111111111111111111111111111111111" (conformance-driver.d-owner-of free.royalty-sale "c-so"))
+(expect "royalty-bps projected via get-token" 500 (conformance-driver.d-royalty-bps free.royalty-sale "c-so"))
+(expect "transferable projected via get-token" false (conformance-driver.d-transferable free.royalty-sale "c-so"))
+(expect "is-listed total on unlisted token" false (conformance-driver.d-is-listed free.royalty-sale "c-so"))
+;; get-token returns exactly the interface's token schema (5 named fields we probe)
+(let ((tk (conformance-driver.d-get-token free.royalty-sale "c-tr")))
+  (expect "get-token owner" "k:2222222222222222222222222222222222222222222222222222222222222222" (at 'owner tk))
+  (expect "get-token creator" "k:1111111111111111111111111111111111111111111111111111111111111111" (at 'creator tk))
+  (expect "get-token royalty" 250 (at 'royalty-bps tk))
+  (expect "get-token uri" "ipfs://tr" (at 'uri tk)))
+(commit-tx)
+
+;; S4 — sale-only token rejects free transfer (through the modref)
+(begin-tx "S4: sale-only rejects transfer")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "c-so")] } ])
+(expect-failure "sale-only token cannot be free-transferred"
+  "token is sale-only"
+  (conformance-driver.d-transfer free.royalty-sale "c-so" "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(rollback-tx)
+
+;; transferable token CAN be gifted through the modref
+(begin-tx "transferable gift via modref")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.royalty-sale.OWNER "c-tr")] } ])
+(expect "gift returns id" "c-tr"
+  (conformance-driver.d-transfer free.royalty-sale "c-tr" "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(expect "carol now owns c-tr" "k:3333333333333333333333333333333333333333333333333333333333333333" (conformance-driver.d-owner-of free.royalty-sale "c-tr"))
+(commit-tx)
+
+;; ===========================================================================
+;; MARKET SURFACE (nft-market-v1)
+;; ===========================================================================
+
+;; S2 — a royalty-bearing token cannot be listed at a dust price (royalty floors
+;; to zero). c-so has 5% royalty; a price of 0.00000000001 floors royalty to 0.
+(begin-tx "S2: dust-price listing rejected")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "c-so")] } ])
+(expect-failure "dust price whose royalty floors to zero is rejected"
+  "royalty"
+  (conformance-driver.d-list free.royalty-sale "c-so" 0.00000000001 coin))
+(rollback-tx)
+
+;; list c-so via the STANDARD 3-arg list-token (no marketplace fee)
+(begin-tx "list c-so (standard, fee-free) via modref")
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "c-so")] } ])
+(expect "standard list returns id" "c-so"
+  (conformance-driver.d-list free.royalty-sale "c-so" 100.0 coin))
+(expect "is-listed true after list" true (conformance-driver.d-is-listed free.royalty-sale "c-so"))
+;; listing projects the 5-field interface schema
+(let ((lst (conformance-driver.d-get-listing free.royalty-sale "c-so")))
+  (expect "listing price" 100.0 (at 'price lst))
+  (expect "listing fee-bps 0 (standard fee-free)" 0 (at 'fee-bps lst))
+  (expect "listing active" true (at 'active lst))
+  (expect "listing seller" "k:1111111111111111111111111111111111111111111111111111111111111111" (at 'seller lst)))
+(expect "escrow account is published" true
+  (> (length (conformance-driver.d-escrow free.royalty-sale)) 0))
+(commit-tx)
+
+;; S3 + S2 — buy through the modref: economics come from state, escrow conserves.
+;; c-so: price 100, royalty 5% = 5 to alice(creator), no fee, 95 to alice(seller).
+;; creator == seller (both alice) so payouts merge; alice nets +100 - the coin
+;; she doesn't pay (she's not the buyer). bob is the buyer.
+(begin-tx "S3: buy reads economics from state (modref)")
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                (conformance-driver.d-escrow free.royalty-sale) 100.0)] } ])
+;; alice has no coin account before the sale (she was never funded) — her
+;; account is created by the payout, so baseline is 0.
+(expect "buy via modref returns id" "c-so"
+  (conformance-driver.d-buy free.royalty-sale "c-so" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(expect "bob owns c-so after buy" "k:2222222222222222222222222222222222222222222222222222222222222222" (conformance-driver.d-owner-of free.royalty-sale "c-so"))
+(expect "is-listed false after sale" false (conformance-driver.d-is-listed free.royalty-sale "c-so"))
+;; alice was creator AND seller: she receives royalty(5) + proceeds(95) = 100
+(expect "seller+creator (alice) received the full price" 100.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+;; escrow returned to baseline (0) — conservation, asserted inside buy too
+(expect "escrow empty after settlement" 0.0
+  (coin.get-balance (conformance-driver.d-escrow free.royalty-sale)))
+(commit-tx)
+
+;; ===========================================================================
+;; S3 ADVERSARIAL — economics MUST come from state, NEVER the buy transaction.
+;;   A signature cannot forbid a (read-msg) inside buy; the HARNESS must. We
+;;   drive buy with a malicious env-data payload of economic overrides (a fee,
+;;   a higher royalty, a lower price) that a cheating-but-conforming impl might
+;;   honor, and assert the split is the STATE-derived one. A conforming impl
+;;   ignores the payload entirely.
+;; ===========================================================================
+(begin-tx "mint + list c-s3 (10% royalty to carol, price 200)")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [] } ])
+(conformance-driver.d-mint free.royalty-sale
+  "c-s3" "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")
+  "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")
+  1000 true "ipfs://s3")
+(commit-tx)
+(begin-tx "carol lists c-s3 at 200, fee-free")
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [(free.royalty-sale.OWNER "c-s3")] } ])
+(conformance-driver.d-list free.royalty-sale "c-s3" 200.0 coin)
+(commit-tx)
+
+(begin-tx "S3-ADV: buy c-s3 with a MALICIOUS economic override payload")
+;; the buyer (bob) injects bogus economics into the tx. A state-honoring impl
+;; ignores every one of these keys.
+(env-data
+  { "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "carol": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+  ;; --- the attack surface: overrides a cheating impl might read from the tx ---
+  , "fee": 0.0, "marketplace_fee": 0.0, "marketplace-bps": 0
+  , "royalty-bps": 0, "royalty": 0.0, "price": 1.0
+  , "marketplace": "k:2222222222222222222222222222222222222222222222222222222222222222" })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                (conformance-driver.d-escrow free.royalty-sale) 200.0)] } ])
+(let ((carol-before (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333")))
+  (conformance-driver.d-buy free.royalty-sale "c-s3" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
+  ;; carol is creator+seller: STATE says royalty 10% of 200 = 20, proceeds 180,
+  ;; total 200. If the impl had honored the payload (royalty 0, price 1) she'd
+  ;; net far less. The full 200 proves economics came from STATE.
+  (expect "S3: payout is the STATE-derived 200 (tx economic overrides ignored)" 200.0
+    (- (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333") carol-before)))
+(expect "S3: escrow still conserves under the adversarial payload" 0.0
+  (coin.get-balance (conformance-driver.d-escrow free.royalty-sale)))
+(commit-tx)
+
+(print "")
+(print "=== ROYALTY-SALE CONFORMANCE: nft-asset-v1 + nft-market-v1 — PASS ===")
+(print "    (every call dispatched through a module{nft-*-v1} reference)")

--- a/contracts/standards/nft-asset-v1.pact
+++ b/contracts/standards/nft-asset-v1.pact
@@ -1,0 +1,103 @@
+;; nft-asset-v1 — Kadena 1-of-1 NFT asset standard (Pact 5 / KDA-CE)
+;;
+;; The asset half of the NFT standard: what a token IS, who owns it, its
+;; immutable creator royalty, and the event vocabulary every wallet, indexer
+;; and marketplace aggregator reads. Deliberately says NOTHING about how a
+;; token is sold — that is nft-market-v1 — or moved across chains — that is
+;; nft-xchain-v1. An implementation MAY implement this interface alone (a
+;; non-tradable collectible), or with either or both of the others.
+;;
+;; This interface can never be upgraded (Pact CannotUpgradeInterface). Any
+;; breaking change ships as nft-asset-v2. The normative rules an implementer
+;; MUST satisfy — beyond these signatures — live in SPEC.md; the conformance
+;; suite mechanically checks them against any candidate module.
+
+(interface nft-asset-v1
+
+  @doc "Standard surface for a 1-of-1 (non-fungible, non-fractional) token with \
+       \an immutable creator royalty. Ownership is a single account+guard; a \
+       \token is indivisible and has exactly one owner at a time. Royalty terms \
+       \are fixed at mint and can never change. See SPEC.md for the normative \
+       \MUST/MUST-NOT rules (fail-closed inputs, principal accounts, royalty \
+       \immutability, event-completeness) that this signature set cannot express."
+
+  ;; --- shared row shape ------------------------------------------------------
+  ;; get-token returns this named schema so any reader binds the same fields
+  ;; across every conforming module. Implementations MAY store additional
+  ;; private columns, but get-token MUST project exactly these.
+  (defschema token
+    @doc "The public projection of a token. `royalty-bps` is immutable after \
+         \mint. `transferable` false marks a sale-only token (see SPEC S4): it \
+         \may change beneficial owner ONLY through a royalty-paying sale."
+    owner:string
+    owner-guard:guard
+    creator:string
+    creator-guard:guard
+    royalty-bps:integer
+    transferable:bool
+    uri:string)
+
+  ;; --- events (the indexer vocabulary) --------------------------------------
+  ;; Every conforming module MUST emit these — and ONLY with these signatures —
+  ;; so one indexer reconstructs full ownership and sale history across all
+  ;; implementers. MINTED carries the initial owner (an indexer that sees only
+  ;; MINTED + TRANSFERRED + SOLD can derive current ownership without a chain
+  ;; read). A market implementation's buy MUST emit SOLD (declared here so the
+  ;; asset-level indexer sees sales even for asset-only tooling).
+
+  (defcap MINTED:bool
+    (id:string owner:string creator:string royalty-bps:integer transferable:bool)
+    @doc "Emitted exactly once, when a token is created. `owner` is the initial \
+         \owner; `creator` is the permanent royalty payee." @event)
+
+  (defcap TRANSFERRED:bool (id:string from:string to:string)
+    @doc "Emitted on a no-payment ownership change (gift / custody move). A \
+         \royalty-paying sale emits SOLD, not TRANSFERRED." @event)
+
+  (defcap SOLD:bool
+    (id:string seller:string buyer:string price:decimal royalty:decimal fee:decimal)
+    @doc "Emitted by a market implementation's buy. `price` is the amount the \
+         \buyer paid; `royalty` went to the creator; `fee` to the platform / \
+         \marketplace; the remainder (price - royalty - fee) to the seller. \
+         \Amounts are in the sale currency's units." @event)
+
+  ;; --- mint -----------------------------------------------------------------
+  (defun mint:string
+    ( id:string
+      owner:string owner-guard:guard
+      creator:string creator-guard:guard
+      royalty-bps:integer
+      transferable:bool
+      uri:string )
+    @doc "Create a 1-of-1 token with id ID. OWNER/OWNER-GUARD and \
+         \CREATOR/CREATOR-GUARD MUST each be a principal account (validate- \
+         \principal). ROYALTY-BPS is the immutable royalty in basis points and \
+         \MUST be validated against an implementation cap. The caller MUST \
+         \prove control of OWNER-GUARD (scoped). Emits MINTED. See SPEC S1/S3.")
+
+  ;; --- free transfer --------------------------------------------------------
+  (defun transfer:string (id:string receiver:string receiver-guard:guard)
+    @doc "Move a token with NO payment. RECEIVER/RECEIVER-GUARD MUST be a \
+         \principal account. MUST reject a sale-only token (transferable=false) \
+         \and MUST reject a token that is currently listed. Owner-authenticated \
+         \(scoped). Emits TRANSFERRED. See SPEC S4.")
+
+  ;; --- views (read-only; the fields tooling depends on) ---------------------
+  (defun get-token:object{token} (id:string)
+    @doc "The public token row. MUST project exactly the `token` schema. NOTE: \
+         \for a cross-chain implementer (nft-xchain-v1) this MAY return the \
+         \stale row of a token that has moved away — the `token` schema carries \
+         \no residence field. Residence is signalled by `owner-of` (which MUST \
+         \abort on a non-resident token) and the MOVE-INITIATED/MOVE-COMPLETED \
+         \events; an indexer MUST follow those, not poll get-token, to track a \
+         \token across chains.")
+
+  (defun owner-of:string (id:string)
+    @doc "The current owner account. An implementation whose tokens can leave \
+         \the chain (see nft-xchain-v1) MUST reject a token not resident here \
+         \rather than return a stale owner.")
+
+  (defun is-listed:bool (id:string)
+    @doc "True iff the token currently has an active listing. MUST be total \
+         \(never abort) — false for unknown or unlisted tokens.")
+)

--- a/contracts/standards/nft-market-v1.pact
+++ b/contracts/standards/nft-market-v1.pact
@@ -1,0 +1,87 @@
+;; nft-market-v1 — Kadena NFT fixed-price sale standard (Pact 5 / KDA-CE)
+;;
+;; The sale half of the NFT standard: how a token is listed at a fixed price
+;; and bought through a trustless, conservation-checked escrow that pays the
+;; creator royalty atomically. A module that implements this MUST also
+;; implement nft-asset-v1 (a market with no asset is meaningless) and MUST emit
+;; nft-asset-v1.SOLD on every buy — that is where the money amounts are
+;; reported to indexers.
+;;
+;; DELIBERATELY OUT OF SCOPE — left implementation-private so competing
+;; marketplaces stay conformant without sharing an economic model:
+;;   * how the platform / marketplace fee PAYEE is chosen (a fixed revenue
+;;     account, a seller-named marketplace, a DAO treasury, …). The fee RATE
+;;     and AMOUNT are public via LISTED.fee-bps and SOLD.fee; the routing is
+;;     not part of the ABI.
+;;   * auctions, offers/bids, bundles, lazy minting — a later interface may add
+;;     these; this one is fixed price only.
+;; This mirrors the lesson from the Marmalade V2 analysis: standardize the
+;; surface tooling depends on, keep the trusted economic surface small and
+;; private. Fixing fee routing into the ABI is exactly the over-coupling to
+;; avoid.
+;;
+;; Cannot be upgraded; a breaking change ships as nft-market-v2.
+
+(interface nft-market-v1
+
+  @doc "Standard surface for fixed-price NFT sales with atomic royalty payout. \
+       \Settlement MUST be single-point and conservation-asserted: the buyer \
+       \pays exactly `price` into an escrow, the escrow pays royalty + fee + \
+       \seller, and the implementation MUST assert escrow-in = sum of payouts \
+       \to the currency's full precision (SPEC S2). Economic parameters MUST \
+       \come from on-chain listing/token state, NEVER from the buy transaction \
+       \(SPEC S3)."
+
+  ;; The sale currency is any fungible-v2 (KDA `coin`, a stablecoin, …). A
+  ;; KDA-only marketplace simply always passes `coin`. This keeps stable-
+  ;; denominated sales possible without a second interface.
+
+  (defschema listing
+    @doc "The public projection of an active listing. `fee-bps` is the platform \
+         \/ marketplace fee rate SNAPSHOTTED at list time — buy MUST read the \
+         \rate from here, never from the buyer's transaction, so a post-listing \
+         \rate change cannot alter a live sale and a buyer cannot zero the fee. \
+         \`currency` is the fungible the price is denominated in."
+    seller:string
+    price:decimal
+    currency:module{fungible-v2}
+    fee-bps:integer
+    active:bool)
+
+  (defcap LISTED:bool (id:string seller:string price:decimal fee-bps:integer)
+    @doc "Emitted when a token is listed. `fee-bps` is the snapshotted platform \
+         \/ marketplace fee rate the sale will charge." @event)
+
+  (defcap DELISTED:bool (id:string)
+    @doc "Emitted when an active listing is cancelled." @event)
+
+  (defun list-token:string (id:string price:decimal currency:module{fungible-v2})
+    @doc "List an owned, resident token at a fixed PRICE in CURRENCY. PRICE MUST \
+         \be positive and satisfy the currency precision. A royalty-bearing \
+         \token MUST NOT be listable at a price whose floored royalty is zero \
+         \(SPEC S2: a dust price is a royalty-free ownership change). The fee \
+         \rate MUST be snapshotted from implementation state at list time, not \
+         \taken from the caller. Owner-authenticated (scoped). Emits LISTED.")
+
+  (defun delist:string (id:string)
+    @doc "Cancel the caller's active listing. Owner-authenticated. Emits \
+         \DELISTED.")
+
+  (defun buy:string (id:string buyer:string buyer-guard:guard)
+    @doc "Purchase a listed token at its fixed price. BUYER/BUYER-GUARD MUST be \
+         \a principal account; BUYER signs the currency transfer of exactly \
+         \`price` into the escrow. Settlement MUST pay creator (royalty) + \
+         \platform/marketplace (fee, at the snapshotted rate) + seller \
+         \(remainder) and MUST assert escrow conservation (SPEC S2). No \
+         \parameter that affects the money MAY be read from the buy transaction \
+         \(SPEC S3). Emits nft-asset-v1.SOLD.")
+
+  (defun get-listing:object{listing} (id:string)
+    @doc "The public listing row. MUST project exactly the `listing` schema.")
+
+  (defun get-escrow-account:string ()
+    @doc "The escrow account that briefly holds sale funds during settlement. \
+         \Published so integrators can verify it is a capability-guarded \
+         \principal (no external party can spend it) and MUST NOT send funds to \
+         \it directly.")
+)

--- a/contracts/standards/nft-xchain-v1.pact
+++ b/contracts/standards/nft-xchain-v1.pact
@@ -1,0 +1,56 @@
+;; nft-xchain-v1 — Kadena cross-chain NFT relocation standard (Pact 5 / KDA-CE)
+;;
+;; The portability half of the NFT standard: how a token leaves one Chainweb
+;; chain and arrives on another via a two-step SPV defpact. OPT-IN — a
+;; marketplace that operates on a single chain implements only nft-asset-v1
+;; (+ nft-market-v1) and omits this. A module that DOES implement it MUST also
+;; implement nft-asset-v1.
+;;
+;; This is the interface that makes "a token minted on chain 1, sold on chain
+;; 0" behave identically across competing marketplaces: same defpact shape,
+;; same events, same tombstone semantics, so one indexer follows a token across
+;; chains regardless of which marketplace moved it.
+;;
+;; Cross-chain behavior is DEVNET-provable only — SPV is unsupported in the
+;; bare REPL, so a green cross-chain .repl is a false positive (SPEC S6). The
+;; conformance suite checks only the same-chain guards of step 0; the SPV round
+;; trip is validated on a multi-chain devnet.
+;;
+;; Cannot be upgraded; a breaking change ships as nft-xchain-v2.
+
+(interface nft-xchain-v1
+
+  @doc "Standard surface for relocating a 1-of-1 token between Chainweb chains. \
+       \A move is a two-step SPV defpact: step 0 on the source chain tombstones \
+       \the token locally and yields its full record; step 1 on the target \
+       \chain writes it live. A move MUST NOT change beneficial ownership of a \
+       \sale-only token (SPEC S5: that would bypass the royalty) — such a token \
+       \may relocate ONLY to its own current owner. Listings MUST NOT travel. \
+       \There is NO rollback across the yield: an initiated move is completed \
+       \by continuation only, and an upgrade while moves are in flight MUST \
+       \bless the prior module hash (SPEC S6)."
+
+  (defcap MOVE-INITIATED:bool
+    (id:string owner:string receiver:string target-chain:string)
+    @doc "Emitted by step 0 on the source chain when a token is tombstoned for \
+         \relocation. After this event the token is not resident on this chain \
+         \until the move is rolled forward on TARGET-CHAIN." @event)
+
+  (defcap MOVE-COMPLETED:bool (id:string receiver:string source-chain:string)
+    @doc "Emitted by step 1 on the target chain when the token becomes resident \
+         \there, owned by RECEIVER." @event)
+
+  (defpact move-crosschain:string
+    ( id:string
+      receiver:string
+      receiver-guard:guard
+      target-chain:string )
+    @doc "Relocate token ID to TARGET-CHAIN. Step 0 (source): owner-authorized; \
+         \the token MUST be resident and not listed; TARGET-CHAIN MUST be a \
+         \valid, different Chainweb chain id; a sale-only token's RECEIVER/ \
+         \RECEIVER-GUARD MUST equal its current owner (SPEC S5); the row is \
+         \tombstoned and the full record yielded (emits MOVE-INITIATED). Step 1 \
+         \(target, via SPV continuation): the record is written resident, owned \
+         \by RECEIVER (emits MOVE-COMPLETED). A RECEIVER on a transferable token \
+         \MUST be a principal account.")
+)

--- a/docs/adr/ADR-018-nft-standard.md
+++ b/docs/adr/ADR-018-nft-standard.md
@@ -1,0 +1,130 @@
+# ADR-018: A Kadena NFT interface standard (nft-asset-v1 / nft-market-v1 / nft-xchain-v1)
+
+**Status:** ACCEPTED (2026-07-07 — founder decision: shared-standard-surface v1; multi-currency
+market; implementation-private fee routing; adopt in both royalty-sale and Gallery)
+**Date:** 2026-07-07
+**Decider:** Solo developer (Smart Pacts); founder set the scope and the two open forks
+**Relates to:** ADR-017 (Gallery is the production implementer), ADR-001 (catalog/registry layout),
+the Marmalade V2 security & architecture analysis (2026-07-06, the source of the S-clauses)
+
+---
+
+## 1. Context
+
+Founder direction (2026-07-07): *"we still want to create the standards. Future companies will take
+this product from the Pact organization or from us and create their own marketplace; we want all
+marketplaces to be compatible between them. We want to properly set the standards"* — and the
+standard should reflect *what the public expects from markets* (per the Marmalade V2 analysis).
+
+"Multiple future implementers we do not control" is exactly the condition under which a Pact
+interface earns its existence. Until now both NFT contracts were single-implementation modules, so
+an interface would have been a banned one-impl abstraction. That changed with this direction.
+
+Two facts shaped every decision:
+
+1. **Interfaces cannot be upgraded** (`CannotUpgradeInterface`). Whatever v1 freezes is permanent
+   on-chain; the only escape is publishing `-v2` and migrating an ecosystem (the `fungible-v1` →
+   `fungible-v2` precedent). So v1 must be small, version-suffixed, and validated against ≥2
+   independent implementations before any public deploy.
+2. **The public expectation** (Marmalade analysis §1): creators want royalties that hold, buyers
+   want to receive exactly what they paid for, owners want to move their own property. The one
+   design on any chain that enforces all three without a trusted marketplace is Kadena's escrow
+   model. The standard's job is to make that model portable across marketplaces, not to reinvent it.
+
+## 2. Decision
+
+### 2.1 Scope — "compatible" means shared surface, not shared custody (founder fork #1)
+v1 delivers **compatibility of tooling and semantics**: every marketplace exposes the same views,
+emits the same events, and obeys the same royalty/settlement rules, so one wallet, one indexer, one
+aggregator work across all of them. Each marketplace's tokens live in its own module (the
+`fungible-v2` model — every contract is its own ledger, yet one wallet handles them all). **Full
+asset portability across a shared neutral ledger is explicitly NOT a v1 goal** (that is Marmalade's
+problem space and reopens royalty-bypass / modref-trust); if the ecosystem ever needs it, that is a
+v2 track with its own ADR. Versioning means choosing shared-surface now does not foreclose it.
+
+### 2.2 Three layered interfaces
+Standardize what tooling depends on; keep the trusted economic surface small and private (the
+Marmalade lesson — over-coupling the policy-manager was its core mistake).
+
+- **`nft-asset-v1`** (required) — the token: `mint`, `transfer`, ownership/royalty views
+  (`get-token`, `owner-of`, `is-listed`), the shared `token` schema, and the event vocabulary
+  (`MINTED` with initial owner, `TRANSFERRED`, `SOLD`). This is the indexer contract.
+- **`nft-market-v1`** (if sellable; requires the asset interface) — fixed-price sale:
+  `list-token(id, price, currency)`, `delist`, `buy(id, buyer, buyer-guard)`, `get-listing`,
+  `get-escrow-account`, plus `LISTED`/`DELISTED`. Settlement MUST be single-point and
+  conservation-asserted; economics MUST come from state, never the buy transaction.
+- **`nft-xchain-v1`** (opt-in; requires the asset interface) — two-step SPV `move-crosschain` +
+  `MOVE-INITIATED`/`MOVE-COMPLETED`. Where cross-marketplace cross-chain compatibility lives.
+
+### 2.3 Currency: multi-currency in the market interface (founder fork #2a)
+`list-token` carries `currency:module{fungible-v2}`; the price is denominated in it. A KDA-only
+marketplace always passes `coin`. This matches royalty-sale (already multi-currency) and the
+analysis's POL-4 finding (*parameterize the settlement fungible*), and keeps stable-denominated
+sales possible without a second interface. Gallery, being KDA-revenue, accepts the arg but enforces
+`currency == coin`.
+
+### 2.4 Fee routing: implementation-private (founder fork #2b)
+The interface standardizes the fee *rate* and *amount* (via `LISTED.fee-bps` and `SOLD.fee`) but NOT
+how the fee **payee** is chosen. Gallery routes to a fixed SPT revenue account; royalty-sale lets
+the seller name a marketplace. Both conform; tooling sees fees through events. Fixing fee routing
+into the ABI would be exactly the over-coupling to avoid.
+
+### 2.5 The normative rules (SPEC.md, S1–S6)
+The signatures fix shape; six MUST-clauses fix behavior, each traced to a Marmalade failure mode:
+S1 fail-closed inputs (POL-1), S2 one conservation-asserted settlement + dust-floor listing ban
+(ARCH-1/POL-3), S3 economics-from-state (ARCH-2), S4 explicit robust sale-only (POL-2), S5
+cross-chain royalty non-bypass, S6 no-rollback/bless-in-flight/devnet-proven.
+
+### 2.6 Governance home
+The interfaces live in the **PCO catalog** (`contracts/standards/`), the neutral standards body —
+a standard cannot credibly live in one competitor's namespace. `royalty-sale` is the MIT reference
+implementation; `smartpacts-gallery` is the production implementation. Neither defines the standard;
+SPEC.md + the three interfaces do.
+
+## 3. Conformance — proven, not asserted
+
+A `conformance-driver` module knows only `module{nft-asset-v1}` / `module{nft-market-v1}`; the
+conformance suites drive each candidate **through that modref**, so passing proves the surface is
+polymorphically usable, not merely name-compatible. Run against **both** implementations:
+
+| Implementation | asset | market | xchain | Evidence |
+|---|---|---|---|---|
+| `royalty-sale` (reference) | ✓ | ✓ | n/a | `royalty-sale-conformance.repl` — PASS (modref-driven) |
+| `smartpacts-gallery` (production) | ✓ | ✓ | ✓ | `gallery-conformance.repl` — PASS; **devnet 31/31** incl. SPV round trip |
+
+The conformance suite already earned its keep: it caught the reference implementation
+(`royalty-sale`) violating **S2** — it lacked the dust-price listing guard the SPEC requires (and
+that Gallery already had via audit F3). Fixed in `list-token-with-fee`; the standard tightened the
+reference, which is the point of a conformance gate.
+
+## 4. On-chain findings (KDA-CE)
+
+- **Root namespace is locked.** `"Cannot install modules in the root namespace"` — only genesis
+  interfaces (`fungible-v2`, `fungible-xchain-v1`) live there. The standard interfaces therefore
+  deploy **into the implementer's namespace**, and a module + interface in the same namespace
+  resolve by **bare name** (no source qualification needed). On testnet the interfaces live in the
+  Gallery namespace alongside the module. Proven on the devnet campaign.
+- **Interface conformance requires exact event signatures.** An implementer MUST declare a `defcap`
+  for every `@event` in the interface, with matching parameter list AND `:bool` return — a mismatch
+  fails to load. Views may keep a richer private table schema but MUST project onto the interface's
+  named schema.
+- Gas: Gallery deploy rose ~1.5k (interface machinery) to 24,803 — well under the 150k ceiling.
+
+## 5. Consequences
+
+**Positive.** A real standard, validated against two independently-built marketplaces through a
+modref before any public deploy; Gallery adopts it before its testnet port (nothing shipped is
+wasted — the module just gains `implements` lines); third parties demonstrate conformance by passing
+the same suite; the standard is small and every clause is mechanically checkable.
+
+**Costs / non-goals.** No auctions, offers/bids, bundles, lazy minting, fractional ownership, shared
+cross-marketplace ledger, or metadata schema beyond a `uri` string in v1 — each is a candidate
+additive interface so v1 stays small. Conforming tokens are NOT visible to Marmalade-aware wallets
+(different, marmalade-free type family — a deliberate founder directive), only to standard-aware
+tooling.
+
+**Deploy gates (unchanged from ADR-017).** Testnet = the v2 release line
+(`n_d97ffd2ca290429b5dc85ce551a8d07d038e9641`): interfaces + module deploy together, all gates
+re-run, hash-verify before announcing cross-chain moves, bless on every upgrade. Mainnet +
+standards-body publication are counsel-gated (D7 flag #5). Publishing the interfaces publicly is the
+moment their signatures freeze forever — do it only after the testnet validation confirms the shape.


### PR DESCRIPTION
## What

A **Kadena NFT interface standard** (ADR-018) so independently-built marketplaces are compatible — one wallet, one indexer, one aggregator across every implementer (the `fungible-v2` model: shared surface + semantics, each marketplace keeps its own ledger). Plus adoption in `royalty-sale` as the reference implementation.

Three interfaces (`contracts/standards/`), **un-upgradeable** so version-suffixed and validated against two independent implementations before any public deploy:

- **`nft-asset-v1`** — the token, ownership, immutable creator royalty, and the event vocabulary (`MINTED` with owner / `TRANSFERRED` / `SOLD`) an indexer reads.
- **`nft-market-v1`** — fixed-price sale through a conservation-asserted escrow; `list-token(id, price, currency)` (any `fungible-v2`); fee routing is implementation-private (surfaced via `LISTED.fee-bps` / `SOLD.fee`).
- **`nft-xchain-v1`** — opt-in two-step SPV `move-crosschain`.

`SPEC.md` carries six normative rules (S1–S6) the signatures can't express, each traced to a failure mode in the Marmalade V2 analysis.

## Conformance is proven, not asserted

`conformance-driver.pact` drives a candidate **through a `module{X}` reference** — passing proves the surface is polymorphically usable, not merely name-compatible. Two implementers pass the **same** modref-driven suite:

- `royalty-sale` (this PR, reference) — `royalty-sale-conformance.repl`
- `smartpacts-gallery` (production, SmartPacts/gallery) — devnet 31/31 incl. the SPV round trip

That's the "compatible between marketplaces" guarantee, demonstrated. The suite already earned its keep twice: it caught the reference implementation missing the **S2** dust-price listing guard (fixed here in `list-token-with-fee`), and it now includes an **adversarial S3** vector — it drives `buy` with a malicious payload of economic overrides (fee, royalty, price, payee) and asserts the state-derived split is unchanged, closing the one "conforming yet unsafe" gap a signature cannot.

## royalty-sale adoption

`(implements nft-asset-v1)` + `(implements nft-market-v1)`. `MINTED` gains `owner`. `list-token` split into the standard 3-arg entry + `list-token-with-fee` (the seller-named-fee extension, unchanged behavior). Views project onto the interface schemas. The prior audited settlement/escrow/conservation logic is untouched.

## Security audit

Independent cold-context review at highest effort over the standard + adoption: **GO, zero findings at MEDIUM or above.** Verified against the Pact-5 Haskell source: modref equality, object-`+` merge, guard `Eq`, the dust-guard node-safety and math, the fee-free sentinel path (never a live spend), and no regression in the reference module. The three INFO items are addressed (adversarial S3 test + SPEC note; `get-token` cross-chain residence note).

## Gates

3 repls green (`royalty-sale-test`, `royalty-sale-market-sim`, `royalty-sale-conformance`), static gate PASS (0 violations). No Claude/Anthropic attribution; author is the GitHub noreply address.

## Notes

- KDA-CE finding baked into the design: the **root namespace is locked**, so standard interfaces deploy into the implementer's namespace and resolve by bare name (ADR-018 §4).
- Publishing the interfaces publicly freezes their signatures forever — do it only after testnet validation confirms the shape.
