### PR TITLE
feat(standards): per-NFT cross-chain spike (verify-spv, deploy-on-demand)

### DIFF
--- a/contracts/standards/nft-xchain-spike/XCHAIN-SPIKE.md
+++ b/contracts/standards/nft-xchain-spike/XCHAIN-SPIKE.md
@@ -1,0 +1,89 @@
+# Per-NFT cross-chain spike — the painting moves chain to chain
+
+**Result: it works.** A self-sovereign per-NFT module can move across Chainweb chains **without being
+pre-deployed on every chain** — it is deployed on demand at the destination and mints itself from a
+verified SPV proof of its departure at the source. Proven on a real multi-chain KDA-CE devnet, **14/14
+checks pass**, including the two adversarial defenses (replay to the wrong chain, double-claim).
+
+This resolves the one open design question the consignment spike deliberately deferred.
+
+## The hard constraint, and the mechanism that solves it
+
+A Pact module lives only on the chains it is deployed to, and the defpact **continuation** transport
+(the current Gallery pattern) resumes the *same module* on the target chain — so it needs that module
+already deployed everywhere. With one-module-per-NFT that would force an artist to deploy on all 20
+chains up front, even for an NFT that only ever lives on one.
+
+The other cross-chain mechanism is **`verify-spv "TXOUT"`** — a generic native that verifies a proof
+of another chain's *transaction output* inside arbitrary code. We use it so a **freshly-deployed**
+module on the target chain verifies a proof of the *departure* on the source chain and mints itself
+from the proven payload. The artist pays deploy gas **only on chains the NFT actually visits**.
+
+### The verify-spv recipe (established here, non-obvious)
+- The source transaction whose proof you verify **must return an object** (a `TXOUT` proof verifies
+  the tx *result*; a non-object result fails `verifySPV: command result not an object`).
+- `@kadena/client`'s `pollCreateSpv` returns **base64(JSON)**; `verify-spv "TXOUT"` wants the **decoded
+  JSON object** (`Buffer.from(proof,'base64')` → `JSON.parse` → pass as env-data).
+- The SPV layer **natively binds the proof's target chain** — redeeming a proof on the wrong chain
+  fails with `verifySPV: cannot redeem spv proof on wrong target chain`, independent of any app check.
+
+## The model (residency + SPV-gated transition)
+
+Each chain's copy of the NFT carries `present:bool` — true on exactly one chain, false everywhere it
+has left. A move is two steps:
+
+- **`depart(target-chain)`** on the source: owner-authorized; the token must be present here and not
+  consigned; sets `present:false`; **returns** the move payload (origin-id, owner, creator, royalty,
+  uri, source-chain, target-chain) as the transaction's object result.
+- **`claim(proof)`** on the target: `verify-spv "TXOUT"` returns the proven payload; the module
+  `insert`s itself `present:true` with the **same** creator/royalty/owner; enforces
+  `target-chain == this-chain`.
+
+**Double-residency is uncreatable by construction:** `present:true` on the target is reachable only by
+consuming a proof that `present:false` was set on the source. The invariant is maintained by the
+transition, not by a global cross-chain scan (which is impossible to do atomically — no contract can
+synchronously read all 20 chains). A residency scan across chains remains useful as an off-chain
+indexer sanity check, but it is not what enforces correctness.
+
+## What the devnet campaign proves (`gallery/devnet/src/nft-xchain-spike.ts`, 14/14)
+
+| Check | Result |
+|---|---|
+| X01 mint on c1 — present, owner=artist | PASS |
+| X02 depart c1→c0 — succeeds, present=false on c1, payload returned | PASS |
+| X03 claim on c0 (deploy-on-demand + verify-spv) — present=true, **owner/royalty/creator all preserved** | PASS |
+| X04 replay the c0-proof onto c2 — **REJECTED** (SPV layer: "wrong target chain"; claim also enforces the chain) | PASS |
+| X05 double-claim on c0 — **REJECTED** (`insert` fails: already present) | PASS |
+| X06 sell the arrived NFT on c0 — buyer owns it; the **original creator** gets royalty+proceeds (97.5) on the sale chain | PASS |
+
+Gas: NFT module deploy 17,654 (one-time, per chain visited, artist-paid); mint 235; depart/claim/sale
+all well under the 150k ceiling.
+
+## Interface finding (de-risks the freeze)
+
+**Cross-chain needs NO change to the `nft-asset` interface.** `depart`/`claim` are module-level
+extensions the *owner* calls; a marketplace never touches them (it only calls the standard `buy` via a
+modref). So the provisional interface signatures are stable regardless of the cross-chain mechanism —
+the interface can be frozen without waiting on cross-chain.
+
+## Contents
+
+- `nft-single-xchain.pact` — the cross-chain NFT (the consignment `nft-single` plus `present`
+  residency and `depart`/`claim`). Static gate: 0 violations.
+- `nft-asset.pact` / `nft-marketplace.pact` / `simple-market.pact` — the same standard surface as the
+  consignment spike (reused verbatim).
+- The runnable devnet campaign lives in the gallery devnet harness
+  (`gallery/devnet/src/nft-xchain-spike.ts`) because it depends on that `@kadena/client` infra; it
+  reads the modules from this directory.
+
+## Open items for the production build
+
+- **Consignment across a move** — this spike departs an *unconsigned* token (delist before moving, as
+  in the current Gallery). Whether a listing should survive a move (it should not — listings are
+  chain-local) is confirmed, but the production module should reject a move-while-consigned explicitly
+  (it does: `depart` enforces not-listed).
+- **Origin-id uniqueness** — here `origin-id` is the module's `SELF` key; production wants a globally
+  unique origin id (e.g. the origin module's namespaced name) so an indexer can follow one painting
+  across chains and distinguish it from another module's token.
+- **Signatures** remain provisional until the production build + testnet validation (a published
+  interface freezes forever).

--- a/contracts/standards/nft-xchain-spike/nft-asset.pact
+++ b/contracts/standards/nft-xchain-spike/nft-asset.pact
@@ -1,0 +1,70 @@
+;; nft-asset — self-custody NFT standard
+;;
+;; The asset half of the asset/marketplace SEPARATION. Unlike a marketplace-owned
+;; token (a row inside a marketplace ledger), an nft-asset module OWNS ITSELF: it
+;; records its own owner, its immutable creator royalty, and the
+;; single active CONSIGNMENT (which marketplace guard may currently sell it).
+;; This is what lets the same NFT be sold by any marketplace, in any namespace —
+;; "the painting moves gallery to gallery."
+;;
+;; Two Pact-5 facts drive the shape (design note):
+;;   * A foreign marketplace cannot acquire this module's capabilities, so a sale
+;;     is authorized by an enforce-guard on the RECORDED consignment guard, not a
+;;     cap the caller acquires. `buy` is public; its guard check passes only for
+;;     the currently-consigned marketplace.
+;;   * The NFT pays its OWN royalty inside `buy`, so no marketplace can skim or
+;;     bypass it, whoever triggers the sale.
+;;
+;; Spike interface — signatures are provisional (a production interface is frozen
+;; forever; this one is a proving ground, not published).
+
+(interface nft-asset
+
+  @doc "A self-custody 1-of-1 NFT with an immutable creator royalty and a single \
+       \active marketplace consignment. Ownership, royalty, and the consignment \
+       \are authoritative HERE, in the asset — a marketplace owns no tokens."
+
+  ;; --- views (read-only) ----------------------------------------------------
+  (defun get-owner:string ()
+    @doc "The current owner account.")
+  (defun get-creator:string ()
+    @doc "The permanent royalty payee, fixed at mint.")
+  (defun get-royalty-bps:integer ()
+    @doc "The immutable royalty rate in basis points.")
+  (defun get-price:decimal ()
+    @doc "The consigned sale price (0.0 when not listed).")
+  (defun is-listed:bool ()
+    @doc "True iff the NFT is currently consigned to a marketplace. Total.")
+  (defun is-frozen:bool ()
+    @doc "True iff the economic terms are locked (always true after mint). Total.")
+
+  ;; --- owner actions --------------------------------------------------------
+  (defun transfer:string (receiver:string receiver-guard:guard)
+    @doc "Free (no-payment) transfer. Owner-authorized. MUST reject when the NFT \
+         \is currently consigned (delist first). RECEIVER MUST be a principal.")
+
+  (defun list-for-sale:string (mkt-guard:guard price:decimal)
+    @doc "Consign this NFT to ONE marketplace: record MKT-GUARD (the guard only \
+         \that marketplace can satisfy) and PRICE. Owner-authorized. A second \
+         \list-for-sale SUPERSEDES the first — exactly one consignment is ever \
+         \active, so two marketplaces can never both sell it. PRICE MUST be \
+         \positive and MUST NOT floor the royalty to zero.")
+
+  (defun delist:string ()
+    @doc "Revoke the active consignment (the painting returns to the wallet). \
+         \Owner-authorized.")
+
+  ;; --- the sale (public; authorized by the consignment guard) ---------------
+  (defun buy:string
+    ( buyer:string buyer-guard:guard
+      fee-account:string fee-guard:guard fee-bps:integer )
+    @doc "Purchase the consigned NFT. Callable by ANYONE, but MUST enforce the \
+         \recorded consignment guard — so in practice only the consigned \
+         \marketplace's `execute-sale` (which holds that guard) can complete it. \
+         \BUYER signs the coin transfer of the full price into THIS module's \
+         \escrow; the module pays royalty (from state, to the creator) + the \
+         \marketplace fee (FEE-BPS, to FEE-ACCOUNT, capped so a hostile fee \
+         \cannot exceed the module's limit) + the remainder to the seller, and \
+         \asserts the escrow returns to baseline. BUYER and FEE-ACCOUNT MUST be \
+         \principals. Economics (royalty, price) come from STATE, never the tx.")
+)

--- a/contracts/standards/nft-xchain-spike/nft-marketplace.pact
+++ b/contracts/standards/nft-xchain-spike/nft-marketplace.pact
@@ -1,0 +1,31 @@
+;; nft-marketplace — sale-contract standard
+;;
+;; The marketplace half of the separation: a sale contract that OWNS NO TOKENS.
+;; It presents a guard (the one an owner consigns to via nft-asset.list-for-sale)
+;; and drives a foreign NFT's sale through a module{std.nft-asset} modref.
+;;
+;; The Pact-5 constraint (design note): a caller cannot acquire THIS module's
+;; SELL capability from outside, so `execute-sale` is a PUBLIC entry that acquires
+;; SELL internally and calls nft::buy. The NFT is a modref PARAMETER — one
+;; marketplace sells any conforming NFT, never a hard-coded one.
+
+(interface nft-marketplace
+
+  @doc "A permissionless NFT sale contract. Owns no tokens; sells any nft-asset \
+       \consigned to its guard. Its fee policy (rate, payee) is its own — the \
+       \asset caps the fee it will accept, but does not dictate it."
+
+  (defun marketplace-guard:guard ()
+    @doc "The guard an owner consigns to (nft-asset.list-for-sale mkt-guard …). \
+         \Only this marketplace can satisfy it, so only this marketplace can \
+         \drive a sale of an NFT consigned to it.")
+
+  (defun execute-sale:string
+    ( nft:module{std.nft-asset}
+      buyer:string buyer-guard:guard )
+    @doc "Sell NFT (consigned to this marketplace) to BUYER. Acquires this \
+         \marketplace's SELL authority internally and calls nft::buy, passing \
+         \this marketplace's fee account/guard and rate. The NFT enforces the \
+         \consignment guard and pays the creator royalty itself, so this \
+         \marketplace can never bypass the royalty — it only adds its own fee.")
+)

--- a/contracts/standards/nft-xchain-spike/nft-single-xchain.pact
+++ b/contracts/standards/nft-xchain-spike/nft-single-xchain.pact
@@ -1,0 +1,264 @@
+;; nft-single-xchain — a self-sovereign, frozen-at-mint NFT that can MOVE ACROSS
+;; CHAINS without pre-deploying on every chain (spike).
+;;
+;; A Pact module cannot ship its own code cross-chain, and the defpact
+;; continuation transport requires the SAME module to already exist on the target
+;; chain. This module uses the OTHER cross-chain mechanism — `verify-spv "TXOUT"`
+;; — so the NFT can be DEPLOYED ON DEMAND at a destination and mint itself from a
+;; verified proof of its departure at the source. The artist/owner pays deploy
+;; gas only on chains the NFT actually visits.
+;;
+;; RESIDENCY: `present` is true on exactly ONE chain and false everywhere the NFT
+;; has left. A move is depart (source: present->false, return the payload) then
+;; claim (target: verify-spv the payload, insert present->true). `present=true`
+;; on the target is reachable ONLY by consuming proof of `present=false` at the
+;; source, so the NFT can never be live on two chains — the invariant is
+;; maintained by the transition, not audited after the fact.
+;;
+;; Same-chain behavior (consignment, sale, royalty) is identical to nft-single;
+;; every operation additionally requires `present` on this chain.
+
+(namespace (read-msg 'ns))
+
+(module nft-single-xchain GOVERNANCE
+  @doc "A self-custody NFT with an immutable creator royalty, one active \
+       \marketplace consignment, its own escrow, and cross-chain relocation via \
+       \verify-spv. Frozen at mint."
+
+  (implements std.nft-asset)
+
+  ;; --- governance: freezes at mint ------------------------------------------
+  (defconst ADMIN-KS:string (read-msg 'admin-ks))
+  (defcap GOVERNANCE ()
+    (enforce (not (minted)) "NFT is frozen — terms are immutable after mint")
+    (enforce-keyset ADMIN-KS))
+
+  ;; --- constants ------------------------------------------------------------
+  (defconst BPS-DENOM:integer 10000)
+  (defconst MAX-ROYALTY-BPS:integer 5000)
+  (defconst MAX-FEE-BPS:integer 1000)
+  ;; the immutable origin id: the token's identity, stable across every chain it
+  ;; visits (set at mint on the origin chain, carried verbatim in the payload).
+  (defconst SELF:string "self")
+
+  ;; --- escrow ---------------------------------------------------------------
+  (defcap SPEND ()
+    @doc "Internal escrow-spend token. Weak body by design: acquired only inside \
+         \`buy`'s settlement, which pays out exactly what was paid in (asserted)."
+    true)
+  (defun escrow-guard-pred:bool () (require-capability (SPEND)))
+  (defun create-escrow-guard:guard () (create-user-guard (escrow-guard-pred)))
+  (defconst ESCROW:string (create-principal (create-escrow-guard)))
+
+  ;; --- state ----------------------------------------------------------------
+  (defschema nft
+    minted:bool
+    present:bool            ;; RESIDENCY: is the NFT live on THIS chain?
+    origin-id:string        ;; immutable identity across chains
+    creator:string
+    creator-guard:guard
+    royalty-bps:integer
+    owner:string
+    owner-guard:guard
+    uri:string
+    mkt-guard:guard
+    price:decimal
+    listed:bool)
+  (deftable state:{nft})
+
+  ;; the object shape a depart RETURNS and a claim VERIFIES (the TXOUT payload).
+  (defschema move-payload
+    origin-id:string
+    owner:string
+    owner-guard:guard
+    creator:string
+    creator-guard:guard
+    royalty-bps:integer
+    uri:string
+    source-chain:string
+    target-chain:string)
+
+  ;; --- events ---------------------------------------------------------------
+  (defcap MINTED:bool (creator:string owner:string royalty-bps:integer) @event true)
+  (defcap LISTED:bool (price:decimal) @event true)
+  (defcap DELISTED:bool () @event true)
+  (defcap SOLD:bool (seller:string buyer:string price:decimal royalty:decimal fee:decimal) @event true)
+  (defcap TRANSFERRED:bool (from:string to:string) @event true)
+  (defcap DEPARTED:bool (origin-id:string owner:string target-chain:string) @event true)
+  (defcap CLAIMED:bool (origin-id:string owner:string source-chain:string) @event true)
+
+  ;; --- helpers --------------------------------------------------------------
+  (defun minted:bool ()
+    (with-default-read state SELF { 'minted: false } { 'minted := m } m))
+  (defun is-present:bool ()
+    (with-default-read state SELF { 'present: false } { 'present := p } p))
+  (defun this-chain:string () (at 'chain-id (chain-data)))
+
+  (defcap OWNER ()
+    (enforce-guard (at 'owner-guard (read state SELF))))
+
+  ;; --- mint (origin chain; freezes; present=true) ---------------------------
+  (defun mint:string
+    ( owner:string owner-guard:guard
+      creator:string creator-guard:guard
+      royalty-bps:integer uri:string )
+    @doc "Create THE token on its ORIGIN chain (present=true). One-time. Sets \
+         \frozen. origin-id = SELF (this module's identity). Principals required."
+    (enforce (validate-principal owner-guard owner) "owner must be a principal")
+    (enforce (validate-principal creator-guard creator) "creator must be a principal")
+    (enforce (and (>= royalty-bps 0) (<= royalty-bps MAX-ROYALTY-BPS))
+      (format "royalty-bps must be in [0, {}]" [MAX-ROYALTY-BPS]))
+    (insert state SELF
+      { 'minted: true, 'present: true, 'origin-id: SELF
+      , 'creator: creator, 'creator-guard: creator-guard, 'royalty-bps: royalty-bps
+      , 'owner: owner, 'owner-guard: owner-guard, 'uri: uri
+      , 'mkt-guard: owner-guard, 'price: 0.0, 'listed: false })
+    (emit-event (MINTED creator owner royalty-bps))
+    "minted")
+
+  ;; --- views (nft-asset) ----------------------------------------------------
+  (defun get-owner:string ()
+    (with-read state SELF { 'owner := o, 'present := p }
+      (enforce p "token is not on this chain") o))
+  (defun get-creator:string () (at 'creator (read state SELF)))
+  (defun get-royalty-bps:integer () (at 'royalty-bps (read state SELF)))
+  (defun get-price:decimal () (at 'price (read state SELF)))
+  (defun is-listed:bool ()
+    (with-default-read state SELF { 'listed: false } { 'listed := l } l))
+  (defun is-frozen:bool () (minted))
+
+  ;; --- free transfer (nft-asset) --------------------------------------------
+  (defun transfer:string (receiver:string receiver-guard:guard)
+    (enforce (validate-principal receiver-guard receiver) "receiver must be a principal")
+    (with-read state SELF { 'listed := listed, 'present := present }
+      (enforce present "token is not on this chain")
+      (enforce (not listed) "delist before transferring"))
+    (with-capability (OWNER)
+      (let ((from (at 'owner (read state SELF))))
+        (update state SELF { 'owner: receiver, 'owner-guard: receiver-guard })
+        (emit-event (TRANSFERRED from receiver))
+        "transferred")))
+
+  ;; --- consignment (nft-asset) ----------------------------------------------
+  (defun list-for-sale:string (mkt-guard:guard price:decimal)
+    (enforce (> price 0.0) "price must be positive")
+    (with-read state SELF { 'royalty-bps := rbps, 'present := present }
+      (enforce present "token is not on this chain")
+      (if (> rbps 0)
+        (let ((prec (coin.precision)))
+          (enforce (> (floor (/ (* price (dec rbps)) (dec BPS-DENOM)) prec) 0.0)
+            "price too low: royalty rounds to zero"))
+        true))
+    (with-capability (OWNER)
+      (update state SELF { 'mkt-guard: mkt-guard, 'price: price, 'listed: true })
+      (emit-event (LISTED price))
+      "listed"))
+
+  (defun delist:string ()
+    (with-read state SELF { 'present := present }
+      (enforce present "token is not on this chain"))
+    (with-capability (OWNER)
+      (update state SELF { 'listed: false })
+      (emit-event (DELISTED))
+      "delisted"))
+
+  ;; --- the sale (nft-asset) -------------------------------------------------
+  (defun buy:string
+    ( buyer:string buyer-guard:guard
+      fee-account:string fee-guard:guard fee-bps:integer )
+    (enforce (validate-principal buyer-guard buyer) "buyer must be a principal")
+    (enforce (validate-principal fee-guard fee-account) "fee account must be a principal")
+    (enforce (and (>= fee-bps 0) (<= fee-bps MAX-FEE-BPS))
+      (format "fee-bps must be in [0, {}] (asset-capped)" [MAX-FEE-BPS]))
+    (with-read state SELF
+      { 'mkt-guard := mkt-guard, 'price := price, 'listed := listed, 'present := present
+      , 'creator := creator, 'creator-guard := creator-guard
+      , 'owner := seller, 'owner-guard := seller-guard, 'royalty-bps := rbps }
+      (enforce present "token is not on this chain")
+      (enforce listed "not listed")
+      (enforce-guard mkt-guard)
+      (let* ((prec (coin.precision))
+             (royalty (floor (/ (* price (dec rbps)) (dec BPS-DENOM)) prec))
+             (fee (if (> fee-bps 0) (floor (/ (* price (dec fee-bps)) (dec BPS-DENOM)) prec) 0.0))
+             (proceeds (- price (+ royalty fee))))
+        (enforce (>= proceeds 0.0) "royalty + fee exceed price")
+        (coin.transfer-create buyer ESCROW (create-escrow-guard) price)
+        (let ((funded (coin.get-balance ESCROW)))
+          (update state SELF { 'owner: buyer, 'owner-guard: buyer-guard, 'listed: false })
+          (let* ((raw [ { 'account: creator, 'guard: creator-guard, 'amount: royalty }
+                      , { 'account: fee-account, 'guard: fee-guard, 'amount: fee }
+                      , { 'account: seller, 'guard: seller-guard, 'amount: proceeds } ])
+                 (payouts (fold (merge-payout) [] raw)))
+            (with-capability (SPEND) (map (pay-from-escrow) payouts)))
+          (let ((final (coin.get-balance ESCROW)))
+            (enforce (= final (- funded price)) "escrow not fully settled"))
+          (emit-event (SOLD seller buyer price royalty fee))
+          "sold"))))
+
+  ;; --- CROSS-CHAIN: depart (source) then claim (target) ---------------------
+  (defun depart:object{move-payload} (target-chain:string)
+    @doc "Leave THIS chain for TARGET-CHAIN. Owner-authorized; the token must be \
+         \present here and NOT consigned. Sets present=false (tombstone) and \
+         \RETURNS the move payload (this tx's object result — the TXOUT the \
+         \target chain will verify). A sale-only relocation cannot change the \
+         \owner (the payload carries the current owner); ownership only changes \
+         \via `buy`, so a move is never a royalty bypass. The payload binds \
+         \TARGET-CHAIN, so the resulting proof can be claimed only there."
+    (with-read state SELF
+      { 'present := present, 'listed := listed, 'origin-id := oid
+      , 'owner := owner, 'owner-guard := owner-guard
+      , 'creator := creator, 'creator-guard := creator-guard
+      , 'royalty-bps := rbps, 'uri := uri }
+      (enforce present "token is not on this chain")
+      (enforce (not listed) "delist before moving")
+      (enforce (!= target-chain "") "empty target-chain")
+      (enforce (!= (this-chain) target-chain) "cannot move to the same chain")
+      (enforce (contains target-chain coin.VALID_CHAIN_IDS)
+        "target chain is not a valid chainweb chain id")
+      (with-capability (OWNER)
+        (update state SELF { 'present: false, 'listed: false })
+        (emit-event (DEPARTED oid owner target-chain))
+        { 'origin-id: oid
+        , 'owner: owner, 'owner-guard: owner-guard
+        , 'creator: creator, 'creator-guard: creator-guard
+        , 'royalty-bps: rbps, 'uri: uri
+        , 'source-chain: (this-chain), 'target-chain: target-chain })))
+
+  (defun claim:string (proof:object)
+    @doc "Arrive on THIS chain by verifying an SPV proof of a `depart` at the \
+         \source. verify-spv returns the proven move-payload; the token is \
+         \written present=true here with the SAME creator/royalty/owner. The \
+         \proof binds TARGET-CHAIN — enforced to equal this chain, so a proof \
+         \cannot be replayed onto a different chain. `insert` fails if this \
+         \module already holds the token here (no double-claim on one chain)."
+    (let ((p (verify-spv "TXOUT" proof)))
+      (enforce (= (at 'target-chain p) (this-chain))
+        "proof is not addressed to this chain (replay/misroute rejected)")
+      (insert state SELF
+        { 'minted: true, 'present: true, 'origin-id: (at 'origin-id p)
+        , 'creator: (at 'creator p), 'creator-guard: (at 'creator-guard p)
+        , 'royalty-bps: (at 'royalty-bps p)
+        , 'owner: (at 'owner p), 'owner-guard: (at 'owner-guard p)
+        , 'uri: (at 'uri p)
+        , 'mkt-guard: (at 'owner-guard p), 'price: 0.0, 'listed: false })
+      (emit-event (CLAIMED (at 'origin-id p) (at 'owner p) (at 'source-chain p)))
+      "claimed"))
+
+  ;; --- payout helpers -------------------------------------------------------
+  (defun merge-payout:[object] (acc:[object] p:object)
+    (if (<= (at 'amount p) 0.0)
+      acc
+      (let ((seen (contains (at 'account p) (map (at 'account) acc))))
+        (if seen
+          (map (lambda (x:object)
+                 (if (= (at 'account x) (at 'account p))
+                   (+ { 'amount: (+ (at 'amount x) (at 'amount p)) } x)
+                   x))
+               acc)
+          (+ acc [p])))))
+
+  (defun pay-from-escrow:string (p:object)
+    (require-capability (SPEND))
+    (install-capability (coin.TRANSFER ESCROW (at 'account p) (at 'amount p)))
+    (coin.transfer-create ESCROW (at 'account p) (at 'guard p) (at 'amount p)))
+)

--- a/contracts/standards/nft-xchain-spike/simple-market.pact
+++ b/contracts/standards/nft-xchain-spike/simple-market.pact
@@ -1,0 +1,51 @@
+;; simple-market — a reference nft-marketplace
+;;
+;; A permissionless sale contract that owns NO tokens. It sells any nft-asset
+;; consigned to its guard. Deployed into ITS OWN namespace (the spike deploys two
+;; copies in two namespaces to prove "gallery to gallery"). Its fee account and
+;; rate are its own policy; the asset caps the fee it will accept.
+;;
+;; The Pact-5 pattern (design note): execute-sale is PUBLIC and acquires SELL
+;; internally, then calls nft::buy — a caller cannot acquire SELL from outside.
+;; The NFT is a modref parameter, so one market sells any conforming NFT.
+
+(namespace (read-msg 'ns))
+
+(module simple-market GOVERNANCE
+  @doc "A reference NFT marketplace: consignment-based, owns no tokens, charges \
+       \its own fee, sells any nft-asset via a modref. Implements nft-marketplace."
+
+  (implements std.nft-marketplace)
+
+  (defcap GOVERNANCE () (enforce-keyset (read-msg 'admin-ks)))
+
+  ;; This market's fee policy (its own; the asset caps what it will accept).
+  ;; All bound at deploy from tx data so no call-time read-msg is needed.
+  (defconst FEE-ACCOUNT:string (read-msg 'fee-account)
+    @doc "Where this market's fee is paid. A principal.")
+  (defconst FEE-GUARD:guard (read-keyset 'fee-guard)
+    @doc "The fee account's guard, captured at deploy (used by buy's payout).")
+  (defconst FEE-BPS:integer (read-integer 'fee-bps)
+    @doc "This market's fee rate. The asset rejects it if above its own cap.")
+
+  ;; The market's authority: an owner consigns to (marketplace-guard), and only
+  ;; execute-sale (which acquires SELL) satisfies it.
+  (defcap SELL ()
+    @doc "Weak body by design: acquired ONLY inside execute-sale, never handed \
+         \out. The asset's buy enforces the guard built from this cap, so only \
+         \this market — and only through execute-sale — can settle a consigned \
+         \sale."
+    true)
+  (defun sell-guard-pred:bool () (require-capability (SELL)))
+  (defun marketplace-guard:guard () (create-user-guard (sell-guard-pred)))
+
+  (defun execute-sale:string
+    ( nft:module{std.nft-asset}
+      buyer:string buyer-guard:guard )
+    @doc "Sell NFT (consigned to this market) to BUYER. Acquires SELL internally \
+         \so the asset's enforce-guard on the consignment guard passes, then \
+         \calls nft::buy with this market's fee account/guard/rate. The asset \
+         \pays the creator royalty itself — this market only adds its own fee."
+    (with-capability (SELL)
+      (nft::buy buyer buyer-guard FEE-ACCOUNT FEE-GUARD FEE-BPS)))
+)


### PR DESCRIPTION
## What

Proves the **hardest open question** in the NFT asset/marketplace-separation design: can a self-sovereign per-NFT module move across Chainweb chains? **Yes — and without being pre-deployed on every chain.** Proven on a real multi-chain KDA-CE devnet, **14/14 checks pass**.

## The problem, and the mechanism that solves it

A Pact module lives only on the chains it's deployed to, and the defpact **continuation** transport (the current Gallery cross-chain pattern) resumes the *same module* on the target chain — so it needs that module pre-deployed everywhere. With one-module-per-NFT, that would force an artist to deploy on all 20 chains up front.

Instead this uses **`verify-spv "TXOUT"`** — a fresh module deployed on the target chain verifies a proof of the *departure* transaction on the source chain and mints itself from the proven payload. **The artist pays deploy gas only on chains the NFT actually visits.**

### verify-spv recipe (non-obvious, established here)
- The source tx whose proof you verify **must return an object** (TXOUT proves the tx *result*).
- `pollCreateSpv` returns **base64(JSON)**; `verify-spv "TXOUT"` wants the **decoded JSON object**.
- The SPV layer **natively binds the proof's target chain** — redeeming on the wrong chain fails independent of any app check.

## The model — residency + SPV-gated transition

A `present:bool` flag, true on exactly one chain. A move is **`depart(target-chain)`** on the source (owner-authorized; `present→false`; returns the payload as the tx result) then **`claim(proof)`** on the target (`verify-spv` the payload; `insert` `present→true` with the same creator/royalty/owner; enforce `target-chain == this-chain`).

**Double-residency is uncreatable by construction:** `present=true` on the target is reachable only by consuming proof of `present=false` at the source — the invariant is maintained by the transition, not by an (impossible) atomic cross-chain scan.

## Proven on devnet (14/14)

| | |
|---|---|
| mint on c1 (present, owner=artist) | PASS |
| depart c1→c0 (present=false on c1, payload returned) | PASS |
| claim on c0 (deploy-on-demand + verify-spv) — **owner/royalty/creator preserved** | PASS |
| replay the c0-proof onto c2 — **REJECTED** (SPV layer: "wrong target chain") | PASS |
| double-claim on c0 — **REJECTED** (`insert` fails) | PASS |
| sell the arrived NFT on c0 — **original creator gets royalty+proceeds (97.5) on the sale chain** | PASS |

NFT module deploy 17,654 gas (one-time per chain visited, artist-paid); everything else well under the 150k ceiling. The runnable campaign lives in the gallery devnet harness (SmartPacts/gallery#5) — it needs that `@kadena/client` infra.

## Interface finding (de-risks the freeze)

**Cross-chain needs NO change to the `nft-asset` interface.** `depart`/`claim` are owner-called module extensions a marketplace never touches (it only calls the standard `buy` via a modref). The provisional interface signatures are stable regardless of the cross-chain mechanism — the interface can be frozen without waiting on cross-chain.

## Scope

A proving ground. Static gate: 0 violations on `nft-single-xchain` (1 dispositioned dependency-load WARN on `nft-marketplace`, same benign class as the consignment spike). Open for the production build: globally-unique origin-ids, and the interface freeze after testnet validation.
