### PR TITLE
feat(nft): framework Phase 3 — concrete policy set (royalty, guard, 1/1, collection, uri veto)

### DIFF
--- a/contracts/nft/README.md
+++ b/contracts/nft/README.md
@@ -1,0 +1,69 @@
+# The `nft` framework — a shared-ledger NFT standard, hardened
+
+A complete NFT framework for Kadena (Pact 5.4ce / KDA-CE), authored by the PCO as a neutral
+community standard in the `nft` namespace. It keeps the **one architectural idea worth keeping**
+from the deployed Marmalade V2 stack — token identity anchored in a shared ledger — and re-authors
+the settlement/policy layer around five principles the analysis of that stack produced. This is an
+original implementation, not a fork; the Marmalade sources under `contracts/registry/marmalade/`
+are read-only reference.
+
+## Identity: why a shared ledger
+
+A token id is `n:{hash([token-details, chain-id, creation-guard])}` — derived from the creator's
+guard. `create-token` re-derives the id, enforces the creation guard, and inserts exactly one row:
+
+- **Forgery is impossible** — you cannot create a token whose id claims someone else's guard;
+- **Double-mint is impossible** — one id, one row, forever;
+- **The id is order-independent** — the ledger canonicalizes the policy list (name-sorted,
+  duplicates rejected), so the same policy *set* always derives the same id.
+
+Self-sovereign per-NFT modules cannot provide this anchor (anyone can deploy a lookalike module);
+see the consignment spike under `contracts/standards/nft-consignment-spike/` for that
+proving-ground record.
+
+## Settlement: the five principles
+
+1. **Fail closed.** Every required input (royalty spec, operation guards, collection id, quote) is
+   typed and required — absence aborts; nothing defaults to permissive.
+2. **One settlement, conservation-asserted.** Policies DECLARE payouts and move no money. The
+   policy-manager pays every declared cut + the marketplace fee + the seller remainder from one
+   capability-guarded per-sale escrow and asserts `escrow-in = Σ payouts` at the fungible's full
+   precision. Same-payee legs merge; zero legs drop.
+3. **Economics on-chain, never in the buy transaction.** The quote (price, fungible, seller payout
+   account, fee) binds in STATE at offer, signed by the seller. The buyer supplies only their own
+   paying account; a malicious economic payload in the buy transaction is ignored.
+4. **Sale-only is explicit and robust.** Enforced at settlement by the royalty policy's opt-in
+   flag — a sale through the pact always works and always pays the royalty; the property cannot be
+   composed away and is never a blanket transfer ban.
+5. **Minimal trusted surface.** Every policy hook is unreachable outside the ledger's lifecycle
+   path: the manager `require-capability`s the registered ledger's matching `-CALL` capability
+   through its stored modref before dispatching. Fabricated token-info dies at the gate.
+
+## Layout
+
+| Path | Contents |
+|---|---|
+| `interfaces/` | `token-policy` (the hook surface + payout schema), `poly-fungible` (the multi-token accounting standard), `ledger-iface` (the `-CALL` handshake), `sale` (price-discovery sale contracts), `updatable-uri-policy`, `account-protocols` |
+| `core/` | `ledger` (identity + balances + the offer/withdraw/buy sale defpact), `policy-manager` (dispatch + the single conservation-asserted settlement), `util` (account protocols) |
+| `policies/` | `royalty-policy`, `guard-policy`, `non-fungible-policy` (strict 1/1, minted once ever), `collection-policy`, `non-updatable-uri-policy` (unconditional uri veto) |
+| `test/` | one adversarial suite per policy + `identity`, `settlement`, and `composition` (a royalty+guard+1/1 stack settled and reconciled to 12 dp) |
+
+## Relationship to the rest of the catalog
+
+- **`contracts/standards/` (NFT interface standard v1)** — the compatibility standard for
+  *standalone* marketplaces, each custodying its own tokens (the `fungible-v2` model). This
+  framework is the **shared-ledger track** that SPEC.md explicitly scopes out of v1: tokens live in
+  one ledger, marketplaces are sale contracts, portability is native. The two coexist; conforming
+  standalone marketplaces and this framework emit compatible economics by construction (state-bound
+  quotes, conservation-asserted settlement, enforceable royalties).
+- **`contracts/library/royalty-sale/`** — the standalone hardened marketplace template and v1
+  reference implementation. This framework generalizes its settlement discipline (dust guard,
+  merged legs, conservation assert) behind a policy architecture.
+- **`contracts/registry/marmalade/`** — the deployed stack whose analysis produced the principles
+  above; reference only.
+
+## Gates
+
+Every change: all suites in `test/` green (`pact <name>.repl`) and the repository's static gate at
+0 VIOLATIONs. Cross-chain classes are devnet evidence (the ledger currently rejects cross-chain
+transfers outright rather than shipping them unproven).

--- a/contracts/nft/policies/collection-policy.pact
+++ b/contracts/nft/policies/collection-policy.pact
@@ -1,0 +1,139 @@
+;; nft.collection-policy — operator-curated, size-capped collections.
+;;
+;; Collections are self-serve: anyone may create one, proving control of its
+;; OPERATOR guard at creation. Tokens then join a collection at create-token
+;; time via the 'collection_id' payload field — only the operator may add
+;; tokens (fail closed: a missing or unknown collection id aborts creation),
+;; up to max-size (0 = unbounded). Minting a collection token is likewise
+;; operator-authorized: curation covers both what enters the collection and
+;; when it is issued. Ownership, sale economics and the NFT shape are the
+;; other policies' concerns — stack them.
+;;
+;; Every hook requires the ledger's matching -CALL capability in scope, so no
+;; hook is reachable outside the real ledger lifecycle path.
+
+(namespace (read-string 'ns))
+
+(module collection-policy GOVERNANCE
+  @doc "Collection membership policy for the nft framework: self-serve \
+       \collections, operator-gated token creation + mint, size cap."
+
+  (implements token-policy)
+  (use token-policy [token-info payout])
+
+  (defconst ADMIN-KS:string (read-string 'admin-ks)
+    @doc "Admin keyset name, captured ONCE at deploy — never read from a \
+         \caller's payload at enforcement time. Governance upgrades the \
+         \module and nothing else: collections belong to their operators.")
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset ADMIN-KS))
+
+  (defconst COLLECTION-ID-MSG-KEY:string "collection_id"
+    @doc "Create-token-tx payload key naming the target collection. REQUIRED \
+         \for any token carrying this policy — fail closed.")
+
+  (defschema collection
+    @doc "An operator-owned collection."
+    name:string
+    operator-guard:guard
+    max-size:integer
+    size:integer)
+  (deftable collections:{collection})
+
+  (defschema token-collection
+    @doc "Which collection a token belongs to (bound once at creation)."
+    collection-id:string)
+  (deftable collection-tokens:{token-collection})
+
+  (defcap COLLECTION:bool (id:string name:string max-size:integer)
+    @doc "Emitted once, when a collection is created."
+    @event true)
+
+  (defcap TOKEN-ADDED:bool (collection-id:string token-id:string)
+    @doc "Emitted when a token joins a collection."
+    @event true)
+
+  (defcap OPERATOR:bool (collection-id:string operator-guard:guard)
+    @doc "Authenticates the collection operator (a signer can scope their \
+         \signature to it). The guard argument always comes from this \
+         \module's own state or, at creation, the enrolling tx."
+    (enforce-guard operator-guard))
+
+  ;; --- collections (self-serve, operator-owned) ---------------------------------
+  (defun create-collection:bool (id:string name:string max-size:integer operator-guard:guard)
+    @doc "Create a collection owned by OPERATOR-GUARD (the caller must \
+         \satisfy it). MAX-SIZE 0 = unbounded. ID must be unique."
+    (enforce (!= id "") "collection id required")
+    (enforce (!= name "") "collection name required")
+    (enforce (>= max-size 0) "max-size must be >= 0 (0 = unbounded)")
+    (with-capability (OPERATOR id operator-guard)
+      (insert collections id
+        { 'name: name, 'operator-guard: operator-guard
+        , 'max-size: max-size, 'size: 0 })
+      (emit-event (COLLECTION id name max-size)))
+    true)
+
+  ;; --- views -------------------------------------------------------------------
+  (defun get-collection:object{collection} (id:string)
+    (read collections id))
+
+  (defun get-token-collection:string (token-id:string)
+    (at 'collection-id (read collection-tokens token-id)))
+
+  ;; --- token-policy hooks --------------------------------------------------------
+  ;; Each hook first requires the ledger's matching -CALL capability (via the
+  ;; manager's registered ledger modref), so it is unreachable outside the real
+  ;; ledger lifecycle path — direct calls with fabricated token-info fail.
+
+  (defun enforce-init:bool (token:object{token-info})
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::INIT-CALL (at 'id token) (at 'precision token) (at 'uri token))))
+    ;; the target collection is REQUIRED (fail closed) and must have room;
+    ;; only its operator may add tokens
+    (let ((collection-id:string (read-msg COLLECTION-ID-MSG-KEY)))
+      (with-read collections collection-id
+        { 'operator-guard := operator-guard, 'max-size := max-size, 'size := size }
+        (let ((new-size:integer (+ 1 size)))
+          (enforce (or (= 0 max-size) (<= new-size max-size)) "collection is full")
+          (with-capability (OPERATOR collection-id operator-guard)
+            (update collections collection-id { 'size: new-size })
+            (insert collection-tokens (at 'id token) { 'collection-id: collection-id })
+            (emit-event (TOKEN-ADDED collection-id (at 'id token)))))))
+    true)
+
+  (defun enforce-mint:bool (token:object{token-info} account:string guard:guard amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::MINT-CALL (at 'id token) account amount)))
+    ;; issuing a collection token is the operator's call (the recipient may be
+    ;; anyone — the operator's guard authorizes the mint itself)
+    (let ((collection-id:string (at 'collection-id (read collection-tokens (at 'id token)))))
+      (with-read collections collection-id { 'operator-guard := operator-guard }
+        (with-capability (OPERATOR collection-id operator-guard) true)))
+    true)
+
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BURN-CALL (at 'id token) account amount)))
+    true)
+
+  (defun enforce-offer:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::OFFER-CALL (at 'id token) seller amount timeout sale-id)))
+    true)
+
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::WITHDRAW-CALL (at 'id token) seller amount timeout sale-id)))
+    true)
+
+  (defun enforce-buy:[object{payout}] (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BUY-CALL (at 'id token) seller buyer amount sale-id)))
+    [])
+
+  (defun enforce-transfer:bool (token:object{token-info} sender:string guard:guard receiver:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::TRANSFER-CALL (at 'id token) sender receiver amount)))
+    true)
+)

--- a/contracts/nft/policies/guard-policy.pact
+++ b/contracts/nft/policies/guard-policy.pact
@@ -1,0 +1,115 @@
+;; nft.guard-policy — per-operation guards, FAIL CLOSED.
+;;
+;; The four operation guards (mint, burn, sale, transfer) are ALL REQUIRED in
+;; the create-token transaction — a missing guard ABORTS creation instead of
+;; silently becoming "anyone can, forever" (the POL-1 fix). Each lifecycle hook
+;; then enforces its matching stored guard:
+;;
+;;   mint-guard     — who may mint (the ledger's mint has no owner yet;
+;;                    without a policy gate, minting is open);
+;;   burn-guard     — who may authorize burns, IN ADDITION to the ledger's own
+;;                    owner-guard (DEBIT) check;
+;;   sale-guard     — who may LIST the token for sale (checked at offer; the
+;;                    buyer is deliberately not gated — a buyer cannot carry
+;;                    the seller-side guard);
+;;   transfer-guard — who may authorize free transfers, in addition to the
+;;                    ledger's owner-guard check.
+;;
+;; The guards bind once at creation and are immutable after. Every hook
+;; requires the ledger's matching -CALL capability in scope, so no hook is
+;; reachable outside the real ledger lifecycle path.
+
+(namespace (read-string 'ns))
+
+(module guard-policy GOVERNANCE
+  @doc "Fail-closed per-operation guard policy for the nft framework: all \
+       \four operation guards are required at create, enforced per hook."
+
+  (implements token-policy)
+  (use token-policy [token-info payout])
+
+  (defconst ADMIN-KS:string (read-string 'admin-ks)
+    @doc "Admin keyset name, captured ONCE at deploy — never read from a \
+         \caller's payload at enforcement time.")
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset ADMIN-KS))
+
+  (defconst GUARDS-MSG-KEY:string "operation_guards"
+    @doc "Create-token-tx payload key carrying the four operation guards. \
+         \ALL fields are required — a partial object aborts creation.")
+
+  (defschema operation-guards
+    @doc "The per-operation guards, bound once at token creation."
+    mint-guard:guard
+    burn-guard:guard
+    sale-guard:guard
+    transfer-guard:guard)
+  (deftable op-guards:{operation-guards})
+
+  (defcap GUARDS:bool (token-id:string)
+    @doc "Emitted once, when the operation guards bind at token creation."
+    @event true)
+
+  ;; --- views -------------------------------------------------------------------
+  (defun get-guards:object{operation-guards} (token-id:string)
+    (read op-guards token-id))
+
+  ;; --- token-policy hooks --------------------------------------------------------
+  ;; Each hook first requires the ledger's matching -CALL capability (via the
+  ;; manager's registered ledger modref), so it is unreachable outside the real
+  ;; ledger lifecycle path — direct calls with fabricated token-info fail.
+
+  (defun enforce-init:bool (token:object{token-info})
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::INIT-CALL (at 'id token) (at 'precision token) (at 'uri token))))
+    ;; ALL four guards are REQUIRED (typed read: absent or partial -> abort,
+    ;; fail closed — a missing guard never defaults to "anyone can")
+    (let ((gs:object{operation-guards} (read-msg GUARDS-MSG-KEY)))
+      (insert op-guards (at 'id token) gs)
+      (emit-event (GUARDS (at 'id token))))
+    true)
+
+  (defun enforce-mint:bool (token:object{token-info} account:string guard:guard amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::MINT-CALL (at 'id token) account amount)))
+    (with-read op-guards (at 'id token) { 'mint-guard := g }
+      (enforce-guard g))
+    true)
+
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BURN-CALL (at 'id token) account amount)))
+    (with-read op-guards (at 'id token) { 'burn-guard := g }
+      (enforce-guard g))
+    true)
+
+  (defun enforce-offer:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::OFFER-CALL (at 'id token) seller amount timeout sale-id)))
+    (with-read op-guards (at 'id token) { 'sale-guard := g }
+      (enforce-guard g))
+    true)
+
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    ;; the ledger's WITHDRAW cap already enforces the seller's own account
+    ;; guard (or offer expiry); gating withdrawal behind the sale-guard would
+    ;; let the guard holder hold the seller's escrowed token hostage
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::WITHDRAW-CALL (at 'id token) seller amount timeout sale-id)))
+    true)
+
+  (defun enforce-buy:[object{payout}] (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string)
+    ;; the sale was authorized by the sale-guard at OFFER; the buyer side is
+    ;; deliberately not gated (a buyer cannot carry the seller-side guard)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BUY-CALL (at 'id token) seller buyer amount sale-id)))
+    [])
+
+  (defun enforce-transfer:bool (token:object{token-info} sender:string guard:guard receiver:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::TRANSFER-CALL (at 'id token) sender receiver amount)))
+    (with-read op-guards (at 'id token) { 'transfer-guard := g }
+      (enforce-guard g))
+    true)
+)

--- a/contracts/nft/policies/non-fungible-policy.pact
+++ b/contracts/nft/policies/non-fungible-policy.pact
@@ -1,0 +1,85 @@
+;; nft.non-fungible-policy — the strict 1/1 NFT shape.
+;;
+;; Enforces at init that the token has precision 0, and at mint that the
+;; amount is exactly 1.0 and that the mint happens ONCE, EVER: the mint marker
+;; is an `insert` (fails on a duplicate key), so even after a burn drops the
+;; supply back to zero the token can never be re-minted. Burn must take the
+;; whole token (amount 1.0), so supply is always exactly 0 or 1.
+;;
+;; Every hook requires the ledger's matching -CALL capability in scope, so no
+;; hook is reachable outside the real ledger lifecycle path.
+
+(namespace (read-string 'ns))
+
+(module non-fungible-policy GOVERNANCE
+  @doc "1/1 NFT shape policy for the nft framework: precision 0, supply \
+       \exactly 1, minted once ever, burned whole."
+
+  (implements token-policy)
+  (use token-policy [token-info payout])
+
+  (defconst ADMIN-KS:string (read-string 'admin-ks)
+    @doc "Admin keyset name, captured ONCE at deploy — never read from a \
+         \caller's payload at enforcement time.")
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset ADMIN-KS))
+
+  (defschema minted-schema
+    @doc "One-way mint marker: the insert is the once-ever gate (a burned \
+         \token cannot be re-minted)."
+    minted:bool)
+  (deftable minted-table:{minted-schema})
+
+  ;; --- views -------------------------------------------------------------------
+  (defun is-minted:bool (token-id:string)
+    (with-default-read minted-table token-id { 'minted: false } { 'minted := m } m))
+
+  ;; --- token-policy hooks --------------------------------------------------------
+  ;; Each hook first requires the ledger's matching -CALL capability (via the
+  ;; manager's registered ledger modref), so it is unreachable outside the real
+  ;; ledger lifecycle path — direct calls with fabricated token-info fail.
+
+  (defun enforce-init:bool (token:object{token-info})
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::INIT-CALL (at 'id token) (at 'precision token) (at 'uri token))))
+    (enforce (= 0 (at 'precision token)) "a 1/1 NFT requires precision 0")
+    true)
+
+  (defun enforce-mint:bool (token:object{token-info} account:string guard:guard amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::MINT-CALL (at 'id token) account amount)))
+    (enforce (= amount 1.0) "a 1/1 NFT mints exactly 1.0")
+    (enforce (= (at 'supply token) 0.0) "a 1/1 NFT is already minted")
+    ;; the once-EVER gate: insert fails on a duplicate, so a burned token
+    ;; (supply back to 0) still cannot be re-minted
+    (insert minted-table (at 'id token) { 'minted: true })
+    true)
+
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BURN-CALL (at 'id token) account amount)))
+    (enforce (= amount 1.0) "a 1/1 NFT burns whole (amount 1.0)")
+    true)
+
+  (defun enforce-offer:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::OFFER-CALL (at 'id token) seller amount timeout sale-id)))
+    (enforce (= amount 1.0) "a 1/1 NFT sells whole (amount 1.0)")
+    true)
+
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::WITHDRAW-CALL (at 'id token) seller amount timeout sale-id)))
+    true)
+
+  (defun enforce-buy:[object{payout}] (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BUY-CALL (at 'id token) seller buyer amount sale-id)))
+    [])
+
+  (defun enforce-transfer:bool (token:object{token-info} sender:string guard:guard receiver:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::TRANSFER-CALL (at 'id token) sender receiver amount)))
+    true)
+)

--- a/contracts/nft/policies/non-updatable-uri-policy.pact
+++ b/contracts/nft/policies/non-updatable-uri-policy.pact
@@ -1,0 +1,71 @@
+;; nft.non-updatable-uri-policy — the immutable-metadata marker.
+;;
+;; A token's uri is only updatable if its policy set includes a policy
+;; implementing `updatable-uri-policy` that PERMITS the update. This policy
+;; implements that interface with an unconditional REJECT, so attaching it
+;; VETOES uri updates no matter what other policies are stacked on the token
+;; — every policy must pass, so one veto is final. Attach it to make "this
+;; metadata can never change" an on-chain guarantee rather than a convention.
+;;
+;; All token-policy lifecycle hooks are permissive; each still requires the
+;; ledger's matching -CALL capability in scope, so no hook is reachable
+;; outside the real ledger lifecycle path (a direct caller could otherwise
+;; mistake the permissive `true` for an authorization).
+
+(namespace (read-string 'ns))
+
+(module non-updatable-uri-policy GOVERNANCE
+  @doc "Immutable-metadata marker for the nft framework: permits the whole \
+       \token lifecycle, vetoes every uri update."
+
+  (implements token-policy)
+  (implements updatable-uri-policy)
+  (use token-policy [token-info payout])
+
+  (defconst ADMIN-KS:string (read-string 'admin-ks)
+    @doc "Admin keyset name, captured ONCE at deploy — never read from a \
+         \caller's payload at enforcement time.")
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset ADMIN-KS))
+
+  ;; --- updatable-uri-policy: the unconditional veto ------------------------------
+  (defun enforce-update-uri:bool (token:object{token-info} new-uri:string)
+    (enforce false "the token uri is immutable"))
+
+  ;; --- token-policy hooks (permissive, -CALL gated) -------------------------------
+  (defun enforce-init:bool (token:object{token-info})
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::INIT-CALL (at 'id token) (at 'precision token) (at 'uri token))))
+    true)
+
+  (defun enforce-mint:bool (token:object{token-info} account:string guard:guard amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::MINT-CALL (at 'id token) account amount)))
+    true)
+
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BURN-CALL (at 'id token) account amount)))
+    true)
+
+  (defun enforce-offer:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::OFFER-CALL (at 'id token) seller amount timeout sale-id)))
+    true)
+
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::WITHDRAW-CALL (at 'id token) seller amount timeout sale-id)))
+    true)
+
+  (defun enforce-buy:[object{payout}] (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BUY-CALL (at 'id token) seller buyer amount sale-id)))
+    [])
+
+  (defun enforce-transfer:bool (token:object{token-info} sender:string guard:guard receiver:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::TRANSFER-CALL (at 'id token) sender receiver amount)))
+    true)
+)

--- a/contracts/nft/policies/royalty-policy.pact
+++ b/contracts/nft/policies/royalty-policy.pact
@@ -1,0 +1,137 @@
+;; nft.royalty-policy — genuinely enforced on-chain creator royalties.
+;;
+;; The royalty terms (creator, creator-guard, bps, sale-only) are REQUIRED in
+;; the create-token transaction and bound into this policy's OWN state at init
+;; — fail closed: a missing or partial spec aborts token creation (the POL-1
+;; fix), and nothing about the royalty is ever read from a buy transaction
+;; (the ARCH-2 fix).
+;;
+;; At settlement this policy DECLARES the creator's cut — computed from its
+;; stored spec and the manager's state-bound quote price — and moves no money;
+;; the policy-manager's single conservation-asserted settlement pays it (the
+;; ARCH-1 / POL-3 fix).
+;;
+;; Sale-only is an explicit opt-in flag in the spec, enforced by rejecting
+;; free transfers — a sale through the ledger's sale pact ALWAYS works and
+;; always pays the royalty, so the royalty cannot be composed away by another
+;; policy and never becomes a blanket transfer ban (the POL-2 fix). The
+;; dust-price guard at offer rejects a price whose floored royalty would be
+;; zero, closing the round-to-zero evasion path.
+;;
+;; Every hook requires the ledger's matching -CALL capability in scope, so no
+;; hook is reachable outside the real ledger lifecycle path.
+
+(namespace (read-string 'ns))
+
+(module royalty-policy GOVERNANCE
+  @doc "Hardened creator-royalty policy for the nft framework: spec bound at \
+       \create, cut declared from state at settlement, explicit sale-only."
+
+  (implements token-policy)
+  (use token-policy [token-info payout])
+
+  (defconst ADMIN-KS:string (read-string 'admin-ks)
+    @doc "Admin keyset name, captured ONCE at deploy — never read from a \
+         \caller's payload at enforcement time.")
+
+  (defcap GOVERNANCE ()
+    (enforce-keyset ADMIN-KS))
+
+  (defconst BPS-DENOM:integer 10000)
+  (defconst MAX-ROYALTY-BPS:integer 5000
+    @doc "Sanity cap on the royalty rate a creator may set: 50%.")
+  (defconst ROYALTY-SPEC-MSG-KEY:string "royalty_spec"
+    @doc "Create-token-tx payload key carrying the royalty spec (the \
+         \CREATOR's tx — economics are never read from a buy tx).")
+
+  (defschema royalty-spec
+    @doc "The royalty terms, bound once at token creation, immutable after."
+    creator:string
+    creator-guard:guard
+    bps:integer
+    sale-only:bool)
+  (deftable royalties:{royalty-spec})
+
+  (defcap ROYALTY:bool (token-id:string creator:string bps:integer sale-only:bool)
+    @doc "Emitted once, when the royalty terms bind at token creation."
+    @event true)
+
+  ;; --- views -------------------------------------------------------------------
+  (defun get-royalty:object{royalty-spec} (token-id:string)
+    (read royalties token-id))
+
+  ;; --- the creator's cut, computed from STATE ----------------------------------
+  (defun royalty-cut:decimal (sale-id:string bps:integer)
+    @doc "floor(price * bps / 10000) at the quote fungible's precision. The \
+         \price comes from the manager's state-bound quote, never a payload."
+    (let* ((q (policy-manager.get-quote sale-id))
+           (fungible:module{fungible-v2} (at 'fungible q))
+           (prec:integer (fungible::precision)))
+      (floor (/ (* (at 'price q) (dec bps)) (dec BPS-DENOM)) prec)))
+
+  ;; --- token-policy hooks --------------------------------------------------------
+  ;; Each hook first requires the ledger's matching -CALL capability (via the
+  ;; manager's registered ledger modref), so it is unreachable outside the real
+  ;; ledger lifecycle path — direct calls with fabricated token-info fail.
+
+  (defun enforce-init:bool (token:object{token-info})
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::INIT-CALL (at 'id token) (at 'precision token) (at 'uri token))))
+    ;; the spec is REQUIRED (typed read: absent or partial -> abort, fail closed)
+    (let ((spec:object{royalty-spec} (read-msg ROYALTY-SPEC-MSG-KEY)))
+      (let ((creator:string (at 'creator spec))
+            (creator-guard:guard (at 'creator-guard spec))
+            (bps:integer (at 'bps spec)))
+        (enforce (and (>= bps 0) (<= bps MAX-ROYALTY-BPS))
+          (format "royalty bps must be in [0, {}]" [MAX-ROYALTY-BPS]))
+        (enforce (validate-principal creator-guard creator)
+          "creator must be the principal account of creator-guard")
+        (insert royalties (at 'id token) spec)
+        (emit-event (ROYALTY (at 'id token) creator bps (at 'sale-only spec)))))
+    true)
+
+  (defun enforce-mint:bool (token:object{token-info} account:string guard:guard amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::MINT-CALL (at 'id token) account amount)))
+    true)
+
+  (defun enforce-burn:bool (token:object{token-info} account:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BURN-CALL (at 'id token) account amount)))
+    true)
+
+  (defun enforce-offer:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::OFFER-CALL (at 'id token) seller amount timeout sale-id)))
+    ;; dust guard: a price whose floored royalty is zero would evade the
+    ;; royalty — reject it at offer (only when a royalty is actually set)
+    (with-read royalties (at 'id token) { 'bps := bps }
+      (if (> bps 0)
+        (let ((cut:decimal (royalty-cut sale-id bps)))
+          (enforce (> cut 0.0) "price too low: the royalty would floor to zero"))
+        true))
+    true)
+
+  (defun enforce-withdraw:bool (token:object{token-info} seller:string amount:decimal timeout:integer sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::WITHDRAW-CALL (at 'id token) seller amount timeout sale-id)))
+    true)
+
+  (defun enforce-buy:[object{payout}] (token:object{token-info} seller:string buyer:string buyer-guard:guard amount:decimal sale-id:string)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::BUY-CALL (at 'id token) seller buyer amount sale-id)))
+    (with-read royalties (at 'id token)
+      { 'creator := creator, 'creator-guard := creator-guard, 'bps := bps }
+      (let ((cut:decimal (royalty-cut sale-id bps)))
+        (if (> cut 0.0)
+          [{ 'account: creator, 'guard: creator-guard, 'amount: cut }]
+          []))))
+
+  (defun enforce-transfer:bool (token:object{token-info} sender:string guard:guard receiver:string amount:decimal)
+    (let ((l:module{ledger-iface} (policy-manager.retrieve-ledger)))
+      (require-capability (l::TRANSFER-CALL (at 'id token) sender receiver amount)))
+    (with-read royalties (at 'id token) { 'sale-only := sale-only }
+      (enforce (not sale-only)
+        "sale-only token: free transfer is disabled — sell via the sale pact"))
+    true)
+)

--- a/contracts/nft/policies/royalty-policy.pact
+++ b/contracts/nft/policies/royalty-policy.pact
@@ -18,6 +18,14 @@
 ;; dust-price guard at offer rejects a price whose floored royalty would be
 ;; zero, closing the round-to-zero evasion path.
 ;;
+;; CURRENCY: the royalty is denominated in the QUOTE's fungible — the seller
+;; picks the sale currency per listing (multi-currency by design, matching the
+;; catalog's marketplace standard). A creator who wants royalties in one fixed
+;; currency can stack a currency-pinning policy; note that no on-chain rule can
+;; stop economically-equivalent evasion (e.g. under-priced quotes settled
+;; off-chain), so the guarantees here are: the rate binds at create, the cut is
+;; computed from state, and every on-pact sale pays it.
+;;
 ;; Every hook requires the ledger's matching -CALL capability in scope, so no
 ;; hook is reachable outside the real ledger lifecycle path.
 

--- a/contracts/nft/test/collection-policy.repl
+++ b/contracts/nft/test/collection-policy.repl
@@ -1,0 +1,292 @@
+;; nft framework — Phase 3: collection-policy suite.
+;;
+;; Proves operator-curated, size-capped collections:
+;;   * collections are self-serve but creating one proves the operator guard;
+;;   * a token joins a collection only with the operator's signature, only
+;;     while there is room (max-size, 0 = unbounded), and the target
+;;     collection is REQUIRED — a missing/unknown collection id aborts (fail
+;;     closed);
+;;   * minting a collection token is operator-authorized;
+;;   * the sale lifecycle flows through unimpeded and reconciles exactly;
+;;   * no hook is reachable outside the ledger's lifecycle path (-CALL gate).
+;;
+;; Run: pact contracts/nft/test/collection-policy.repl
+
+;; --- coin (payment fungible) ------------------------------------------------
+(begin-tx "coin")
+(load "../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+;; --- the nft framework --------------------------------------------------------
+(begin-tx "deploy nft framework")
+(env-data
+  { "g": { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "ns": "nft", "admin-ks": "nft.admin" })
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "nft" (read-keyset 'g) (read-keyset 'g))
+(namespace "nft")
+(define-keyset "nft.admin" (read-keyset 'g))
+(load "../interfaces/account-protocols.pact")
+(load "../interfaces/token-policy.pact")
+(load "../interfaces/poly-fungible.pact")
+(load "../interfaces/ledger-iface.pact")
+(load "../interfaces/sale.pact")
+(load "../interfaces/updatable-uri-policy.pact")
+(load "../core/util.pact")
+(load "../core/policy-manager.pact")
+(create-table nft.policy-manager.ledgers)
+(create-table nft.policy-manager.quotes)
+(load "../core/ledger.pact")
+(create-table nft.ledger.ledger-table)
+(create-table nft.ledger.tokens)
+(nft.policy-manager.init nft.ledger)
+(commit-tx)
+
+;; --- the collection policy ------------------------------------------------------
+(begin-tx "deploy collection policy")
+(env-data { "ns": "nft", "admin-ks": "nft.admin" })
+(load "../policies/collection-policy.pact")
+(create-table nft.collection-policy.collections)
+(create-table nft.collection-policy.collection-tokens)
+(commit-tx)
+
+;; --- fund the buyer -----------------------------------------------------------
+(begin-tx "fund bob")
+(env-data
+  { "bob": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'bob) 1000.0)
+(commit-tx)
+
+;; ===========================================================================
+;; COLLECTION CREATION — self-serve, operator-proved, validated
+;; ===========================================================================
+(begin-tx "invalid collection parameters reject")
+(env-data
+  { "carol": { "keys": ["5555555555555555555555555555555555555555555555555555555555555555"], "pred": "keys-all" } })
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(expect-failure "an empty collection id is rejected" "collection id required"
+  (nft.collection-policy.create-collection "" "Gallery Drop" 2 (read-keyset 'carol)))
+(expect-failure "an empty collection name is rejected" "collection name required"
+  (nft.collection-policy.create-collection "gallery-drop" "" 2 (read-keyset 'carol)))
+(expect-failure "a negative max-size is rejected" "max-size must be >= 0"
+  (nft.collection-policy.create-collection "gallery-drop" "Gallery Drop" -1 (read-keyset 'carol)))
+(rollback-tx)
+
+(begin-tx "creating a collection proves the operator guard")
+(env-data
+  { "carol": { "keys": ["5555555555555555555555555555555555555555555555555555555555555555"], "pred": "keys-all" } })
+;; nobody signed for carol's guard
+(env-sigs [])
+(expect-failure "an unproven operator guard is rejected" "Keyset failure"
+  (nft.collection-policy.create-collection "gallery-drop" "Gallery Drop" 2 (read-keyset 'carol)))
+(rollback-tx)
+
+(begin-tx "carol creates a size-2 collection (and an unbounded one)")
+(env-data
+  { "carol": { "keys": ["5555555555555555555555555555555555555555555555555555555555555555"], "pred": "keys-all" } })
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(nft.collection-policy.create-collection "gallery-drop" "Gallery Drop" 2 (read-keyset 'carol))
+(nft.collection-policy.create-collection "open-editions" "Open Editions" 0 (read-keyset 'carol))
+(expect-failure "a duplicate collection id is rejected" "already"
+  (nft.collection-policy.create-collection "gallery-drop" "Gallery Drop II" 5 (read-keyset 'carol)))
+(expect "collection starts empty" 0
+  (at 'size (nft.collection-policy.get-collection "gallery-drop")))
+(commit-tx)
+
+;; ===========================================================================
+;; TOKEN CREATION — operator-gated, size-capped, fail closed
+;; ===========================================================================
+(begin-tx "a token without a collection_id aborts (fail closed)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "create-token without a collection_id is rejected" "read-msg failure"
+    (nft.ledger.create-token id 0 "ipfs://c1" [nft.collection-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "an unknown collection aborts")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "collection_id": "no-such-collection" })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "an unknown collection id is rejected" "No value found"
+    (nft.ledger.create-token id 0 "ipfs://c1" [nft.collection-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "only the operator may add a token")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "collection_id": "gallery-drop" })
+;; alice signs alone — carol (the operator) did not
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a stranger cannot add a token to carol's collection" "Keyset failure"
+    (nft.ledger.create-token id 0 "ipfs://c1" [nft.collection-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "two tokens join with the operator's signature; the third overflows")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "collection_id": "gallery-drop" })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] }
+          , { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(let ((id1 (nft.ledger.create-token-id
+             { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+             (read-keyset 'alice)))
+      (id2 (nft.ledger.create-token-id
+             { 'uri: "ipfs://c2", 'precision: 0, 'policies: [nft.collection-policy] }
+             (read-keyset 'alice)))
+      (id3 (nft.ledger.create-token-id
+             { 'uri: "ipfs://c3", 'precision: 0, 'policies: [nft.collection-policy] }
+             (read-keyset 'alice))))
+  (nft.ledger.create-token id1 0 "ipfs://c1" [nft.collection-policy] (read-keyset 'alice))
+  (nft.ledger.create-token id2 0 "ipfs://c2" [nft.collection-policy] (read-keyset 'alice))
+  (expect "the collection tracks both tokens" 2
+    (at 'size (nft.collection-policy.get-collection "gallery-drop")))
+  (expect "token-collection binding recorded" "gallery-drop"
+    (nft.collection-policy.get-token-collection id1))
+  (expect-failure "the size cap holds" "collection is full"
+    (nft.ledger.create-token id3 0 "ipfs://c3" [nft.collection-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+;; the overflow test above rolled back (REPL expect-failure does not undo the
+;; two successful creates in the same tx) — redo the two persistent creates
+(begin-tx "persist the two collection tokens")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "collection_id": "gallery-drop" })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] }
+          , { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(let ((id1 (nft.ledger.create-token-id
+             { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+             (read-keyset 'alice)))
+      (id2 (nft.ledger.create-token-id
+             { 'uri: "ipfs://c2", 'precision: 0, 'policies: [nft.collection-policy] }
+             (read-keyset 'alice))))
+  (nft.ledger.create-token id1 0 "ipfs://c1" [nft.collection-policy] (read-keyset 'alice))
+  (nft.ledger.create-token id2 0 "ipfs://c2" [nft.collection-policy] (read-keyset 'alice)))
+(commit-tx)
+
+(begin-tx "the unbounded collection accepts a token")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "collection_id": "open-editions" })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] }
+          , { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://open-1", 'precision: 0, 'policies: [nft.collection-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.create-token id 0 "ipfs://open-1" [nft.collection-policy] (read-keyset 'alice))
+  (expect "unbounded collection grew" 1
+    (at 'size (nft.collection-policy.get-collection "open-editions"))))
+(commit-tx)
+
+;; --- no hook is reachable outside the ledger flow -----------------------------
+(begin-tx "direct hook calls are rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "collection_id": "gallery-drop" })
+(let ((fake:object{nft.token-policy.token-info}
+        { 'id: "n:fake", 'supply: 0.0, 'precision: 0, 'uri: "ipfs://fake"
+        , 'policies: [nft.collection-policy] }))
+  (expect-failure "enforce-init is not directly callable" "not granted"
+    (nft.collection-policy.enforce-init fake))
+  (expect-failure "enforce-mint is not directly callable" "not granted"
+    (nft.collection-policy.enforce-mint fake "k:x" (read-keyset 'alice) 1.0)))
+(rollback-tx)
+
+;; ===========================================================================
+;; MINT — issuing a collection token is the operator's call
+;; ===========================================================================
+(begin-tx "mint WITHOUT the operator rejects")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "minting a collection token needs the operator" "Keyset failure"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 1.0)))
+(rollback-tx)
+
+(begin-tx "mint WITH the operator passes")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "5555555555555555555555555555555555555555555555555555555555555555", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (read-keyset 'alice) 1.0)
+  (expect "alice holds the collection token" 1.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111")))
+(commit-tx)
+
+;; ===========================================================================
+;; SALE — the collection token sells and reconciles exactly
+;; ===========================================================================
+(begin-tx "alice offers the collection token at 30")
+(env-hash (hash "col-sale-1"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 30.0
+    , "seller-account": "k:1111111111111111111111111111111111111111111111111111111111111111"
+    , "seller-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.OFFER id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 0) ] } ])
+  (nft.ledger.sale id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 0))
+(commit-tx)
+
+(begin-tx "bob buys the collection token")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "buyer": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  , "buyer-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "buyer_fungible_account": "k:2222222222222222222222222222222222222222222222222222222222222222" })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://c1", 'precision: 0, 'policies: [nft.collection-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.BUY id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0
+                            (hash "col-sale-1"))
+                        , (coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            (nft.policy-manager.escrow-account (hash "col-sale-1")) 30.0) ] } ])
+  (continue-pact 1 false (hash "col-sale-1"))
+  (expect "bob holds the collection token" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222")))
+(expect "bob paid exactly 30" 970.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "seller alice received the full 30" 30.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "escrow empty after settlement (conservation)" 0.0
+  (coin.get-balance (nft.policy-manager.escrow-account (hash "col-sale-1"))))
+(commit-tx)
+
+(print "")
+(print "=== NFT FRAMEWORK PHASE 3 — COLLECTION POLICY: ALL GREEN ===")
+(print "  self-serve collections with a proven operator guard;")
+(print "  token creation + mint operator-gated; size cap holds (0 = unbounded);")
+(print "  missing/unknown collection aborts creation (fail closed);")
+(print "  sale lifecycle reconciled exactly; hooks unreachable outside the ledger.")

--- a/contracts/nft/test/composition.repl
+++ b/contracts/nft/test/composition.repl
@@ -1,0 +1,389 @@
+;; nft framework — Phase 3: policy COMPOSITION suite.
+;;
+;; One token carries royalty-policy + guard-policy + non-fungible-policy
+;; stacked together, and every policy's rule holds simultaneously:
+;;   * creation demands EVERY policy's required input — a missing royalty spec
+;;     or a missing operation guard aborts (fail closed across the stack);
+;;   * mint needs the mint-guard AND the 1/1 shape (amount exactly 1.0, once);
+;;   * free transfer needs the transfer-guard;
+;;   * offer needs the sale-guard AND survives the royalty dust guard;
+;;   * at settlement the FULL split reconciles: creator royalty + marketplace
+;;     fee + seller remainder, with the buyer's malicious economics ignored;
+;;   * burn needs the burn-guard AND takes the whole token; re-mint is
+;;     rejected forever.
+;;
+;; Run: pact contracts/nft/test/composition.repl
+
+;; --- coin (payment fungible) ------------------------------------------------
+(begin-tx "coin")
+(load "../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+;; --- the nft framework --------------------------------------------------------
+(begin-tx "deploy nft framework")
+(env-data
+  { "g": { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "ns": "nft", "admin-ks": "nft.admin" })
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "nft" (read-keyset 'g) (read-keyset 'g))
+(namespace "nft")
+(define-keyset "nft.admin" (read-keyset 'g))
+(load "../interfaces/account-protocols.pact")
+(load "../interfaces/token-policy.pact")
+(load "../interfaces/poly-fungible.pact")
+(load "../interfaces/ledger-iface.pact")
+(load "../interfaces/sale.pact")
+(load "../interfaces/updatable-uri-policy.pact")
+(load "../core/util.pact")
+(load "../core/policy-manager.pact")
+(create-table nft.policy-manager.ledgers)
+(create-table nft.policy-manager.quotes)
+(load "../core/ledger.pact")
+(create-table nft.ledger.ledger-table)
+(create-table nft.ledger.tokens)
+(nft.policy-manager.init nft.ledger)
+(commit-tx)
+
+;; --- the three policies ---------------------------------------------------------
+(begin-tx "deploy the policy stack")
+(env-data { "ns": "nft", "admin-ks": "nft.admin" })
+(load "../policies/royalty-policy.pact")
+(create-table nft.royalty-policy.royalties)
+(load "../policies/guard-policy.pact")
+(create-table nft.guard-policy.op-guards)
+(load "../policies/non-fungible-policy.pact")
+(create-table nft.non-fungible-policy.minted-table)
+(commit-tx)
+
+;; --- fund the buyer -----------------------------------------------------------
+(begin-tx "fund bob")
+(env-data
+  { "bob": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'bob) 1000.0)
+(commit-tx)
+
+;; NOTE: the policy list order is fixed throughout — Pact 5 `sort` is a no-op
+;; on modrefs, so the order the creator passes is part of the derived id.
+
+;; ===========================================================================
+;; CREATION — every policy's required input must be present
+;; ===========================================================================
+(begin-tx "missing royalty spec aborts even with guards present")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "operation_guards":
+    { "mint-guard": { "keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"], "pred": "keys-all" }
+    , "burn-guard": { "keys": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"], "pred": "keys-all" }
+    , "sale-guard": { "keys": ["cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"], "pred": "keys-all" }
+    , "transfer-guard": { "keys": ["dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"], "pred": "keys-all" } } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "the royalty policy's requirement binds the whole stack" "read-msg failure"
+    (nft.ledger.create-token id 0 "ipfs://stack"
+      [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "missing operation guards abort even with the royalty spec present")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:1111111111111111111111111111111111111111111111111111111111111111"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": 1000, "sale-only": false } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "the guard policy's requirement binds the whole stack" "read-msg failure"
+    (nft.ledger.create-token id 0 "ipfs://stack"
+      [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "precision 1 aborts (the 1/1 policy binds the whole stack)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:1111111111111111111111111111111111111111111111111111111111111111"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": 1000, "sale-only": false }
+  , "operation_guards":
+    { "mint-guard": { "keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"], "pred": "keys-all" }
+    , "burn-guard": { "keys": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"], "pred": "keys-all" }
+    , "sale-guard": { "keys": ["cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"], "pred": "keys-all" }
+    , "transfer-guard": { "keys": ["dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"], "pred": "keys-all" } } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 1
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "precision 1 is rejected by the stacked 1/1 policy" "requires precision 0"
+    (nft.ledger.create-token id 1 "ipfs://stack"
+      [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "create the fully-specified stacked token")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:1111111111111111111111111111111111111111111111111111111111111111"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": 1000, "sale-only": false }
+  , "operation_guards":
+    { "mint-guard": { "keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"], "pred": "keys-all" }
+    , "burn-guard": { "keys": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"], "pred": "keys-all" }
+    , "sale-guard": { "keys": ["cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"], "pred": "keys-all" }
+    , "transfer-guard": { "keys": ["dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"], "pred": "keys-all" } } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.create-token id 0 "ipfs://stack"
+    [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] (read-keyset 'alice))
+  (expect "royalty terms bound" 1000 (at 'bps (nft.royalty-policy.get-royalty id)))
+  (expect "guards bound" true (contains 'mint-guard (nft.guard-policy.get-guards id)))
+  (expect "not minted yet" false (nft.non-fungible-policy.is-minted id)))
+(commit-tx)
+
+;; ===========================================================================
+;; MINT — the mint-guard AND the 1/1 shape hold together
+;; ===========================================================================
+(begin-tx "mint without the mint key rejects")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "the mint-guard holds in the stack" "Keyset failure"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 1.0)))
+(rollback-tx)
+
+(begin-tx "mint amount 2.0 rejects even WITH the mint key")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "the 1/1 shape holds in the stack" "mints exactly 1.0"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 2.0)))
+(rollback-tx)
+
+(begin-tx "mint 1.0 with the mint key passes; a second mint rejects")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (read-keyset 'alice) 1.0)
+  (expect "alice holds the stacked token" 1.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111"))
+  (expect-failure "no second mint" "already minted"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 1.0)))
+(commit-tx)
+
+;; ===========================================================================
+;; TRANSFER — the transfer-guard holds (royalty sale-only is off)
+;; ===========================================================================
+(begin-tx "transfer without the transfer key rejects")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "dave": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0) ] } ])
+  (expect-failure "the transfer-guard holds in the stack" "Keyset failure"
+    (nft.ledger.transfer-create id
+      "k:1111111111111111111111111111111111111111111111111111111111111111"
+      "k:3333333333333333333333333333333333333333333333333333333333333333"
+      (read-keyset 'dave) 1.0)))
+(rollback-tx)
+
+(begin-tx "transfer with the transfer key passes")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "dave": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0) ] }
+            , { "key": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "caps": [] } ])
+  (nft.ledger.transfer-create id
+    "k:1111111111111111111111111111111111111111111111111111111111111111"
+    "k:3333333333333333333333333333333333333333333333333333333333333333"
+    (read-keyset 'dave) 1.0)
+  (expect "dave holds the stacked token" 1.0
+    (nft.ledger.get-balance id "k:3333333333333333333333333333333333333333333333333333333333333333")))
+(commit-tx)
+
+;; ===========================================================================
+;; SALE — sale-guard + dust guard at offer; the FULL split at settlement
+;; ===========================================================================
+(begin-tx "offer without the sale key rejects")
+(env-hash (hash "stack-sale-0"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 60.0
+    , "seller-account": "k:3333333333333333333333333333333333333333333333333333333333333333"
+    , "seller-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-account": "k:4444444444444444444444444444444444444444444444444444444444444444"
+    , "fee-guard": { "keys": ["4444444444444444444444444444444444444444444444444444444444444444"], "pred": "keys-all" }
+    , "fee-bps": 250 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+              , "caps": [ (nft.ledger.OFFER id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0) ] } ])
+  (expect-failure "the sale-guard holds in the stack" "Keyset failure"
+    (nft.ledger.sale id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0)))
+(rollback-tx)
+
+(begin-tx "dust price rejects even with the sale key")
+(env-hash (hash "stack-dust"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 0.000000000001
+    , "seller-account": "k:3333333333333333333333333333333333333333333333333333333333333333"
+    , "seller-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+              , "caps": [ (nft.ledger.OFFER id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0) ] }
+            , { "key": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "caps": [] } ])
+  (expect-failure "the royalty dust guard holds in the stack"
+    "price too low: the royalty would floor to zero"
+    (nft.ledger.sale id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0)))
+(rollback-tx)
+
+(begin-tx "dave lists at 60 (fee 250 bps) with the sale key")
+(env-hash (hash "stack-sale-1"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 60.0
+    , "seller-account": "k:3333333333333333333333333333333333333333333333333333333333333333"
+    , "seller-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-account": "k:4444444444444444444444444444444444444444444444444444444444444444"
+    , "fee-guard": { "keys": ["4444444444444444444444444444444444444444444444444444444444444444"], "pred": "keys-all" }
+    , "fee-bps": 250 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+              , "caps": [ (nft.ledger.OFFER id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0) ] }
+            , { "key": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "caps": [] } ])
+  (nft.ledger.sale id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0))
+(commit-tx)
+
+(begin-tx "bob buys — the full stacked split reconciles; bogus economics ignored")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "buyer": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  , "buyer-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "buyer_fungible_account": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  ;; the attack surface — bogus economics in the BUY tx must be ignored:
+  , "quote": { "fee-bps": 0, "price": 1.0 }
+  , "royalty_spec": { "creator": "k:2222222222222222222222222222222222222222222222222222222222222222"
+                    , "creator-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+                    , "bps": 0, "sale-only": false } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.BUY id
+                            "k:3333333333333333333333333333333333333333333333333333333333333333"
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0
+                            (hash "stack-sale-1"))
+                        , (coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            (nft.policy-manager.escrow-account (hash "stack-sale-1")) 60.0) ] } ])
+  (continue-pact 1 false (hash "stack-sale-1"))
+  (expect "bob holds the stacked token" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222"))
+  (expect "supply is still exactly 1" 1.0 (nft.ledger.total-supply id)))
+;; reconciliation (12 dp): royalty 6 + fee 1.5 + proceeds 52.5 = 60
+(expect "bob paid exactly the state price 60" 940.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "creator alice received the 10% royalty (6)" 6.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "the marketplace fee 1.5 accrued (not zeroed by the buyer)" 1.5
+  (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444"))
+(expect "seller dave received the 52.5 remainder" 52.5
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "escrow empty after settlement (conservation)" 0.0
+  (coin.get-balance (nft.policy-manager.escrow-account (hash "stack-sale-1"))))
+(commit-tx)
+
+;; ===========================================================================
+;; BURN — burn-guard + whole-token + once-ever hold together
+;; ===========================================================================
+(begin-tx "burn without the burn key rejects")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "the burn-guard holds in the stack" "Keyset failure"
+    (nft.ledger.burn id "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0)))
+(rollback-tx)
+
+(begin-tx "burn with owner + burn key passes; re-mint rejected forever")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] }
+          , { "key": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "caps": [] }
+          , { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://stack", 'precision: 0
+            , 'policies: [nft.royalty-policy nft.guard-policy nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.burn id "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0)
+  (expect "burned (supply 0)" 0.0 (nft.ledger.total-supply id))
+  ;; even with the mint key signing, the 1/1 marker is final
+  (expect-failure "no re-mint after burn, ever" "already"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 1.0)))
+(commit-tx)
+
+(print "")
+(print "=== NFT FRAMEWORK PHASE 3 — COMPOSITION: ALL GREEN ===")
+(print "  royalty + guard + non-fungible stacked on ONE token:")
+(print "  creation demands every policy's input; mint/transfer/offer/burn guards")
+(print "  hold alongside the 1/1 shape; the settlement split reconciles exactly")
+(print "  (royalty 6 + fee 1.5 + proceeds 52.5 = 60) with bogus economics ignored.")

--- a/contracts/nft/test/composition.repl
+++ b/contracts/nft/test/composition.repl
@@ -66,8 +66,9 @@
 (coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'bob) 1000.0)
 (commit-tx)
 
-;; NOTE: the policy list order is fixed throughout — Pact 5 `sort` is a no-op
-;; on modrefs, so the order the creator passes is part of the derived id.
+;; NOTE: the ledger canonicalizes the policy list (name-sorted) — the same
+;; policy SET derives the same token id no matter the order passed, and hooks
+;; dispatch in canonical order (identity.repl proves this end-to-end).
 
 ;; ===========================================================================
 ;; CREATION — every policy's required input must be present

--- a/contracts/nft/test/guard-policy.repl
+++ b/contracts/nft/test/guard-policy.repl
@@ -1,0 +1,344 @@
+;; nft framework — Phase 3: guard-policy suite.
+;;
+;; Proves fail-closed per-operation guards (the POL-1 fix):
+;;   * a MISSING guard field aborts token creation — it never defaults to
+;;     "anyone can, forever";
+;;   * mint / burn / offer / transfer each enforce their own distinct guard
+;;     (four different keys prove no cross-satisfaction);
+;;   * the buy side is deliberately not gated (a buyer cannot carry the
+;;     seller-side guard) — a listed token can always settle;
+;;   * withdraw needs only the seller (the sale-guard cannot hold the escrowed
+;;     token hostage);
+;;   * no hook is reachable outside the ledger's lifecycle path (-CALL gate).
+;;
+;; Run: pact contracts/nft/test/guard-policy.repl
+
+;; --- coin (payment fungible) ------------------------------------------------
+(begin-tx "coin")
+(load "../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+;; --- the nft framework --------------------------------------------------------
+(begin-tx "deploy nft framework")
+(env-data
+  { "g": { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "ns": "nft", "admin-ks": "nft.admin" })
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "nft" (read-keyset 'g) (read-keyset 'g))
+(namespace "nft")
+(define-keyset "nft.admin" (read-keyset 'g))
+(load "../interfaces/account-protocols.pact")
+(load "../interfaces/token-policy.pact")
+(load "../interfaces/poly-fungible.pact")
+(load "../interfaces/ledger-iface.pact")
+(load "../interfaces/sale.pact")
+(load "../interfaces/updatable-uri-policy.pact")
+(load "../core/util.pact")
+(load "../core/policy-manager.pact")
+(create-table nft.policy-manager.ledgers)
+(create-table nft.policy-manager.quotes)
+(load "../core/ledger.pact")
+(create-table nft.ledger.ledger-table)
+(create-table nft.ledger.tokens)
+(nft.policy-manager.init nft.ledger)
+(commit-tx)
+
+;; --- the guard policy ---------------------------------------------------------
+(begin-tx "deploy guard policy")
+(env-data { "ns": "nft", "admin-ks": "nft.admin" })
+(load "../policies/guard-policy.pact")
+(create-table nft.guard-policy.op-guards)
+(commit-tx)
+
+;; --- fund the buyer -----------------------------------------------------------
+(begin-tx "fund bob")
+(env-data
+  { "bob": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'bob) 1000.0)
+(commit-tx)
+
+;; ===========================================================================
+;; FAIL CLOSED — a missing guard ABORTS creation (never defaults to open)
+;; ===========================================================================
+(begin-tx "no guards object at all -> creation aborts")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://no-guards", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "create-token without operation guards is rejected" "read-msg failure"
+    (nft.ledger.create-token id 0 "ipfs://no-guards" [nft.guard-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "a MISSING guard field -> creation aborts (the POL-1 fix)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "operation_guards":
+    { "mint-guard": { "keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"], "pred": "keys-all" }
+    , "burn-guard": { "keys": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"], "pred": "keys-all" }
+    , "sale-guard": { "keys": ["cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"], "pred": "keys-all" } } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://partial-guards", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a missing transfer-guard aborts creation — it does NOT default to open"
+    "Runtime typecheck failure"
+    (nft.ledger.create-token id 0 "ipfs://partial-guards" [nft.guard-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+;; ===========================================================================
+;; HAPPY CREATE — four DISTINCT operation guards bind at creation
+;; ===========================================================================
+(begin-tx "create token-g with four distinct operation guards")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "operation_guards":
+    { "mint-guard": { "keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"], "pred": "keys-all" }
+    , "burn-guard": { "keys": ["bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"], "pred": "keys-all" }
+    , "sale-guard": { "keys": ["cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"], "pred": "keys-all" }
+    , "transfer-guard": { "keys": ["dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"], "pred": "keys-all" } } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.create-token id 0 "ipfs://guarded" [nft.guard-policy] (read-keyset 'alice))
+  (expect "the guards are bound on-chain" true
+    (contains 'mint-guard (nft.guard-policy.get-guards id))))
+(commit-tx)
+
+;; --- MINT is gated by the mint-guard ------------------------------------------
+(begin-tx "mint WITHOUT the mint key rejects")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "minting is closed to non-holders of the mint-guard" "Keyset failure"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 1.0)))
+(rollback-tx)
+
+(begin-tx "mint WITH the mint key passes")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (read-keyset 'alice) 1.0)
+  (expect "alice holds token-g" 1.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111")))
+(commit-tx)
+
+;; --- no hook is reachable outside the ledger flow -----------------------------
+(begin-tx "direct hook calls are rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "operation_guards":
+    { "mint-guard": { "keys": ["6666666666666666666666666666666666666666666666666666666666666666"], "pred": "keys-all" }
+    , "burn-guard": { "keys": ["6666666666666666666666666666666666666666666666666666666666666666"], "pred": "keys-all" }
+    , "sale-guard": { "keys": ["6666666666666666666666666666666666666666666666666666666666666666"], "pred": "keys-all" }
+    , "transfer-guard": { "keys": ["6666666666666666666666666666666666666666666666666666666666666666"], "pred": "keys-all" } } })
+(let ((fake:object{nft.token-policy.token-info}
+        { 'id: "n:fake", 'supply: 0.0, 'precision: 0, 'uri: "ipfs://fake"
+        , 'policies: [nft.guard-policy] }))
+  (expect-failure "enforce-init is not directly callable" "not granted"
+    (nft.guard-policy.enforce-init fake))
+  (expect-failure "enforce-mint is not directly callable" "not granted"
+    (nft.guard-policy.enforce-mint fake "k:x" (read-keyset 'alice) 1.0))
+  (expect-failure "enforce-transfer is not directly callable" "not granted"
+    (nft.guard-policy.enforce-transfer fake "k:x" (read-keyset 'alice) "k:y" 1.0)))
+(rollback-tx)
+
+;; --- TRANSFER is gated by the transfer-guard (distinct from the others) --------
+(begin-tx "transfer WITHOUT the transfer key rejects (owner sig alone is not enough)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "dave": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0) ] }
+            ;; the MINT key signs too — a different guard must NOT satisfy transfer
+            , { "key": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "caps": [] } ])
+  (expect-failure "the transfer-guard is enforced (mint key does not cross-satisfy)" "Keyset failure"
+    (nft.ledger.transfer-create id
+      "k:1111111111111111111111111111111111111111111111111111111111111111"
+      "k:3333333333333333333333333333333333333333333333333333333333333333"
+      (read-keyset 'dave) 1.0)))
+(rollback-tx)
+
+(begin-tx "transfer WITH the transfer key passes")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "dave": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0) ] }
+            , { "key": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "caps": [] } ])
+  (nft.ledger.transfer-create id
+    "k:1111111111111111111111111111111111111111111111111111111111111111"
+    "k:3333333333333333333333333333333333333333333333333333333333333333"
+    (read-keyset 'dave) 1.0)
+  (expect "dave holds token-g" 1.0
+    (nft.ledger.get-balance id "k:3333333333333333333333333333333333333333333333333333333333333333")))
+(commit-tx)
+
+;; ===========================================================================
+;; SALE — listing is gated by the sale-guard; the BUYER is not gated
+;; ===========================================================================
+(begin-tx "offer WITHOUT the sale key rejects")
+(env-hash (hash "guard-sale-0"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 25.0
+    , "seller-account": "k:3333333333333333333333333333333333333333333333333333333333333333"
+    , "seller-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+              , "caps": [ (nft.ledger.OFFER id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0) ] } ])
+  (expect-failure "listing is closed to non-holders of the sale-guard" "Keyset failure"
+    (nft.ledger.sale id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0)))
+(rollback-tx)
+
+(begin-tx "offer WITH the sale key passes")
+(env-hash (hash "guard-sale-1"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 25.0
+    , "seller-account": "k:3333333333333333333333333333333333333333333333333333333333333333"
+    , "seller-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+              , "caps": [ (nft.ledger.OFFER id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0) ] }
+            , { "key": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "caps": [] } ])
+  (nft.ledger.sale id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0)
+  (expect "token-g escrowed out of dave" 0.0
+    (nft.ledger.get-balance id "k:3333333333333333333333333333333333333333333333333333333333333333")))
+(commit-tx)
+
+(begin-tx "bob buys — the buyer needs NO operation guard")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "buyer": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  , "buyer-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "buyer_fungible_account": "k:2222222222222222222222222222222222222222222222222222222222222222" })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.BUY id
+                            "k:3333333333333333333333333333333333333333333333333333333333333333"
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0
+                            (hash "guard-sale-1"))
+                        , (coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            (nft.policy-manager.escrow-account (hash "guard-sale-1")) 25.0) ] } ])
+  (continue-pact 1 false (hash "guard-sale-1"))
+  (expect "bob holds token-g" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222")))
+;; reconciliation: no fee, no royalty — the full price reaches the seller
+(expect "bob paid exactly 25" 975.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "seller dave received the full 25" 25.0
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "escrow empty after settlement (conservation)" 0.0
+  (coin.get-balance (nft.policy-manager.escrow-account (hash "guard-sale-1"))))
+(commit-tx)
+
+;; ===========================================================================
+;; WITHDRAW — needs only the seller; the sale-guard CANNOT hold the escrowed
+;; token hostage
+;; ===========================================================================
+(begin-tx "bob lists again (sale key co-signs the offer)")
+(env-hash (hash "guard-sale-2"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 30.0
+    , "seller-account": "k:2222222222222222222222222222222222222222222222222222222222222222"
+    , "seller-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.OFFER id "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0 0) ] }
+            , { "key": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "caps": [] } ])
+  (nft.ledger.sale id "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0 0))
+(commit-tx)
+
+(begin-tx "bob withdraws WITHOUT the sale key — the token comes back")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.WITHDRAW id
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0 0
+                            (hash "guard-sale-2")) ] } ])
+  (continue-pact 0 true (hash "guard-sale-2"))
+  (expect "withdraw returned token-g to bob (no sale-guard hostage)" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222")))
+(commit-tx)
+
+;; ===========================================================================
+;; BURN — gated by the burn-guard IN ADDITION to the owner's guard
+;; ===========================================================================
+(begin-tx "burn WITHOUT the burn key rejects (owner sig alone is not enough)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "burning is closed to non-holders of the burn-guard" "Keyset failure"
+    (nft.ledger.burn id "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0)))
+(rollback-tx)
+
+(begin-tx "burn WITH owner + burn key passes")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] }
+          , { "key": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://guarded", 'precision: 0, 'policies: [nft.guard-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.burn id "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0)
+  (expect "token-g burned (supply 0)" 0.0 (nft.ledger.total-supply id)))
+(commit-tx)
+
+(print "")
+(print "=== NFT FRAMEWORK PHASE 3 — GUARD POLICY: ALL GREEN ===")
+(print "  fail closed: a missing guard field ABORTS creation (POL-1 fixed);")
+(print "  mint/burn/offer/transfer each enforce their own distinct guard;")
+(print "  the buyer is not gated; withdraw needs only the seller (no hostage);")
+(print "  no policy hook reachable outside the ledger lifecycle path.")

--- a/contracts/nft/test/non-fungible-policy.repl
+++ b/contracts/nft/test/non-fungible-policy.repl
@@ -1,0 +1,228 @@
+;; nft framework — Phase 3: non-fungible-policy suite.
+;;
+;; Proves the strict 1/1 NFT shape:
+;;   * precision must be 0 at creation;
+;;   * mint amount must be exactly 1.0, and only while supply is 0;
+;;   * the mint is ONCE, EVER — after a burn (supply back to 0) a re-mint is
+;;     still rejected (the one-way insert marker);
+;;   * burn and offer must take the whole token (amount 1.0);
+;;   * the full sale lifecycle reconciles exactly;
+;;   * no hook is reachable outside the ledger's lifecycle path (-CALL gate).
+;;
+;; Run: pact contracts/nft/test/non-fungible-policy.repl
+
+;; --- coin (payment fungible) ------------------------------------------------
+(begin-tx "coin")
+(load "../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+;; --- the nft framework --------------------------------------------------------
+(begin-tx "deploy nft framework")
+(env-data
+  { "g": { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "ns": "nft", "admin-ks": "nft.admin" })
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "nft" (read-keyset 'g) (read-keyset 'g))
+(namespace "nft")
+(define-keyset "nft.admin" (read-keyset 'g))
+(load "../interfaces/account-protocols.pact")
+(load "../interfaces/token-policy.pact")
+(load "../interfaces/poly-fungible.pact")
+(load "../interfaces/ledger-iface.pact")
+(load "../interfaces/sale.pact")
+(load "../interfaces/updatable-uri-policy.pact")
+(load "../core/util.pact")
+(load "../core/policy-manager.pact")
+(create-table nft.policy-manager.ledgers)
+(create-table nft.policy-manager.quotes)
+(load "../core/ledger.pact")
+(create-table nft.ledger.ledger-table)
+(create-table nft.ledger.tokens)
+(nft.policy-manager.init nft.ledger)
+(commit-tx)
+
+;; --- the non-fungible policy ----------------------------------------------------
+(begin-tx "deploy non-fungible policy")
+(env-data { "ns": "nft", "admin-ks": "nft.admin" })
+(load "../policies/non-fungible-policy.pact")
+(create-table nft.non-fungible-policy.minted-table)
+(commit-tx)
+
+;; --- fund the buyer -----------------------------------------------------------
+(begin-tx "fund bob")
+(env-data
+  { "bob": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'bob) 1000.0)
+(commit-tx)
+
+;; ===========================================================================
+;; SHAPE — precision 0, mint exactly 1.0, once
+;; ===========================================================================
+(begin-tx "precision 1 rejected at creation")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://frac", 'precision: 1, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a fractional-precision 1/1 is rejected" "requires precision 0"
+    (nft.ledger.create-token id 1 "ipfs://frac" [nft.non-fungible-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "create the 1/1 token")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.create-token id 0 "ipfs://one-of-one" [nft.non-fungible-policy] (read-keyset 'alice))
+  (expect "not minted yet" false (nft.non-fungible-policy.is-minted id)))
+(commit-tx)
+
+(begin-tx "mint amount 2.0 rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a 1/1 NFT mints exactly 1.0" "mints exactly 1.0"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 2.0)))
+(rollback-tx)
+
+(begin-tx "mint 1.0 passes; a second mint is rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (read-keyset 'alice) 1.0)
+  (expect "alice holds the 1/1" 1.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111"))
+  (expect "supply is exactly 1" 1.0 (nft.ledger.total-supply id))
+  (expect "minted marker set" true (nft.non-fungible-policy.is-minted id)))
+(commit-tx)
+
+(begin-tx "second mint rejected while supply is 1")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a 1/1 NFT cannot be minted twice" "already minted"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 1.0)))
+(rollback-tx)
+
+;; --- no hook is reachable outside the ledger flow -----------------------------
+(begin-tx "direct hook calls are rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((fake:object{nft.token-policy.token-info}
+        { 'id: "n:fake", 'supply: 0.0, 'precision: 0, 'uri: "ipfs://fake"
+        , 'policies: [nft.non-fungible-policy] }))
+  (expect-failure "enforce-init is not directly callable" "not granted"
+    (nft.non-fungible-policy.enforce-init fake))
+  (expect-failure "enforce-mint is not directly callable" "not granted"
+    (nft.non-fungible-policy.enforce-mint fake "k:x" (read-keyset 'alice) 1.0)))
+(rollback-tx)
+
+;; ===========================================================================
+;; SALE — the 1/1 sells whole and reconciles exactly
+;; ===========================================================================
+(begin-tx "offer the 1/1 at 25")
+(env-hash (hash "nf-sale-1"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 25.0
+    , "seller-account": "k:1111111111111111111111111111111111111111111111111111111111111111"
+    , "seller-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.OFFER id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 0) ] } ])
+  (nft.ledger.sale id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 0)
+  (expect "the 1/1 escrowed out of alice" 0.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111")))
+(commit-tx)
+
+(begin-tx "bob buys the 1/1")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "buyer": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  , "buyer-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "buyer_fungible_account": "k:2222222222222222222222222222222222222222222222222222222222222222" })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.BUY id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0
+                            (hash "nf-sale-1"))
+                        , (coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            (nft.policy-manager.escrow-account (hash "nf-sale-1")) 25.0) ] } ])
+  (continue-pact 1 false (hash "nf-sale-1"))
+  (expect "bob holds the 1/1" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222"))
+  (expect "supply is still exactly 1" 1.0 (nft.ledger.total-supply id)))
+(expect "bob paid exactly 25" 975.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "seller alice received the full 25" 25.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "escrow empty after settlement (conservation)" 0.0
+  (coin.get-balance (nft.policy-manager.escrow-account (hash "nf-sale-1"))))
+(commit-tx)
+
+;; ===========================================================================
+;; BURN ONCE — the whole token burns; a re-mint is rejected FOREVER
+;; ===========================================================================
+(begin-tx "partial burn rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a 1/1 NFT burns whole" "burns whole"
+    (nft.ledger.burn id "k:2222222222222222222222222222222222222222222222222222222222222222" 2.0)))
+(rollback-tx)
+
+(begin-tx "bob burns the 1/1")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.burn id "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0)
+  (expect "supply back to 0" 0.0 (nft.ledger.total-supply id)))
+(commit-tx)
+
+(begin-tx "re-mint after burn is rejected — once means EVER")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://one-of-one", 'precision: 0, 'policies: [nft.non-fungible-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a burned 1/1 cannot be re-minted" "already"
+    (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+      (read-keyset 'alice) 1.0)))
+(rollback-tx)
+
+(print "")
+(print "=== NFT FRAMEWORK PHASE 3 — NON-FUNGIBLE POLICY: ALL GREEN ===")
+(print "  precision 0 enforced at creation; mint exactly 1.0, once EVER;")
+(print "  re-mint after burn rejected (one-way marker); burn/offer take the whole token;")
+(print "  sale lifecycle reconciled exactly; hooks unreachable outside the ledger.")

--- a/contracts/nft/test/non-updatable-uri-policy.repl
+++ b/contracts/nft/test/non-updatable-uri-policy.repl
@@ -1,0 +1,174 @@
+;; nft framework — Phase 3: non-updatable-uri-policy suite.
+;;
+;; Proves the immutable-metadata marker:
+;;   * enforce-update-uri rejects UNCONDITIONALLY (the veto is final even if
+;;     other stacked policies would permit an update — every policy must pass);
+;;   * the full token lifecycle (create/mint/offer/buy/transfer/burn) flows
+;;     through the marker unimpeded and reconciles exactly;
+;;   * no lifecycle hook is reachable outside the ledger's path (-CALL gate).
+;;
+;; Run: pact contracts/nft/test/non-updatable-uri-policy.repl
+
+;; --- coin (payment fungible) ------------------------------------------------
+(begin-tx "coin")
+(load "../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+;; --- the nft framework --------------------------------------------------------
+(begin-tx "deploy nft framework")
+(env-data
+  { "g": { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "ns": "nft", "admin-ks": "nft.admin" })
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "nft" (read-keyset 'g) (read-keyset 'g))
+(namespace "nft")
+(define-keyset "nft.admin" (read-keyset 'g))
+(load "../interfaces/account-protocols.pact")
+(load "../interfaces/token-policy.pact")
+(load "../interfaces/poly-fungible.pact")
+(load "../interfaces/ledger-iface.pact")
+(load "../interfaces/sale.pact")
+(load "../interfaces/updatable-uri-policy.pact")
+(load "../core/util.pact")
+(load "../core/policy-manager.pact")
+(create-table nft.policy-manager.ledgers)
+(create-table nft.policy-manager.quotes)
+(load "../core/ledger.pact")
+(create-table nft.ledger.ledger-table)
+(create-table nft.ledger.tokens)
+(nft.policy-manager.init nft.ledger)
+(commit-tx)
+
+;; --- the marker policy ----------------------------------------------------------
+(begin-tx "deploy non-updatable-uri policy")
+(env-data { "ns": "nft", "admin-ks": "nft.admin" })
+(load "../policies/non-updatable-uri-policy.pact")
+(commit-tx)
+
+;; --- fund the buyer -----------------------------------------------------------
+(begin-tx "fund bob")
+(env-data
+  { "bob": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'bob) 1000.0)
+(commit-tx)
+
+;; ===========================================================================
+;; THE VETO — a uri update is rejected unconditionally
+;; ===========================================================================
+(begin-tx "enforce-update-uri always rejects")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((tok:object{nft.token-policy.token-info}
+        { 'id: "n:any", 'supply: 1.0, 'precision: 0, 'uri: "ipfs://frozen"
+        , 'policies: [nft.non-updatable-uri-policy] }))
+  (expect-failure "the uri veto is unconditional" "the token uri is immutable"
+    (nft.non-updatable-uri-policy.enforce-update-uri tok "ipfs://replaced")))
+(rollback-tx)
+
+;; --- no lifecycle hook is reachable outside the ledger flow --------------------
+(begin-tx "direct lifecycle hook calls are rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(let ((fake:object{nft.token-policy.token-info}
+        { 'id: "n:fake", 'supply: 0.0, 'precision: 0, 'uri: "ipfs://fake"
+        , 'policies: [nft.non-updatable-uri-policy] }))
+  (expect-failure "enforce-init is not directly callable" "not granted"
+    (nft.non-updatable-uri-policy.enforce-init fake))
+  (expect-failure "enforce-transfer is not directly callable" "not granted"
+    (nft.non-updatable-uri-policy.enforce-transfer fake "k:x" (read-keyset 'alice) "k:y" 1.0)))
+(rollback-tx)
+
+;; ===========================================================================
+;; LIFECYCLE — the marker never obstructs the token's life
+;; ===========================================================================
+(begin-tx "create + mint")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://frozen", 'precision: 0, 'policies: [nft.non-updatable-uri-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.create-token id 0 "ipfs://frozen" [nft.non-updatable-uri-policy] (read-keyset 'alice))
+  (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (read-keyset 'alice) 1.0)
+  (expect "alice holds the token" 1.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111")))
+(commit-tx)
+
+(begin-tx "offer at 20")
+(env-hash (hash "uri-sale-1"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 20.0
+    , "seller-account": "k:1111111111111111111111111111111111111111111111111111111111111111"
+    , "seller-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://frozen", 'precision: 0, 'policies: [nft.non-updatable-uri-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.OFFER id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 0) ] } ])
+  (nft.ledger.sale id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 0))
+(commit-tx)
+
+(begin-tx "bob buys")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "buyer": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  , "buyer-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "buyer_fungible_account": "k:2222222222222222222222222222222222222222222222222222222222222222" })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://frozen", 'precision: 0, 'policies: [nft.non-updatable-uri-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.BUY id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0
+                            (hash "uri-sale-1"))
+                        , (coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            (nft.policy-manager.escrow-account (hash "uri-sale-1")) 20.0) ] } ])
+  (continue-pact 1 false (hash "uri-sale-1"))
+  (expect "bob holds the token" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222")))
+(expect "bob paid exactly 20" 980.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "seller alice received the full 20" 20.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "escrow empty after settlement (conservation)" 0.0
+  (coin.get-balance (nft.policy-manager.escrow-account (hash "uri-sale-1"))))
+(commit-tx)
+
+(begin-tx "transfer and burn flow through")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "dave": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://frozen", 'precision: 0, 'policies: [nft.non-updatable-uri-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0) ] } ])
+  (nft.ledger.transfer-create id
+    "k:2222222222222222222222222222222222222222222222222222222222222222"
+    "k:3333333333333333333333333333333333333333333333333333333333333333"
+    (read-keyset 'dave) 1.0)
+  (expect "dave holds the token" 1.0
+    (nft.ledger.get-balance id "k:3333333333333333333333333333333333333333333333333333333333333333"))
+  (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [] } ])
+  (nft.ledger.burn id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0)
+  (expect "burned (supply 0)" 0.0 (nft.ledger.total-supply id)))
+(commit-tx)
+
+(print "")
+(print "=== NFT FRAMEWORK PHASE 3 — NON-UPDATABLE-URI POLICY: ALL GREEN ===")
+(print "  the uri veto is unconditional (final against any policy stack);")
+(print "  the full lifecycle flows through the marker and reconciles exactly;")
+(print "  lifecycle hooks unreachable outside the ledger.")

--- a/contracts/nft/test/royalty-policy.repl
+++ b/contracts/nft/test/royalty-policy.repl
@@ -1,0 +1,398 @@
+;; nft framework — Phase 3: royalty-policy suite.
+;;
+;; Proves genuinely enforced on-chain creator royalties:
+;;   * fail-closed init: a missing/partial/invalid royalty spec ABORTS creation
+;;     (bps capped at 50%, creator principal-validated — impersonation rejected);
+;;   * the creator is paid on a SECONDARY sale (creator != seller) — the cut is
+;;     computed from the policy's stored spec + the manager's state-bound quote,
+;;     never from the buy tx;
+;;   * the dust guard rejects an offer whose floored royalty would be zero;
+;;   * sale-only is an explicit opt-in: free transfers reject (for every owner),
+;;     while a sale via the sale pact always works and always pays the royalty;
+;;   * no hook is reachable outside the ledger's lifecycle path (-CALL gate).
+;;
+;; Run: pact contracts/nft/test/royalty-policy.repl
+
+;; --- coin (payment fungible) ------------------------------------------------
+(begin-tx "coin")
+(load "../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
+(load "../../registry/core/coin/coin-v6.pact")
+(create-table coin.coin-table)
+(commit-tx)
+
+;; --- the nft framework --------------------------------------------------------
+(begin-tx "deploy nft framework")
+(env-data
+  { "g": { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "ns": "nft", "admin-ks": "nft.admin" })
+(env-keys ["9999999999999999999999999999999999999999999999999999999999999999"])
+(define-namespace "nft" (read-keyset 'g) (read-keyset 'g))
+(namespace "nft")
+(define-keyset "nft.admin" (read-keyset 'g))
+(load "../interfaces/account-protocols.pact")
+(load "../interfaces/token-policy.pact")
+(load "../interfaces/poly-fungible.pact")
+(load "../interfaces/ledger-iface.pact")
+(load "../interfaces/sale.pact")
+(load "../interfaces/updatable-uri-policy.pact")
+(load "../core/util.pact")
+(load "../core/policy-manager.pact")
+(create-table nft.policy-manager.ledgers)
+(create-table nft.policy-manager.quotes)
+(load "../core/ledger.pact")
+(create-table nft.ledger.ledger-table)
+(create-table nft.ledger.tokens)
+(nft.policy-manager.init nft.ledger)
+(commit-tx)
+
+;; --- the royalty policy -------------------------------------------------------
+(begin-tx "deploy royalty policy")
+(env-data { "ns": "nft", "admin-ks": "nft.admin" })
+(load "../policies/royalty-policy.pact")
+(create-table nft.royalty-policy.royalties)
+(commit-tx)
+
+;; --- fund the buyer -----------------------------------------------------------
+(begin-tx "fund bob")
+(env-data
+  { "bob": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" } })
+(test-capability (coin.CREDIT "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(coin.credit "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset 'bob) 1000.0)
+(commit-tx)
+
+;; ===========================================================================
+;; FAIL-CLOSED INIT — every malformed spec ABORTS token creation
+;; ===========================================================================
+
+(begin-tx "no spec at all -> creation aborts (fail closed)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://no-spec", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "create-token without a royalty spec is rejected" "read-msg failure"
+    (nft.ledger.create-token id 0 "ipfs://no-spec" [nft.royalty-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "partial spec (missing sale-only) -> creation aborts (fail closed)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:1111111111111111111111111111111111111111111111111111111111111111"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": 1000 } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://partial", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a partial royalty spec is rejected" "Runtime typecheck failure"
+    (nft.ledger.create-token id 0 "ipfs://partial" [nft.royalty-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "bps over the 50% cap -> rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:1111111111111111111111111111111111111111111111111111111111111111"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": 6000, "sale-only": false } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://greedy", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a 60% royalty is rejected" "royalty bps must be in"
+    (nft.ledger.create-token id 0 "ipfs://greedy" [nft.royalty-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "negative bps -> rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:1111111111111111111111111111111111111111111111111111111111111111"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": -1, "sale-only": false } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://negative", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "a negative royalty is rejected" "royalty bps must be in"
+    (nft.ledger.create-token id 0 "ipfs://negative" [nft.royalty-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+(begin-tx "impersonated spec -> rejected (attacker account, victim guard)")
+;; mallory names HER account as creator but pairs it with ALICE's guard: the
+;; principal validation catches the mismatch, so a spec cannot route royalties
+;; to an account its guard does not own.
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:6666666666666666666666666666666666666666666666666666666666666666"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": 1000, "sale-only": false } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://impersonated", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (expect-failure "an account/guard mismatch in the spec is rejected"
+    "creator must be the principal account of creator-guard"
+    (nft.ledger.create-token id 0 "ipfs://impersonated" [nft.royalty-policy] (read-keyset 'alice))))
+(rollback-tx)
+
+;; ===========================================================================
+;; HAPPY PATH — alice creates + mints token-1 (10% royalty, freely transferable)
+;; ===========================================================================
+(begin-tx "create + mint token-1")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:1111111111111111111111111111111111111111111111111111111111111111"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": 1000, "sale-only": false } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-1", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.create-token id 0 "ipfs://art-1" [nft.royalty-policy] (read-keyset 'alice))
+  (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (read-keyset 'alice) 1.0)
+  (expect "alice owns token-1" 1.0
+    (nft.ledger.get-balance id "k:1111111111111111111111111111111111111111111111111111111111111111"))
+  (expect "the royalty terms are bound on-chain" 1000
+    (at 'bps (nft.royalty-policy.get-royalty id))))
+(commit-tx)
+
+;; --- no hook is reachable outside the ledger flow -----------------------------
+(begin-tx "direct hook calls are rejected")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:6666666666666666666666666666666666666666666666666666666666666666"
+                    , "creator-guard": { "keys": ["6666666666666666666666666666666666666666666666666666666666666666"], "pred": "keys-all" }
+                    , "bps": 5000, "sale-only": false } })
+(let ((fake:object{nft.token-policy.token-info}
+        { 'id: "n:fake", 'supply: 0.0, 'precision: 0, 'uri: "ipfs://fake"
+        , 'policies: [nft.royalty-policy] }))
+  (expect-failure "enforce-init is not directly callable" "not granted"
+    (nft.royalty-policy.enforce-init fake))
+  (expect-failure "enforce-buy is not directly callable" "not granted"
+    (nft.royalty-policy.enforce-buy fake "k:seller" "k:buyer" (read-keyset 'alice) 1.0 "sale-x"))
+  (expect-failure "enforce-transfer is not directly callable" "not granted"
+    (nft.royalty-policy.enforce-transfer fake "k:seller" (read-keyset 'alice) "k:buyer" 1.0)))
+(rollback-tx)
+
+;; --- free transfer works when sale-only is off --------------------------------
+(begin-tx "alice gifts token-1 to dave (sale-only off)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "dave": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-1", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0) ] } ])
+  (nft.ledger.transfer-create id
+    "k:1111111111111111111111111111111111111111111111111111111111111111"
+    "k:3333333333333333333333333333333333333333333333333333333333333333"
+    (read-keyset 'dave) 1.0)
+  (expect "dave holds token-1" 1.0
+    (nft.ledger.get-balance id "k:3333333333333333333333333333333333333333333333333333333333333333")))
+(commit-tx)
+
+;; ===========================================================================
+;; DUST GUARD — a price whose floored royalty is zero is rejected at offer
+;; ===========================================================================
+(begin-tx "dust-price offer rejected")
+(env-hash (hash "roy-dust"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 0.000000000001
+    , "seller-account": "k:3333333333333333333333333333333333333333333333333333333333333333"
+    , "seller-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-1", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+              , "caps": [ (nft.ledger.OFFER id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0) ] } ])
+  (expect-failure "a royalty-evading dust price is rejected"
+    "price too low: the royalty would floor to zero"
+    (nft.ledger.sale id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0)))
+(rollback-tx)
+
+;; ===========================================================================
+;; SECONDARY SALE — dave (seller) lists at 100 with a 2.5% marketplace fee;
+;; bob buys. The CREATOR alice is paid 10 although she is not a party to the
+;; sale: royalty 10 -> alice, fee 2.5 -> marketplace, proceeds 87.5 -> dave.
+;; ===========================================================================
+(begin-tx "offer token-1 at 100 (fee 250 bps)")
+(env-hash (hash "roy-sale-1"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 100.0
+    , "seller-account": "k:3333333333333333333333333333333333333333333333333333333333333333"
+    , "seller-guard": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+    , "fee-account": "k:4444444444444444444444444444444444444444444444444444444444444444"
+    , "fee-guard": { "keys": ["4444444444444444444444444444444444444444444444444444444444444444"], "pred": "keys-all" }
+    , "fee-bps": 250 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-1", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333"
+              , "caps": [ (nft.ledger.OFFER id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0) ] } ])
+  (let ((sale-id (nft.ledger.sale id "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0 0)))
+    (expect "the sale-id is the deterministic pact-id" (hash "roy-sale-1") sale-id)
+    (expect "token-1 escrowed out of dave" 0.0
+      (nft.ledger.get-balance id "k:3333333333333333333333333333333333333333333333333333333333333333"))))
+(commit-tx)
+
+(begin-tx "bob buys — the creator is paid on a sale she is no party to")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "buyer": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  , "buyer-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "buyer_fungible_account": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  ;; bogus economics in the buy tx MUST be ignored (state quote wins)
+  , "quote": { "fee-bps": 0, "price": 1.0 }
+  , "royalty_spec": { "creator": "k:2222222222222222222222222222222222222222222222222222222222222222"
+                    , "creator-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+                    , "bps": 0, "sale-only": false } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-1", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.BUY id
+                            "k:3333333333333333333333333333333333333333333333333333333333333333"
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0
+                            (hash "roy-sale-1"))
+                        , (coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            (nft.policy-manager.escrow-account (hash "roy-sale-1")) 100.0) ] } ])
+  (continue-pact 1 false (hash "roy-sale-1"))
+  (expect "bob holds token-1" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222")))
+;; reconciliation (12 dp): 10 + 2.5 + 87.5 = 100
+(expect "bob paid exactly the state price 100" 900.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "creator alice received the 10% royalty on the SECONDARY sale" 10.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "seller dave received the 87.5 remainder" 87.5
+  (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333"))
+(expect "the marketplace fee 2.5 accrued (not zeroed by the buyer)" 2.5
+  (coin.get-balance "k:4444444444444444444444444444444444444444444444444444444444444444"))
+(expect "escrow empty after settlement (conservation)" 0.0
+  (coin.get-balance (nft.policy-manager.escrow-account (hash "roy-sale-1"))))
+(commit-tx)
+
+;; ===========================================================================
+;; SALE-ONLY — an explicit opt-in: free transfers reject for EVERY owner, the
+;; sale pact always works (and pays the royalty) — royalty-by-settlement, not
+;; a composable-away transfer ban.
+;; ===========================================================================
+(begin-tx "create + mint token-2 (5% royalty, sale-only)")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "royalty_spec": { "creator": "k:1111111111111111111111111111111111111111111111111111111111111111"
+                    , "creator-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+                    , "bps": 500, "sale-only": true } })
+(env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-2", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (nft.ledger.create-token id 0 "ipfs://art-2" [nft.royalty-policy] (read-keyset 'alice))
+  (nft.ledger.mint id "k:1111111111111111111111111111111111111111111111111111111111111111"
+    (read-keyset 'alice) 1.0))
+(commit-tx)
+
+(begin-tx "free transfer of a sale-only token rejects")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "dave": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-2", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0) ] } ])
+  (expect-failure "sale-only blocks the free transfer" "sale-only token: free transfer is disabled"
+    (nft.ledger.transfer-create id
+      "k:1111111111111111111111111111111111111111111111111111111111111111"
+      "k:3333333333333333333333333333333333333333333333333333333333333333"
+      (read-keyset 'dave) 1.0)))
+(rollback-tx)
+
+(begin-tx "the sale pact still works for a sale-only token")
+(env-hash (hash "roy-sale-2"))
+(env-chain-data { "block-time": (time "2026-01-01T00:00:00Z") })
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "quote":
+    { "fungible": coin, "price": 40.0
+    , "seller-account": "k:1111111111111111111111111111111111111111111111111111111111111111"
+    , "seller-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+    , "fee-account": "", "fee-guard": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+    , "fee-bps": 0 } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-2", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111"
+              , "caps": [ (nft.ledger.OFFER id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 0) ] } ])
+  (nft.ledger.sale id "k:1111111111111111111111111111111111111111111111111111111111111111" 1.0 0))
+(commit-tx)
+
+(begin-tx "bob buys token-2 — royalty enforced at settlement")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "buyer": "k:2222222222222222222222222222222222222222222222222222222222222222"
+  , "buyer-guard": { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "buyer_fungible_account": "k:2222222222222222222222222222222222222222222222222222222222222222" })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-2", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.BUY id
+                            "k:1111111111111111111111111111111111111111111111111111111111111111"
+                            "k:2222222222222222222222222222222222222222222222222222222222222222" 1.0
+                            (hash "roy-sale-2"))
+                        , (coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            (nft.policy-manager.escrow-account (hash "roy-sale-2")) 40.0) ] } ])
+  (continue-pact 1 false (hash "roy-sale-2"))
+  (expect "bob holds token-2" 1.0
+    (nft.ledger.get-balance id "k:2222222222222222222222222222222222222222222222222222222222222222")))
+;; alice is creator AND seller here: royalty 2 + proceeds 38, merged = +40
+(expect "alice netted royalty 2 + proceeds 38 = 50 total balance" 50.0
+  (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
+(expect "bob paid 40 (balance 860)" 860.0
+  (coin.get-balance "k:2222222222222222222222222222222222222222222222222222222222222222"))
+(expect "escrow empty after settlement (conservation)" 0.0
+  (coin.get-balance (nft.policy-manager.escrow-account (hash "roy-sale-2"))))
+(commit-tx)
+
+(begin-tx "sale-only persists for the NEW owner")
+(env-data
+  { "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "dave": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" } })
+(let ((id (nft.ledger.create-token-id
+            { 'uri: "ipfs://art-2", 'precision: 0, 'policies: [nft.royalty-policy] }
+            (read-keyset 'alice))))
+  (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222"
+              , "caps": [ (nft.ledger.TRANSFER id
+                            "k:2222222222222222222222222222222222222222222222222222222222222222"
+                            "k:3333333333333333333333333333333333333333333333333333333333333333" 1.0) ] } ])
+  (expect-failure "bob cannot free-transfer the sale-only token either"
+    "sale-only token: free transfer is disabled"
+    (nft.ledger.transfer-create id
+      "k:2222222222222222222222222222222222222222222222222222222222222222"
+      "k:3333333333333333333333333333333333333333333333333333333333333333"
+      (read-keyset 'dave) 1.0)))
+(rollback-tx)
+
+(print "")
+(print "=== NFT FRAMEWORK PHASE 3 — ROYALTY POLICY: ALL GREEN ===")
+(print "  fail-closed init: missing/partial/greedy/impersonated specs all abort;")
+(print "  creator paid 10% on a SECONDARY sale (creator != seller), from state;")
+(print "  dust guard: royalty-evading price rejected at offer;")
+(print "  sale-only: free transfers reject for every owner, sales always work;")
+(print "  no policy hook reachable outside the ledger lifecycle path.")


### PR DESCRIPTION
Stacked on Phase 2 (#38). The headline value-add: the concrete policies that make the hardened settlement mean something.

## What

Five policies implementing `nft.token-policy` in `contracts/nft/policies/`, each with a full-lifecycle adversarial suite in `contracts/nft/test/`, plus a composition suite. Every hook in every policy first requires the ledger's matching `-CALL` capability (via the manager's registered ledger modref) — **no hook is reachable outside the real ledger lifecycle path**, so policy state can neither be pre-seeded nor probed with fabricated token-info.

## `royalty-policy` — genuinely enforced creator royalties

- The spec (`creator`, `creator-guard`, `bps`, `sale-only`) is **REQUIRED in the create-token tx** and bound in policy state: missing/partial spec aborts creation, bps is capped at 5000 (50%), and the creator account is principal-validated against the creator guard — an impersonated spec (attacker account, victim guard) rejects.
- At settlement the policy **declares** `floor(price × bps / 10000)` at the quote fungible's precision, computed from its stored spec + the manager's **state-bound** quote price — nothing economic is read from the buy tx.
- **Dust guard at offer**: a price whose floored royalty is zero rejects (closes the round-to-zero evasion path); applies only when bps > 0.
- **Sale-only is an explicit opt-in**: free transfers reject for every owner, but a sale via the sale pact always works and always pays the royalty — royalty-by-settlement, not a composable-away transfer ban.

## `guard-policy` — fail closed per operation

All four guards (mint/burn/sale/transfer) are **required at create**: a missing guard field ABORTS creation instead of silently becoming "anyone can, forever". Four distinct keys in the suite prove no cross-satisfaction. Buy is deliberately ungated (a buyer cannot carry the seller-side guard); withdraw needs only the seller, so the sale-guard cannot hold the escrowed token hostage.

## `non-fungible-policy` — the strict 1/1 shape

Precision 0 at create; mint exactly 1.0, **once EVER** — the mint marker is an insert, so a burned token (supply back to 0) still cannot be re-minted; burn/offer take the whole token.

## `collection-policy` — operator-curated membership

Self-serve collections (creating one proves the operator guard); tokens join only with the operator's signature via a **required** `collection_id`, up to max-size (0 = unbounded); mint is operator-authorized. Adapted from the audited library `nft-collection-policy` semantics; the 1/1 shape is `non-fungible-policy`'s job — stack them.

## `non-updatable-uri-policy` — the immutability veto

Permissive lifecycle marker implementing `updatable-uri-policy` with an unconditional reject: since every policy must pass, one veto is final regardless of what else is stacked.

## Proven — six suites, 0 FAILURE, reconciled to 12 dp

- **`royalty-policy.repl`**: creator paid 10 on a **secondary sale she is no party to** (royalty 10 → creator, fee 2.5 → marketplace, 87.5 → seller; buyer's bogus `quote`/`royalty_spec` payload ignored); all malformed specs abort; dust offer rejects; sale-only holds across owners.
- **`guard-policy.repl`**: each operation needs exactly its own key; full sale reconciles; hostage-free withdraw.
- **`non-fungible-policy.repl`**: no second mint, no re-mint after burn, whole-token burn, sale reconciles.
- **`collection-policy.repl`**: operator gate on join + mint, size cap holds, unknown/missing collection aborts, sale reconciles.
- **`non-updatable-uri-policy.repl`**: veto unconditional; full lifecycle unimpeded.
- **`composition.repl`**: royalty + guard + non-fungible on ONE token — creation demands every policy's input, all guards + the 1/1 shape hold simultaneously, and the stacked split reconciles exactly (royalty 6 + fee 1.5 + proceeds 52.5 = 60) with the buyer's bogus economics ignored.

Static gate: **0 violations**. Phase 1/2 suites (`identity.repl`, `settlement.repl`) re-run green.

## Notes for review

- **`sort` on a modref list is a no-op in Pact 5** (verified in the REPL): the ledger's `(sort policies)` canonicalization in `create-token` therefore does not reorder — the policy-list **order is part of the derived token id**. Not a forgery vector (the creation-guard still anchors the id and re-derivation still binds the exact list), but the same policy set in a different order yields a different id. Worth a follow-up decision: sort by a canonical key, or document order-sensitivity as part of the standard.
- The `updatable-uri-policy` interface + the ledger's `UPDATE-URI-CALL` cap exist, but the ledger has **no `update-uri` entry point yet** — the manager-side routing (reject unless an updatable-uri policy permits) is pending; proposed alongside Phase 4.
