### PR TITLE
feat(nft): framework Phase 1 — interfaces + identity core

### DIFF
--- a/contracts/nft/core/ledger.pact
+++ b/contracts/nft/core/ledger.pact
@@ -180,11 +180,26 @@
       { 'id: i, 'supply: s, 'precision: p, 'uri: u, 'policies: pol }))
 
   ;; --- IDENTITY (behavior kept verbatim from the correct Marmalade model) -----
+  (defun canonical-policies:[module{token-policy}] (policies:[module{token-policy}])
+    @doc "The canonical policy list: sorted by the policy's fully-qualified \
+         \name. Pact's plain `sort` is a NO-OP on module references, so the id \
+         \derivation, the stored row, the TOKEN event and hook dispatch all use \
+         \THIS order — the same policy SET derives the same token id no matter \
+         \the order the creator passed."
+    (map (lambda (o) (at 'p o))
+      (sort ['k]
+        (map (lambda (p:module{token-policy}) { 'k: (format "{}" [p]), 'p: p })
+             policies))))
+
   (defun create-token-id:string (details:object{token-details} creation-guard:guard)
     @doc "The token id is a hash of the token details + chain + CREATION-GUARD, \
-         \so the id is derived from the creator's key — forgery-proof."
-    (format "{}:{}" [TOKEN-ID-PREFIX
-      (hash [(format "{}" [details]) (at 'chain-id (chain-data)) creation-guard])]))
+         \so the id is derived from the creator's key — forgery-proof. The \
+         \policy list is canonicalized before hashing (order-independent id)."
+    (let ((canon:object{token-details}
+            { 'uri: (at 'uri details), 'precision: (at 'precision details)
+            , 'policies: (canonical-policies (at 'policies details)) }))
+      (format "{}:{}" [TOKEN-ID-PREFIX
+        (hash [(format "{}" [canon]) (at 'chain-id (chain-data)) creation-guard])])))
 
   (defun check-reserved:string (token-id:string)
     (let ((pfx (take 2 token-id)))
@@ -208,17 +223,22 @@
       policies:[module{token-policy}] creation-guard:guard )
     @doc "Create a token id. The id MUST re-derive from the details + \
          \CREATION-GUARD, the caller MUST satisfy that guard, and `insert` \
-         \fails on a duplicate — one id, one token, exactly once."
+         \fails on a duplicate — one id, one token, exactly once. The policy \
+         \list is canonicalized (name-sorted, duplicates rejected): storage, \
+         \the TOKEN event and every hook dispatch use the canonical order."
     (enforce-uri-reserved uri)
-    (let ((details:object{token-details} { 'uri: uri, 'precision: precision, 'policies: (sort policies) }))
-      (enforce-token-reserved id details creation-guard))
-    (with-capability (INIT-CALL id precision uri)
-      (policy-manager.enforce-init
-        { 'id: id, 'supply: 0.0, 'precision: precision, 'uri: uri, 'policies: policies }))
-    (with-capability (CREATE-TOKEN id creation-guard)
-      (insert tokens id { 'id: id, 'uri: uri, 'precision: precision, 'supply: 0.0, 'policies: policies })
-      (emit-event (TOKEN id precision policies uri creation-guard))
-      true))
+    (let ((canon:[module{token-policy}] (canonical-policies policies)))
+      (let ((names (map (lambda (p:module{token-policy}) (format "{}" [p])) canon)))
+        (enforce (= (length names) (length (distinct names))) "duplicate policy"))
+      (let ((details:object{token-details} { 'uri: uri, 'precision: precision, 'policies: canon }))
+        (enforce-token-reserved id details creation-guard))
+      (with-capability (INIT-CALL id precision uri)
+        (policy-manager.enforce-init
+          { 'id: id, 'supply: 0.0, 'precision: precision, 'uri: uri, 'policies: canon }))
+      (with-capability (CREATE-TOKEN id creation-guard)
+        (insert tokens id { 'id: id, 'uri: uri, 'precision: precision, 'supply: 0.0, 'policies: canon })
+        (emit-event (TOKEN id precision canon uri creation-guard))
+        true)))
 
   ;; --- accounts ----------------------------------------------------------------
   (defun create-account:bool (id:string account:string guard:guard)

--- a/contracts/nft/core/ledger.pact
+++ b/contracts/nft/core/ledger.pact
@@ -1,0 +1,313 @@
+;; nft.ledger — the shared NFT ledger: the single source of truth for token
+;; identity, ownership balances, and supply, for the PCO `nft` framework.
+;;
+;; IDENTITY (the part of the Marmalade architecture that is correct, kept
+;; verbatim in behavior): a token id is `n:{hash([token-details, chain-id,
+;; creation-guard])}` — DERIVED from the creator's creation-guard. `create-token`
+;; re-derives the id and enforces equality (enforce-token-reserved), and inserts
+;; the token row (insert fails on a duplicate id). Therefore:
+;;   * FORGERY is impossible — you cannot create a token with a given id unless
+;;     you control the creation-guard that hashes to it (CREATE-TOKEN enforces
+;;     that guard), and a fabricated id fails the protocol re-derivation.
+;;   * DOUBLE-MINT is impossible — one id, one row, forever.
+;; This is the anchor a self-sovereign per-NFT module could never provide.
+;;
+;; Lifecycle mutations route through nft.policy-manager.enforce-* (the extension
+;; point where royalty/guard/sale-only policies run), secured by the -CALL
+;; capability handshake: the manager verifies mid-call that the matching -CALL
+;; cap is in scope, proving the call originated in this ledger's lifecycle path.
+;;
+;; Phase 1 ships identity + accounting; offer/buy settlement is Phase 2 (the
+;; hardened, conservation-asserted manager). Until then the sale defpact and the
+;; manager's offer/buy hooks reject.
+
+(namespace (read-string 'ns))
+
+(module ledger GOVERNANCE
+  @doc "The nft framework's shared poly-fungible token ledger + identity anchor."
+
+  (implements ledger-iface)
+  (implements poly-fungible)
+
+  (use poly-fungible [account-details sender-balance-change receiver-balance-change])
+  (use token-policy [token-info])
+
+  (defconst ADMIN-KS:string (read-string 'admin-ks)
+    @doc "Admin keyset name, captured ONCE at deploy from the deployer's tx — \
+         \never read from a caller's payload at enforcement time.")
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset ADMIN-KS))
+
+  (defconst VERSION:integer 1)
+  (defconst TOKEN-ID-PREFIX:string "n"
+    @doc "Our token-id reserved protocol prefix (n:...).")
+  (defconst URI-RESERVED-PREFIX:string "nft:"
+    @doc "Reserved uri prefix nobody may self-assign.")
+
+  ;; --- schemas / tables -----------------------------------------------------
+  (deftable ledger-table:{account-details})
+
+  (defschema token-schema
+    id:string
+    uri:string
+    precision:integer
+    supply:decimal
+    policies:[module{token-policy}])
+  (deftable tokens:{token-schema})
+
+  (defschema token-details
+    uri:string
+    precision:integer
+    policies:[module{token-policy}])
+
+  ;; --- events -----------------------------------------------------------------
+  (defcap TOKEN:bool (id:string precision:integer policies:[module{token-policy}] uri:string creation-guard:guard)
+    @doc "Emitted once, when a token id is created."
+    @event true)
+  (defcap SUPPLY:bool (id:string supply:decimal)
+    @doc "Emitted when the supply of ID changes."
+    @event true)
+  (defcap ACCOUNT_GUARD:bool (id:string account:string guard:guard)
+    @doc "Emitted when an account guard is enrolled."
+    @event true)
+  (defcap RECONCILE:bool
+    (token-id:string amount:decimal sender:object{sender-balance-change} receiver:object{receiver-balance-change})
+    @doc "Accounting event: sender={\"\",0,0} for mint, receiver={\"\",0,0} for burn."
+    @event true)
+  (defcap SALE:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Wrapper event for a sale offer (settlement lands in Phase 2)."
+    @event true)
+
+  ;; --- auth caps --------------------------------------------------------------
+  (defcap CREATE-TOKEN:bool (id:string creation-guard:guard)
+    @doc "The creator proves control of the CREATION-GUARD the token id is \
+         \derived from — the anti-forgery signature check."
+    (enforce-guard creation-guard))
+
+  (defcap TRANSFER:bool (id:string sender:string receiver:string amount:decimal)
+    @managed amount TRANSFER-mgr
+    (enforce (!= sender receiver) "same sender and receiver")
+    (enforce-unit id amount)
+    (enforce (> amount 0.0) "positive amount")
+    (compose-capability (DEBIT id sender))
+    (compose-capability (CREDIT id receiver)))
+
+  (defun TRANSFER-mgr:decimal (managed:decimal requested:decimal)
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0) (format "TRANSFER exceeded for balance {}" [managed]))
+      newbal))
+
+  (defcap XTRANSFER:bool (id:string sender:string receiver:string target-chain:string amount:decimal)
+    @managed amount TRANSFER-mgr
+    (enforce false "cross-chain transfer not supported by this ledger"))
+
+  (defcap DEBIT:bool (id:string sender:string)
+    @doc "Debit authority: the sender's account guard (bound in arg position — \
+         \node-safe read)."
+    (enforce-guard (account-guard id sender)))
+
+  (defcap CREDIT:bool (id:string receiver:string)
+    @doc "Internal credit token. Weak body by design: only composed into \
+         \TRANSFER/MINT, never acquired externally."
+    true)
+
+  (defcap UPDATE_SUPPLY:bool ()
+    @doc "Internal supply-update token. Weak body by design: only composed into \
+         \MINT/BURN, never acquired externally."
+    true)
+
+  (defcap MINT:bool (id:string account:string amount:decimal)
+    @doc "Mint scope: composes CREDIT + UPDATE_SUPPLY. Mint AUTHORIZATION is a \
+         \policy concern (a token with no guard/mint policy is open — attach \
+         \one; Phase 3 ships the concrete policy set)."
+    (enforce (> amount 0.0) "positive amount")
+    (compose-capability (CREDIT id account))
+    (compose-capability (UPDATE_SUPPLY)))
+
+  (defcap BURN:bool (id:string account:string amount:decimal)
+    @doc "Burn scope: composes DEBIT (account-guard authorization) + UPDATE_SUPPLY."
+    (enforce (> amount 0.0) "positive amount")
+    (compose-capability (DEBIT id account))
+    (compose-capability (UPDATE_SUPPLY)))
+
+  ;; --- ledger-iface -CALL caps (the modref handshake with the manager) --------
+  ;; Weak bodies by design: each is acquired ONLY by this ledger around the
+  ;; matching policy-manager.enforce-* call; the manager require-capability's it
+  ;; through its stored ledger modref, proving the call came from this ledger's
+  ;; lifecycle path and not from an arbitrary caller with fabricated token-info.
+  (defcap INIT-CALL:bool (id:string precision:integer uri:string)
+    @doc "Scopes policy enforce-init dispatch to create-token." true)
+  (defcap TRANSFER-CALL:bool (id:string sender:string receiver:string amount:decimal)
+    @doc "Scopes policy enforce-transfer dispatch to transfer/transfer-create." true)
+  (defcap MINT-CALL:bool (id:string account:string amount:decimal)
+    @doc "Scopes policy enforce-mint dispatch to mint." true)
+  (defcap BURN-CALL:bool (id:string account:string amount:decimal)
+    @doc "Scopes policy enforce-burn dispatch to burn." true)
+  (defcap OFFER-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Scopes policy enforce-offer dispatch to the sale defpact (Phase 2)." true)
+  (defcap WITHDRAW-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Scopes policy enforce-withdraw dispatch to the sale defpact (Phase 2)." true)
+  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal sale-id:string)
+    @doc "Scopes policy enforce-buy dispatch to the sale defpact (Phase 2)." true)
+  (defcap UPDATE-URI-CALL:bool (id:string new-uri:string)
+    @doc "Scopes policy enforce-update-uri dispatch (updatable-uri policies)." true)
+
+  ;; --- key / view helpers -----------------------------------------------------
+  (defun key:string (id:string account:string) (format "{}:{}" [id account]))
+
+  (defun account-guard:guard (id:string account:string)
+    (at 'guard (read ledger-table (key id account))))
+
+  (defun get-balance:decimal (id:string account:string)
+    (at 'balance (read ledger-table (key id account))))
+
+  (defun details:object{account-details} (id:string account:string)
+    (read ledger-table (key id account)))
+
+  (defun precision:integer (id:string) (at 'precision (read tokens id)))
+  (defun get-uri:string (id:string) (at 'uri (read tokens id)))
+  (defun total-supply:decimal (id:string)
+    (with-default-read tokens id { 'supply: 0.0 } { 'supply := s } s))
+  (defun get-version:integer () VERSION)
+
+  (defun enforce-unit:bool (id:string amount:decimal)
+    (let ((p (precision id)))
+      (enforce (= (floor amount p) amount) "precision violation")))
+
+  (defun get-token-info:object{token-info} (id:string)
+    (with-read tokens id { 'id := i, 'supply := s, 'precision := p, 'uri := u, 'policies := pol }
+      { 'id: i, 'supply: s, 'precision: p, 'uri: u, 'policies: pol }))
+
+  ;; --- IDENTITY (behavior kept verbatim from the correct Marmalade model) -----
+  (defun create-token-id:string (details:object{token-details} creation-guard:guard)
+    @doc "The token id is a hash of the token details + chain + CREATION-GUARD, \
+         \so the id is derived from the creator's key — forgery-proof."
+    (format "{}:{}" [TOKEN-ID-PREFIX
+      (hash [(format "{}" [details]) (at 'chain-id (chain-data)) creation-guard])]))
+
+  (defun check-reserved:string (token-id:string)
+    (let ((pfx (take 2 token-id)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-token-reserved:bool (token-id:string details:object{token-details} creation-guard:guard)
+    @doc "The anti-forgery gate: the id MUST re-derive from the details + \
+         \creation-guard."
+    (let ((r (check-reserved token-id)))
+      (if (= TOKEN-ID-PREFIX r)
+        (enforce (= token-id (create-token-id details creation-guard)) "token protocol violation")
+        (enforce false (format "unrecognized reserved protocol: {}" [r])))))
+
+  (defun enforce-uri-reserved:bool (uri:string)
+    (enforce (!= URI-RESERVED-PREFIX (take (length URI-RESERVED-PREFIX) uri))
+      (format "reserved uri protocol: {}" [URI-RESERVED-PREFIX])))
+
+  ;; --- create-token (anti-forgery / anti-double-mint entry) -------------------
+  (defun create-token:bool
+    ( id:string precision:integer uri:string
+      policies:[module{token-policy}] creation-guard:guard )
+    @doc "Create a token id. The id MUST re-derive from the details + \
+         \CREATION-GUARD, the caller MUST satisfy that guard, and `insert` \
+         \fails on a duplicate — one id, one token, exactly once."
+    (enforce-uri-reserved uri)
+    (let ((details:object{token-details} { 'uri: uri, 'precision: precision, 'policies: (sort policies) }))
+      (enforce-token-reserved id details creation-guard))
+    (with-capability (INIT-CALL id precision uri)
+      (policy-manager.enforce-init
+        { 'id: id, 'supply: 0.0, 'precision: precision, 'uri: uri, 'policies: policies }))
+    (with-capability (CREATE-TOKEN id creation-guard)
+      (insert tokens id { 'id: id, 'uri: uri, 'precision: precision, 'supply: 0.0, 'policies: policies })
+      (emit-event (TOKEN id precision policies uri creation-guard))
+      true))
+
+  ;; --- accounts ----------------------------------------------------------------
+  (defun create-account:bool (id:string account:string guard:guard)
+    (util.enforce-valid-account account)
+    (util.enforce-reserved account guard)
+    ;; token must exist (a balance row for a non-token is meaningless)
+    (precision id)
+    (insert ledger-table (key id account)
+      { 'id: id, 'account: account, 'balance: 0.0, 'guard: guard })
+    (emit-event (ACCOUNT_GUARD id account guard))
+    true)
+
+  ;; --- mint / burn / transfer (routed through the manager handshake) ----------
+  (defun mint:bool (id:string account:string guard:guard amount:decimal)
+    (with-capability (MINT-CALL id account amount)
+      (policy-manager.enforce-mint (get-token-info id) account guard amount))
+    (with-capability (MINT id account amount)
+      (let ((receiver (credit id account guard amount))
+            (sender:object{sender-balance-change} { 'account: "", 'previous: 0.0, 'current: 0.0 }))
+        (emit-event (RECONCILE id amount sender receiver))
+        (update-supply id amount)))
+    true)
+
+  (defun burn:bool (id:string account:string amount:decimal)
+    (with-capability (BURN-CALL id account amount)
+      (policy-manager.enforce-burn (get-token-info id) account amount))
+    (with-capability (BURN id account amount)
+      (let ((sender (debit id account amount))
+            (receiver:object{receiver-balance-change} { 'account: "", 'previous: 0.0, 'current: 0.0 }))
+        (emit-event (RECONCILE id amount sender receiver))
+        (update-supply id (- amount))))
+    true)
+
+  (defun transfer:bool (id:string sender:string receiver:string amount:decimal)
+    (util.enforce-valid-transfer sender receiver (precision id) amount)
+    (with-capability (TRANSFER-CALL id sender receiver amount)
+      (policy-manager.enforce-transfer (get-token-info id) sender (account-guard id sender) receiver amount))
+    (with-capability (TRANSFER id sender receiver amount)
+      (with-read ledger-table (key id receiver) { 'guard := g }
+        (let ((s (debit id sender amount)) (r (credit id receiver g amount)))
+          (emit-event (RECONCILE id amount s r)))))
+    true)
+
+  (defun transfer-create:bool (id:string sender:string receiver:string receiver-guard:guard amount:decimal)
+    (util.enforce-valid-transfer sender receiver (precision id) amount)
+    (with-capability (TRANSFER-CALL id sender receiver amount)
+      (policy-manager.enforce-transfer (get-token-info id) sender (account-guard id sender) receiver amount))
+    (with-capability (TRANSFER id sender receiver amount)
+      (let ((s (debit id sender amount)) (r (credit id receiver receiver-guard amount)))
+        (emit-event (RECONCILE id amount s r))))
+    true)
+
+  (defpact transfer-crosschain:bool (id:string sender:string receiver:string receiver-guard:guard target-chain:string amount:decimal)
+    (step (enforce false "cross-chain transfer not supported by this ledger")))
+
+  ;; --- internal debit / credit / supply ----------------------------------------
+  (defun debit:object{sender-balance-change} (id:string account:string amount:decimal)
+    (require-capability (DEBIT id account))
+    (enforce-unit id amount)
+    (with-read ledger-table (key id account) { 'balance := bal }
+      (enforce (<= amount bal) "insufficient funds")
+      (let ((new-bal (- bal amount)))
+        (update ledger-table (key id account) { 'balance: new-bal })
+        { 'account: account, 'previous: bal, 'current: new-bal })))
+
+  (defun credit:object{receiver-balance-change} (id:string account:string guard:guard amount:decimal)
+    (require-capability (CREDIT id account))
+    (enforce-unit id amount)
+    (util.enforce-valid-account account)
+    (util.enforce-reserved account guard)
+    (with-default-read ledger-table (key id account)
+      { 'balance: -1.0, 'guard: guard }
+      { 'balance := bal, 'guard := existing }
+      (let ((is-new (= bal -1.0)))
+        (enforce (= existing guard) "account guard does not match")
+        (let ((prev (if is-new 0.0 bal)) (new-bal (if is-new amount (+ bal amount))))
+          (write ledger-table (key id account) { 'id: id, 'account: account, 'balance: new-bal, 'guard: guard })
+          (if is-new (emit-event (ACCOUNT_GUARD id account guard)) true)
+          { 'account: account, 'previous: prev, 'current: new-bal }))))
+
+  (defun update-supply:bool (id:string amount:decimal)
+    (require-capability (UPDATE_SUPPLY))
+    (with-default-read tokens id { 'supply: 0.0 } { 'supply := s }
+      (let ((new-s (+ s amount)))
+        (update tokens id { 'supply: new-s })
+        (emit-event (SUPPLY id new-s))
+        true)))
+
+  ;; --- sale defpact (offer/buy) — the hardened settlement lands in Phase 2 ----
+  (defpact sale:string (id:string seller:string amount:decimal timeout:integer)
+    (step (format "{}" [(enforce false "sale settlement is delivered in Phase 2 (hardened manager)")])))
+)

--- a/contracts/nft/core/policy-manager-min.pact
+++ b/contracts/nft/core/policy-manager-min.pact
@@ -1,0 +1,80 @@
+;; nft.policy-manager (Phase 1 — dispatcher with the ledger handshake)
+;;
+;; The ledger routes every lifecycle mutation through policy-manager.enforce-*,
+;; and this manager verifies MID-CALL that the registered ledger's matching
+;; -CALL capability is in scope (require-capability through the stored ledger
+;; modref). That closes the fabricated-token-info hole: nobody can invoke a
+;; policy hook directly with fake token data — the call must originate inside
+;; the ledger's own lifecycle path.
+;;
+;; PHASE 2 UPGRADES THIS MODULE with the hardened settlement: one
+;; conservation-asserted routine (escrow-in = Σ payouts), economics bound in
+;; state at offer time (no read-msg of money at buy), no shared-escrow policy
+;; sweep. Until then offer/buy/withdraw reject.
+
+(namespace (read-string 'ns))
+
+(module policy-manager GOVERNANCE
+  @doc "Policy dispatcher for the nft framework: maps enforce-* hooks over each \
+       \token policy, gated by the registered ledger's -CALL handshake."
+
+  (use token-policy [token-info])
+
+  (defconst ADMIN-KS:string (read-string 'admin-ks)
+    @doc "Admin keyset name, captured ONCE at deploy — never read from a \
+         \caller's payload at enforcement time.")
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset ADMIN-KS))
+
+  ;; --- the registered ledger (set once at init) -------------------------------
+  (defschema ledger-ref
+    ledger:module{ledger-iface})
+  (deftable ledgers:{ledger-ref})
+  (defconst LEDGER-KEY:string "l")
+
+  (defun init:bool (ledger:module{ledger-iface})
+    @doc "One-time registration of the ledger this manager serves (insert fails \
+         \on a second call). Governance-gated."
+    (with-capability (GOVERNANCE)
+      (insert ledgers LEDGER-KEY { 'ledger: ledger }))
+    true)
+
+  (defun retrieve-ledger:module{ledger-iface} ()
+    (at 'ledger (read ledgers LEDGER-KEY)))
+
+  ;; --- hooks (each verifies the ledger handshake, then dispatches) -------------
+  (defun enforce-init:bool (token:object{token-info})
+    (let ((l:module{ledger-iface} (retrieve-ledger)))
+      (require-capability (l::INIT-CALL (at 'id token) (at 'precision token) (at 'uri token))))
+    (map (lambda (p:module{token-policy}) (p::enforce-init token)) (at 'policies token))
+    true)
+
+  (defun enforce-mint:bool (token:object{token-info} account:string guard:guard amount:decimal)
+    (let ((l:module{ledger-iface} (retrieve-ledger)))
+      (require-capability (l::MINT-CALL (at 'id token) account amount)))
+    (map (lambda (p:module{token-policy}) (p::enforce-mint token account guard amount)) (at 'policies token))
+    true)
+
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal)
+    (let ((l:module{ledger-iface} (retrieve-ledger)))
+      (require-capability (l::BURN-CALL (at 'id token) account amount)))
+    (map (lambda (p:module{token-policy}) (p::enforce-burn token account amount)) (at 'policies token))
+    true)
+
+  (defun enforce-transfer:bool (token:object{token-info} sender:string guard:guard receiver:string amount:decimal)
+    (let ((l:module{ledger-iface} (retrieve-ledger)))
+      (require-capability (l::TRANSFER-CALL (at 'id token) sender receiver amount)))
+    (map (lambda (p:module{token-policy}) (p::enforce-transfer token sender guard receiver amount)) (at 'policies token))
+    true)
+
+  ;; --- settlement hooks: delivered by the Phase-2 hardened manager -------------
+  (defun enforce-offer:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (enforce false "offer/buy settlement is delivered in Phase 2 (hardened manager)"))
+
+  (defun enforce-buy:bool (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string)
+    (enforce false "offer/buy settlement is delivered in Phase 2 (hardened manager)"))
+
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (enforce false "offer/buy settlement is delivered in Phase 2 (hardened manager)"))
+)

--- a/contracts/nft/core/util.pact
+++ b/contracts/nft/core/util.pact
@@ -1,0 +1,58 @@
+;; nft.util — account-name validity + reserved-name protocol enforcement for the
+;; NFT framework. Implements nft.account-protocols. Used by the ledger to
+;; validate transfers and account names. The reserved-name check is what makes a
+;; principal (k:/w:/…) account un-squattable: the account name must match its
+;; guard. PCO `nft` framework; our own code.
+
+(namespace (read-string 'ns))
+
+(module util GOVERNANCE
+  @doc "Account-protocol helpers for the nft framework: amount/precision/account \
+       \validity and principal reserved-name enforcement."
+
+  (implements account-protocols)
+
+  (defconst ADMIN-KS:string (read-string 'admin-ks)
+    @doc "Admin keyset name, captured ONCE at deploy — never read from a \
+         \caller's payload at enforcement time.")
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset ADMIN-KS))
+
+  (defun enforce-valid-amount:bool (precision:integer amount:decimal)
+    (enforce (> amount 0.0) "amount must be positive")
+    (enforce-precision precision amount))
+
+  (defun enforce-valid-account:bool (account:string)
+    (enforce (> (length account) 2) "account name below minimum length")
+    (enforce (is-charset CHARSET_LATIN1 account) "account name must be latin-1"))
+
+  (defun enforce-precision:bool (precision:integer amount:decimal)
+    (enforce (= (floor amount precision) amount) "precision violation"))
+
+  (defun enforce-valid-transfer:bool
+    (sender:string receiver:string precision:integer amount:decimal)
+    (enforce (!= sender receiver) "sender cannot be the receiver")
+    (enforce-valid-amount precision amount)
+    (enforce-valid-account sender)
+    (enforce-valid-account receiver))
+
+  (defun check-reserved:string (account:string)
+    @doc "Return the reserved-name protocol char of ACCOUNT (single char + ':', \
+         \e.g. 'k:...' -> \"k\"), or \"\" if unreserved."
+    (let ((pfx (take 2 account)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account-name protocols. A k:/w: principal account \
+         \name MUST validate against its GUARD (validate-principal); a k: name \
+         \that is not a valid single-key principal is rejected. Fail-closed."
+    (if (validate-principal guard account)
+      true
+      (let ((r (check-reserved account)))
+        (if (= r "")
+          true
+          (if (= r "k")
+            (enforce false "single-key account protocol violation")
+            (enforce false (format "reserved protocol guard violation: {}" [r])))))))
+)

--- a/contracts/nft/interfaces/account-protocols.pact
+++ b/contracts/nft/interfaces/account-protocols.pact
@@ -1,0 +1,30 @@
+;; nft.account-protocols — account-name validity + reserved-name (k:/w:/…)
+;; protocol enforcement, implemented by nft.util and used by the ledger for
+;; transfer/account validation. Part of the PCO `nft` framework (our own code;
+;; the fungible-account-protocol surface every conforming util module exposes).
+
+(namespace (read-string 'ns))
+
+(interface account-protocols
+
+  (defun enforce-valid-amount:bool (precision:integer amount:decimal)
+    @doc "Enforce AMOUNT is positive and respects PRECISION.")
+
+  (defun enforce-valid-account:bool (account:string)
+    @doc "Enforce minimum account-name validity (non-empty, charset, length).")
+
+  (defun enforce-precision:bool (precision:integer amount:decimal)
+    @doc "Enforce AMOUNT respects PRECISION (no excess decimals).")
+
+  (defun enforce-valid-transfer:bool
+    (sender:string receiver:string precision:integer amount:decimal)
+    @doc "Enforce SENDER/RECEIVER validity, AMOUNT>0 at PRECISION, sender!=receiver.")
+
+  (defun check-reserved:string (account:string)
+    @doc "Return the reserved-name protocol char of ACCOUNT (e.g. \"k\" for \
+         \k:...), or \"\" if unreserved.")
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account-name protocols: a k:/w: principal account \
+         \name MUST match its GUARD. Authored fail-closed.")
+)

--- a/contracts/nft/interfaces/ledger-iface.pact
+++ b/contracts/nft/interfaces/ledger-iface.pact
@@ -1,0 +1,35 @@
+;; nft.ledger-iface — the ledger interface the policy-manager holds as a modref.
+;;
+;; These `-CALL` capabilities secure the modref handshake: the policy-manager can
+;; only invoke a policy hook while the matching ledger `-CALL` cap is in scope,
+;; proving the call originated from the ledger's own lifecycle path (not from an
+;; arbitrary caller). Part of the PCO `nft` framework.
+
+(namespace (read-string 'ns))
+
+(interface ledger-iface
+
+  (defcap INIT-CALL:bool (id:string precision:integer uri:string)
+    @doc "Secures the modref call to a policy's enforce-init.")
+
+  (defcap TRANSFER-CALL:bool (id:string sender:string receiver:string amount:decimal)
+    @doc "Secures the modref call to a policy's enforce-transfer.")
+
+  (defcap MINT-CALL:bool (id:string account:string amount:decimal)
+    @doc "Secures the modref call to a policy's enforce-mint.")
+
+  (defcap BURN-CALL:bool (id:string account:string amount:decimal)
+    @doc "Secures the modref call to a policy's enforce-burn.")
+
+  (defcap OFFER-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Secures the modref call to a policy's enforce-offer.")
+
+  (defcap WITHDRAW-CALL:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Secures the modref call to a policy's enforce-withdraw.")
+
+  (defcap BUY-CALL:bool (id:string seller:string buyer:string amount:decimal sale-id:string)
+    @doc "Secures the modref call to a policy's enforce-buy.")
+
+  (defcap UPDATE-URI-CALL:bool (id:string new-uri:string)
+    @doc "Secures the modref call to a policy's enforce-update-uri.")
+)

--- a/contracts/nft/interfaces/poly-fungible.pact
+++ b/contracts/nft/interfaces/poly-fungible.pact
@@ -1,0 +1,104 @@
+;; nft.poly-fungible — the multi-token (poly-fungible) accounting standard the
+;; ledger implements: per-(token-id, account) balances, managed transfers,
+;; reconciliation events, and the offer/buy sale defpact hook. The PCO `nft`
+;; framework's token standard (functionally the poly-fungible surface every
+;; conforming ledger exposes; our own code).
+
+(namespace (read-string 'ns))
+
+(interface poly-fungible
+
+  (defschema account-details
+    @doc "Balance record for (id, account)."
+    @model [ (invariant (!= id "")) (invariant (!= account "")) (invariant (>= balance 0.0)) ]
+    id:string
+    account:string
+    balance:decimal
+    guard:guard)
+
+  (defschema sender-balance-change
+    @doc "RECONCILE event leg for the sender."
+    account:string previous:decimal current:decimal)
+
+  (defschema receiver-balance-change
+    @doc "RECONCILE event leg for the receiver."
+    account:string previous:decimal current:decimal)
+
+  (defcap TRANSFER:bool (id:string sender:string receiver:string amount:decimal)
+    @doc "Manage transfer of AMOUNT of ID. As an event, notifies burn (\"\" \
+         \receiver) and create/mint (\"\" sender)."
+    @managed amount TRANSFER-mgr)
+
+  (defcap XTRANSFER:bool (id:string sender:string receiver:string target-chain:string amount:decimal)
+    @doc "Manage cross-chain transfer of AMOUNT of ID to TARGET-CHAIN."
+    @managed amount TRANSFER-mgr)
+
+  (defun TRANSFER-mgr:decimal (managed:decimal requested:decimal)
+    @doc "Linear manager for the TRANSFER amount.")
+
+  (defcap SUPPLY:bool (id:string supply:decimal)
+    @doc "Emitted when the supply of ID changes." @event)
+
+  (defcap ACCOUNT_GUARD:bool (id:string account:string guard:guard)
+    @doc "Emitted when an account guard is set/updated." @event)
+
+  (defcap RECONCILE:bool
+    ( token-id:string amount:decimal
+      sender:object{sender-balance-change} receiver:object{receiver-balance-change} )
+    @doc "Accounting event: sender={\"\",0,0} for mint, receiver={\"\",0,0} for burn." @event)
+
+  (defun precision:integer (id:string)
+    @doc "Maximum decimal precision for ID.")
+
+  (defun enforce-unit:bool (id:string amount:decimal)
+    @doc "Enforce AMOUNT meets ID's minimum precision.")
+
+  (defun mint:bool (id:string account:string guard:guard amount:decimal)
+    @doc "Mint AMOUNT of ID to ACCOUNT with GUARD."
+    @model [ (property (!= id "")) (property (!= account "")) (property (>= amount 0.0)) ])
+
+  (defun burn:bool (id:string account:string amount:decimal)
+    @doc "Burn AMOUNT of ID from ACCOUNT."
+    @model [ (property (!= id "")) (property (!= account "")) (property (>= amount 0.0)) ])
+
+  (defun create-account:bool (id:string account:string guard:guard)
+    @doc "Create ACCOUNT for ID at 0.0 balance under GUARD."
+    @model [ (property (!= id "")) (property (!= account "")) ])
+
+  (defun get-balance:decimal (id:string account:string)
+    @doc "Balance of ID for ACCOUNT; fails if the account does not exist.")
+
+  (defun details:object{account-details} (id:string account:string)
+    @doc "Details of ACCOUNT under ID; fails if the account does not exist.")
+
+  (defun transfer:bool (id:string sender:string receiver:string amount:decimal)
+    @doc "Transfer AMOUNT of ID SENDER -> RECEIVER (managed by TRANSFER)."
+    @model [ (property (> amount 0.0)) (property (!= id "")) (property (!= sender ""))
+             (property (!= receiver "")) (property (!= sender receiver)) ])
+
+  (defun transfer-create:bool (id:string sender:string receiver:string receiver-guard:guard amount:decimal)
+    @doc "Transfer AMOUNT of ID SENDER -> RECEIVER, creating RECEIVER if absent \
+         \(else RECEIVER-GUARD must match). Managed by TRANSFER."
+    @model [ (property (> amount 0.0)) (property (!= id "")) (property (!= sender ""))
+             (property (!= receiver "")) (property (!= sender receiver)) ])
+
+  (defpact transfer-crosschain:bool
+    ( id:string sender:string receiver:string receiver-guard:guard target-chain:string amount:decimal )
+    @doc "Cross-chain transfer of AMOUNT of ID to RECEIVER on TARGET-CHAIN."
+    @model [ (property (> amount 0.0)) (property (!= id "")) (property (!= sender ""))
+             (property (!= receiver "")) (property (!= target-chain "")) ])
+
+  (defun total-supply:decimal (id:string)
+    @doc "Total quantity of ID (0.0 if unsupported).")
+
+  (defun get-uri:string (id:string)
+    @doc "The uri for ID.")
+
+  ;; --- sale API ---
+  (defcap SALE:bool (id:string seller:string amount:decimal timeout:integer sale-id:string)
+    @doc "Wrapper cap/event for a sale of ID by SELLER until TIMEOUT." @event)
+
+  (defpact sale:string (id:string seller:string amount:decimal timeout:integer)
+    @doc "Offer -> buy escrow defpact. Step 0 offer (with withdraw rollback after \
+         \TIMEOUT); step 1 buy, completed with 'buyer / 'buyer-guard payload.")
+)

--- a/contracts/nft/interfaces/sale.pact
+++ b/contracts/nft/interfaces/sale.pact
@@ -1,0 +1,18 @@
+;; nft.sale — the interface a sale contract (auction, timed sale, …) implements
+;; so the policy-manager can drive quoted sales through it. Two read-only hooks
+;; the manager enforces during the offer/buy defpact. Part of the PCO `nft`
+;; framework. Fixed-price sales need no sale contract (handled inline by the
+;; hardened manager); this interface is for price-discovery sale types.
+
+(namespace (read-string 'ns))
+
+(interface sale
+
+  (defun enforce-quote-update:bool (sale-id:string price:decimal)
+    @doc "Enforced at buy time to finalize/update the quote price for SALE-ID \
+         \(e.g. an auction's winning bid). Read-only w.r.t. the manager's state.")
+
+  (defun enforce-withdrawal:bool (sale-id:string)
+    @doc "Enforced to allow the seller to withdraw the offer SALE-ID (e.g. only \
+         \after an auction times out with no winning bid). Read-only.")
+)

--- a/contracts/nft/interfaces/token-policy.pact
+++ b/contracts/nft/interfaces/token-policy.pact
@@ -1,0 +1,57 @@
+;; nft.token-policy — the policy hook interface for the NFT framework.
+;;
+;; A concrete policy implements these hooks; the ledger (via the policy-manager)
+;; maps them over every policy attached to a token at each lifecycle event. This
+;; is the extension point where royalty, guard, collection, and sale-only
+;; behavior live. Authored for the PCO `nft` framework (hardened successor to the
+;; Marmalade v2 architecture); the framework's own original code, not a fork.
+
+(namespace (read-string 'ns))
+
+(interface token-policy
+
+  (defschema token-info
+    @doc "The token view passed to every policy hook. `policies` is the set of \
+         \policies attached to the token (self-referential list of this iface)."
+    id:string
+    supply:decimal
+    precision:integer
+    uri:string
+    policies:[module{token-policy}])
+
+  (defun enforce-init:bool (token:object{token-info})
+    @doc "Run at token creation. A hardened policy binds its economic terms \
+         \(e.g. royalty rate + payee) into its OWN on-chain state HERE, from \
+         \required (fail-closed) inputs — never defaulted, never read at buy.")
+
+  (defun enforce-mint:bool
+    ( token:object{token-info} account:string guard:guard amount:decimal )
+    @doc "Run at mint of AMOUNT of TOKEN to ACCOUNT."
+    @model [ (property (!= account "")) (property (> amount 0.0)) ])
+
+  (defun enforce-burn:bool
+    ( token:object{token-info} account:string amount:decimal )
+    @doc "Run at burn of AMOUNT of TOKEN from ACCOUNT."
+    @model [ (property (!= account "")) (property (> amount 0.0)) ])
+
+  (defun enforce-offer:bool
+    ( token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string )
+    @doc "Run when SELLER offers AMOUNT of TOKEN for sale SALE-ID.")
+
+  (defun enforce-buy:bool
+    ( token:object{token-info} seller:string buyer:string buyer-guard:guard
+      amount:decimal sale-id:string )
+    @doc "Run at settlement of SALE-ID (SELLER -> BUYER). A hardened policy \
+         \DECLARES its cut of the price (read from its own state) for the \
+         \single conservation-asserted settlement; it MUST NOT reach into a \
+         \shared escrow itself, and MUST NOT read economics from the tx.")
+
+  (defun enforce-withdraw:bool
+    ( token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string )
+    @doc "Run when SELLER withdraws the offer SALE-ID.")
+
+  (defun enforce-transfer:bool
+    ( token:object{token-info} sender:string guard:guard receiver:string amount:decimal )
+    @doc "Run on a free (no-sale) transfer SENDER -> RECEIVER. A sale-only \
+         \policy rejects this; it governs rotate too (RECEIVER=SENDER, 0.0).")
+)

--- a/contracts/nft/interfaces/token-policy.pact
+++ b/contracts/nft/interfaces/token-policy.pact
@@ -53,5 +53,6 @@
   (defun enforce-transfer:bool
     ( token:object{token-info} sender:string guard:guard receiver:string amount:decimal )
     @doc "Run on a free (no-sale) transfer SENDER -> RECEIVER. A sale-only \
-         \policy rejects this; it governs rotate too (RECEIVER=SENDER, 0.0).")
+         \policy rejects this. (Account guards are immutable in this ledger: \
+         \there is no rotate path for a policy to govern.)")
 )

--- a/contracts/nft/interfaces/updatable-uri-policy.pact
+++ b/contracts/nft/interfaces/updatable-uri-policy.pact
@@ -1,0 +1,15 @@
+;; nft.updatable-uri-policy — the hook a policy implements to gate token-uri
+;; updates. A token whose policy set does NOT include an updatable-uri policy has
+;; an immutable uri (the manager rejects update-uri). Part of the PCO `nft`
+;; framework.
+
+(namespace (read-string 'ns))
+
+(interface updatable-uri-policy
+
+  (defun enforce-update-uri:bool
+    (token:object{token-policy.token-info} new-uri:string)
+    @doc "Run when the token's uri is updated to NEW-URI. A policy that permits \
+         \updates authorizes the updater here (fail-closed); absence of this \
+         \policy means the uri is immutable.")
+)

--- a/contracts/nft/test/identity.repl
+++ b/contracts/nft/test/identity.repl
@@ -136,6 +136,67 @@
 (rollback-tx)
 
 ;; ---------------------------------------------------------------------------
+;; CANONICAL POLICY ORDER — the same policy SET derives the same id no matter
+;; the order passed (plain `sort` is a no-op on modrefs — the ledger
+;; canonicalizes by policy NAME), and a duplicate policy is rejected.
+;; ---------------------------------------------------------------------------
+(begin-tx "canonical policy order")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "ns": "nft", "admin-ks": "nft.admin" })
+;; alice signs (creation guard); the ns key signs (module deploys into `nft`)
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] }
+          , { "key": "9999999999999999999999999999999999999999999999999999999999999999", "caps": [] } ])
+(namespace "nft")
+;; two no-op fixture policies, names chosen to differ from creation order
+(module fixture-pol-b GOV
+  (defcap GOV () (enforce-keyset "nft.admin"))
+  (implements token-policy)
+  (use token-policy [token-info])
+  (defun enforce-init:bool (token:object{token-info}) true)
+  (defun enforce-mint:bool (token:object{token-info} account:string guard:guard amount:decimal) true)
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal) true)
+  (defun enforce-offer:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string) true)
+  (defun enforce-buy:bool (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string) true)
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string) true)
+  (defun enforce-transfer:bool (token:object{token-info} sender:string guard:guard receiver:string amount:decimal) true))
+(module fixture-pol-a GOV
+  (defcap GOV () (enforce-keyset "nft.admin"))
+  (implements token-policy)
+  (use token-policy [token-info])
+  (defun enforce-init:bool (token:object{token-info}) true)
+  (defun enforce-mint:bool (token:object{token-info} account:string guard:guard amount:decimal) true)
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal) true)
+  (defun enforce-offer:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string) true)
+  (defun enforce-buy:bool (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string) true)
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string) true)
+  (defun enforce-transfer:bool (token:object{token-info} sender:string guard:guard receiver:string amount:decimal) true))
+
+(expect "the id is order-independent (canonical policy order)"
+  (nft.ledger.create-token-id
+    { 'uri: "ipfs://ordered", 'precision: 0, 'policies: [nft.fixture-pol-a nft.fixture-pol-b] }
+    (read-keyset 'alice))
+  (nft.ledger.create-token-id
+    { 'uri: "ipfs://ordered", 'precision: 0, 'policies: [nft.fixture-pol-b nft.fixture-pol-a] }
+    (read-keyset 'alice)))
+
+;; create with one order, id derived from the OTHER order — canonical end-to-end
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://ordered", 'precision: 0, 'policies: [nft.fixture-pol-a nft.fixture-pol-b] }
+            (read-keyset 'alice))))
+  (expect "create-token accepts the id whichever order the list is passed in" true
+    (nft.ledger.create-token id 0 "ipfs://ordered"
+      [nft.fixture-pol-b nft.fixture-pol-a] (read-keyset 'alice))))
+
+(expect-failure "a duplicate policy in the list is rejected" "duplicate policy"
+  (let ((id (nft.ledger.create-token-id
+              { 'uri: "ipfs://dup", 'precision: 0, 'policies: [nft.fixture-pol-a nft.fixture-pol-a] }
+              (read-keyset 'alice))))
+    (nft.ledger.create-token id 0 "ipfs://dup"
+      [nft.fixture-pol-a nft.fixture-pol-a] (read-keyset 'alice))))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
 ;; THE HANDSHAKE — policy hooks cannot be invoked directly with fake token-info
 ;; ---------------------------------------------------------------------------
 (begin-tx "manager handshake")

--- a/contracts/nft/test/identity.repl
+++ b/contracts/nft/test/identity.repl
@@ -1,0 +1,288 @@
+;; nft framework — Phase 1 identity suite.
+;;
+;; Proves the property that motivated this architecture (and that a
+;; self-sovereign per-NFT module could not provide): TOKEN IDENTITY IS ANCHORED
+;; IN THE SHARED LEDGER, derived from the creator's guard.
+;;   * forgery rejected two ways: a fabricated id fails protocol re-derivation,
+;;     and a correctly-derived id for someone ELSE's guard fails their guard;
+;;   * double-mint rejected: one id, one row, exactly once (insert);
+;;   * the manager handshake: policy hooks cannot be invoked directly with
+;;     fabricated token-info;
+;;   * accounting: mint/transfer/burn with supply + precision + principal
+;;     (k:) account protocol enforcement.
+;;
+;; Run: pact contracts/nft/test/identity.repl
+
+;; ---------------------------------------------------------------------------
+;; deploy the stack: interfaces -> util -> policy-manager -> ledger -> init
+;; ---------------------------------------------------------------------------
+(begin-tx "deploy the nft framework (Phase 1)")
+(env-data
+  { "g":     { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "ns":    "nft"
+  , "admin-ks": "nft.admin" })
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "nft" (read-keyset 'g) (read-keyset 'g))
+(namespace "nft")
+(define-keyset "nft.admin" (read-keyset 'g))
+(load "../interfaces/account-protocols.pact")
+(load "../interfaces/token-policy.pact")
+(load "../interfaces/poly-fungible.pact")
+(load "../interfaces/ledger-iface.pact")
+(load "../interfaces/sale.pact")
+(load "../interfaces/updatable-uri-policy.pact")
+(load "../core/util.pact")
+(load "../core/policy-manager-min.pact")
+(create-table nft.policy-manager.ledgers)
+(load "../core/ledger.pact")
+(create-table nft.ledger.ledger-table)
+(create-table nft.ledger.tokens)
+;; one-time: register the ledger with the manager (governance-gated)
+(nft.policy-manager.init nft.ledger)
+(commit-tx)
+
+;; init is one-time
+(begin-tx "manager re-init rejected")
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(expect-failure "re-registering a ledger is rejected (one-time insert)" "already"
+  (nft.policy-manager.init nft.ledger))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; personas (raw keysets; k: principal accounts)
+;; ---------------------------------------------------------------------------
+;; alice = creator; bob = collector; mallory = adversary
+;; (env-data replaces the WHOLE map — carry all personas in every tx)
+
+;; ---------------------------------------------------------------------------
+;; happy path: alice creates HER token (id derived from HER guard)
+;; ---------------------------------------------------------------------------
+(begin-tx "alice creates her token")
+(env-data
+  { "alice":   { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":     { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "mallory": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+            (read-keyset 'alice))))
+  (expect "id carries our reserved protocol prefix" "n:" (take 2 id))
+  (expect "create-token succeeds for the guard-holder" true
+    (nft.ledger.create-token id 0 "ipfs://the-painting" [] (read-keyset 'alice)))
+  (expect "token exists with supply 0" 0.0 (nft.ledger.total-supply id)))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; FORGERY A — a fabricated id fails the protocol re-derivation
+;; ---------------------------------------------------------------------------
+(begin-tx "forgery A: fabricated id")
+(env-data
+  { "alice":   { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "mallory": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [] } ])
+(expect-failure "an id that does not re-derive from the details+guard is rejected"
+  "token protocol violation"
+  (nft.ledger.create-token "n:FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE"
+    0 "ipfs://forged" [] (read-keyset 'mallory)))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; FORGERY B — the correct id for ALICE's guard, but mallory signs.
+;;   The id re-derives (mallory passed alice's guard), but CREATE-TOKEN
+;;   enforces that guard — mallory cannot satisfy it. THE anti-impersonation
+;;   proof: you cannot create a token whose identity claims someone else.
+;; ---------------------------------------------------------------------------
+(begin-tx "forgery B: right id, wrong signer")
+(env-data
+  { "alice":   { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "mallory": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [] } ])
+(expect-failure "mallory cannot create a token derived from ALICE's guard"
+  "Keyset failure"
+  (let ((id (nft.ledger.create-token-id
+              { 'uri: "ipfs://impersonation", 'precision: 0, 'policies: [] }
+              (read-keyset 'alice))))
+    (nft.ledger.create-token id 0 "ipfs://impersonation" [] (read-keyset 'alice))))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; DOUBLE-MINT — the same id a second time is rejected (insert: one row ever)
+;; ---------------------------------------------------------------------------
+(begin-tx "double-mint rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(expect-failure "creating the SAME token id twice is rejected" "already"
+  (let ((id (nft.ledger.create-token-id
+              { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+              (read-keyset 'alice))))
+    (nft.ledger.create-token id 0 "ipfs://the-painting" [] (read-keyset 'alice))))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; protocol edges: foreign prefix + reserved uri
+;; ---------------------------------------------------------------------------
+(begin-tx "protocol edges")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(expect-failure "a non-n: prefix is rejected" "unrecognized reserved protocol"
+  (nft.ledger.create-token "t:someforeignid" 0 "ipfs://x" [] (read-keyset 'alice)))
+(expect-failure "the reserved uri prefix cannot be self-assigned" "reserved uri protocol"
+  (let ((id (nft.ledger.create-token-id
+              { 'uri: "nft:sneaky", 'precision: 0, 'policies: [] }
+              (read-keyset 'alice))))
+    (nft.ledger.create-token id 0 "nft:sneaky" [] (read-keyset 'alice))))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; THE HANDSHAKE — policy hooks cannot be invoked directly with fake token-info
+;; ---------------------------------------------------------------------------
+(begin-tx "manager handshake")
+(env-data
+  { "mallory": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [] } ])
+(expect-failure "enforce-mint cannot be called outside the ledger's mint path" "not granted"
+  (nft.policy-manager.enforce-mint
+    { 'id: "n:fake", 'supply: 0.0, 'precision: 0, 'uri: "u", 'policies: [] }
+    "k:3333333333333333333333333333333333333333333333333333333333333333"
+    (read-keyset 'mallory) 1.0))
+(expect-failure "enforce-init cannot be called outside create-token" "not granted"
+  (nft.policy-manager.enforce-init
+    { 'id: "n:fake", 'supply: 0.0, 'precision: 0, 'uri: "u", 'policies: [] }))
+(expect-failure "enforce-transfer cannot be called outside the transfer path" "not granted"
+  (nft.policy-manager.enforce-transfer
+    { 'id: "n:fake", 'supply: 0.0, 'precision: 0, 'uri: "u", 'policies: [] }
+    "a" (read-keyset 'mallory) "b" 1.0))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; accounting: mint -> transfer -> burn (supply + precision + k: protocol)
+;;   NOTE (Phase 1): mint AUTHORIZATION is a policy concern — a token created
+;;   with an empty policy list is open to mint. Phase 3 ships the guard/
+;;   non-fungible policies that gate this; the suite documents the semantics.
+;; ---------------------------------------------------------------------------
+(begin-tx "mint")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+            (read-keyset 'alice))))
+  (expect "mint 1 to alice's k: account" true
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 1.0))
+  (expect "alice balance 1" 1.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111"))
+  (expect "supply 1" 1.0 (nft.ledger.total-supply id))
+  (expect-failure "precision-0 token rejects fractional mint" "precision violation"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 0.5))
+  (expect-failure "zero-amount mint rejected" "positive amount"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 0.0)))
+(commit-tx)
+
+(begin-tx "k: principal protocol on accounts")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+            (read-keyset 'alice))))
+  ;; a k: account whose guard is NOT its key is a squat — rejected
+  (expect-failure "k: account with a mismatched guard is rejected"
+    "single-key account protocol violation"
+    (nft.ledger.create-account id
+      "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset 'bob))))
+(rollback-tx)
+
+(begin-tx "transfer alice -> bob")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+;; sign SCOPED to TRANSFER (as a real transfer tx does): this installs the
+;; managed cap AND authorizes the composed DEBIT (alice's account guard).
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0) ] } ])
+  (expect "transfer-create to bob" true
+    (nft.ledger.transfer-create id
+      "k:1111111111111111111111111111111111111111111111111111111111111111"
+      "k:2222222222222222222222222222222222222222222222222222222222222222"
+      (read-keyset 'bob) 1.0))
+  (expect "alice balance 0" 0.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111"))
+  (expect "bob balance 1" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222"))
+  (expect "supply unchanged by transfer" 1.0 (nft.ledger.total-supply id)))
+(commit-tx)
+
+(begin-tx "over-balance transfer rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            "k:1111111111111111111111111111111111111111111111111111111111111111" 2.0) ] } ])
+  (expect-failure "cannot transfer more than the balance" "insufficient funds"
+    (nft.ledger.transfer id
+      "k:2222222222222222222222222222222222222222222222222222222222222222"
+      "k:1111111111111111111111111111111111111111111111111111111111111111" 2.0)))
+(rollback-tx)
+
+(begin-tx "burn by the owner")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+            (read-keyset 'alice))))
+  (expect "bob burns his token" true
+    (nft.ledger.burn id "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0))
+  (expect "supply back to 0" 0.0 (nft.ledger.total-supply id)))
+(commit-tx)
+
+(begin-tx "burn requires the account guard")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+            (read-keyset 'alice))))
+  ;; re-mint one to alice first requires no sig (no policies); then mallory
+  ;; cannot burn it: DEBIT enforces alice's account guard
+  (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (read-keyset 'alice) 1.0)
+  (expect-failure "a stranger cannot burn someone's token" "Keyset failure"
+    (nft.ledger.burn id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0)))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Phase-2 boundaries are explicit
+;; ---------------------------------------------------------------------------
+(begin-tx "settlement is Phase 2")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://the-painting", 'precision: 0, 'policies: [] }
+            (read-keyset 'alice))))
+  (expect-failure "the sale defpact rejects until the hardened manager lands" "Phase 2"
+    (nft.ledger.sale id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 100)))
+(rollback-tx)
+
+(print "")
+(print "=== NFT FRAMEWORK PHASE 1 — IDENTITY CORE: ALL GREEN ===")
+(print "  forgery rejected (fabricated id + impersonated guard); double-mint")
+(print "  rejected (one id, one row); manager handshake closed (no direct policy")
+(print "  dispatch); accounting sound (mint/transfer/burn, supply, precision,")
+(print "  k: principal protocol). Settlement arrives in Phase 2.")


### PR DESCRIPTION
## What

Phase 1 of a new **PCO-owned NFT framework** — an original, hardened re-authoring of the Marmalade v2 architecture (not a repository fork). Marmalade's **identity model is correct**; its **settlement/policy layer is not** (per our own Marmalade V2 analysis: findings ARCH-1/2, POL-1/2/3). We keep the identity model and fix the rest, shipping it as our own `nft` framework. Smart Pacts Gallery becomes the first marketplace on it.

This phase delivers the **interfaces + identity core**.

## Why (the pivot)

We first built a standalone **per-NFT module** design. The question *"what if a bad actor deploys the NFT with multiple `present:bool` true?"* exposed a critical flaw: a per-NFT module's `mint` is permissionless, so anyone can **forge** an NFT impersonating any creator, and residency can be claimed on multiple deployments. **A self-sovereign per-NFT module cannot self-certify identity** — it needs an anchor the minter doesn't control. Marmalade's shared ledger *is* that anchor: a token id is `n:{hash([token-details, chain-id, creation-guard])}` — derived from the creator's guard.

## Contents

- **Interfaces** (`contracts/nft/interfaces/`): `token-policy`, `poly-fungible`, `sale`, `ledger-iface`, `account-protocols`, `updatable-uri-policy`.
- **`nft.util`** — account/precision/reserved-name protocols (principal `k:`/`w:` accounts are un-squattable: the account name must match its guard).
- **`nft.ledger`** — the shared ledger + identity anchor. The identity functions (`create-token-id` / `enforce-token-reserved` / `check-reserved`) keep the correct Marmalade behavior verbatim, with our own `n:` / `nft:` prefixes.
- **`nft.policy-manager` (Phase 1)** — a policy dispatcher gated by the ledger's `-CALL` capability handshake. The **hardened, conservation-asserted settlement lands in Phase 2**; offer/buy reject until then.

## What `test/identity.repl` proves (Load successful, 0 FAILURE)

- **Forgery rejected, two ways** — a fabricated id fails protocol re-derivation, and a correctly-derived id for *someone else's* guard fails their guard (you cannot create a token whose identity claims another creator).
- **Double-mint rejected** — one id, one row, exactly once (`insert`).
- **The manager handshake** — policy hooks cannot be invoked directly with fabricated token-info (`require-capability` through the ledger's `-CALL` cap).
- **Accounting** — mint / transfer / burn with supply, precision, and `k:` principal protocol enforcement (over-balance, wrong-signer, fractional-on-precision-0 all rejected).

## Security note

Governance keysets are captured **once at deploy** (`defconst ADMIN-KS (read-string 'admin-ks)`), never read from a caller's payload at enforcement time — closing a governance-bypass hole.

## Gates

Static gate: **0 violations** (14 dispositioned WARNs — dependency-load + `enforce-guard`-in-`defcap` confirmations). No Claude/Anthropic attribution; commits under the GitHub noreply address.

## Roadmap (each a gated PR)

Phase 2 — hardened policy-manager + fixed-price settlement (one conservation-asserted routine; economics from state; buyer can't zero the fee). Phase 3 — the concrete policy set (royalty, guard, collection, non-fungible, non-updatable-uri). Phase 4 — auctions. Phase 5 — devnet + independent audit, then Gallery re-cast as the first marketplace.
