### PR TITLE
docs: catalog the standards product; record the consignment spike's outcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Reusable, trusted Pact smart contracts, maintained by the Pact Community Organization (PCO) in service of one mission: **make it easy and safe for businesses to start building with smart contracts.**
 
-The catalog ships two clearly separated products:
+The catalog ships three clearly separated products:
 
 - **[`contracts/library/`](contracts/library/) — the Library**: PCO-authored, deployable templates. Start here.
 - **[`contracts/registry/`](contracts/registry/) — the Registry**: an observatory of contracts that already exist on-chain, catalogued verbatim for reference.
+- **[`contracts/standards/`](contracts/standards/) — the Standards**: the Kadena NFT interface standard v1 — a normative [SPEC](contracts/standards/SPEC.md), three un-upgradeable interfaces, and a runnable conformance suite that independent marketplaces implement to stay compatible.
 
 ## The Library
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Reusable, trusted Pact smart contracts, maintained by the Pact Community Organization (PCO) in service of one mission: **make it easy and safe for businesses to start building with smart contracts.**
 
-The catalog ships three clearly separated products:
+The catalog ships four clearly separated products:
 
 - **[`contracts/library/`](contracts/library/) — the Library**: PCO-authored, deployable templates. Start here.
 - **[`contracts/registry/`](contracts/registry/) — the Registry**: an observatory of contracts that already exist on-chain, catalogued verbatim for reference.
 - **[`contracts/standards/`](contracts/standards/) — the Standards**: the Kadena NFT interface standard v1 — a normative [SPEC](contracts/standards/SPEC.md), three un-upgradeable interfaces, and a runnable conformance suite that independent marketplaces implement to stay compatible.
+- **[`contracts/nft/`](contracts/nft/) — the NFT Framework**: the shared-ledger track — one hardened ledger anchoring token identity (forgery/double-mint structurally impossible), a conservation-asserted settlement engine, a composable policy set (royalties, guards, 1/1, collections, uri rules), auctions, and cross-chain relocation where a token's rules travel with it.
 
 ## The Library
 

--- a/contracts/standards/nft-consignment-spike/SPIKE.md
+++ b/contracts/standards/nft-consignment-spike/SPIKE.md
@@ -1,10 +1,19 @@
 # NFT consignment spike — the painting model, proven
 
-**Result: the architecture works.** An NFT deployed as its own module in an artist's namespace can
-be consigned to a marketplace in a *different* namespace, sold there with the creator royalty paid by
-the asset, then re-consigned by the new owner to a *third* namespace's marketplace and sold again —
+> **OUTCOME (2026-07-07): mechanics proven; identity model not adopted.** The production NFT build
+> went a different way — a **shared-ledger framework** (the `nft` namespace series) — because token
+> identity is the one property a self-sovereign per-NFT module can never anchor: anyone can deploy a
+> lookalike module claiming any provenance, so forgery/double-mint impossibility requires an id
+> derived and enforced in one shared ledger. What this spike proved **stands as reference**:
+> cross-namespace sale authorization via a recorded consignment guard (`enforce-guard` on state, not
+> a foreign capability), frozen-after-mint economics, and a marketplace that sells what it does not
+> own. Read it as a proving-ground record, not the adopted architecture.
+
+**Result: the consignment mechanics work.** An NFT deployed as its own module in an artist's namespace
+can be consigned to a marketplace in a *different* namespace, sold there with the creator royalty paid
+by the asset, then re-consigned by the new owner to a *third* namespace's marketplace and sold again —
 the same painting, gallery to gallery, royalty to the original creator every time, and no marketplace
-able to skim it. This demonstrates the asset/marketplace-separation design before any production build.
+able to skim it.
 
 ## What the spike contains
 
@@ -92,8 +101,8 @@ guard, atomically superseding the prior one.
 
 ## Verdict
 
-The asset/marketplace separation with self-sovereign per-NFT modules and consignment-via-guard is
-**sound and buildable on Kadena today**. The real-world model the founder described — created in a
-studio, consignable to any gallery, held in a wallet or moved gallery to gallery by the owner, royalty
-to the creator on every sale — is realized. Recommended next step: build the production standard (the
-interfaces + reference template) and the first marketplace.
+The consignment-via-guard mechanics — cross-namespace sale authorization, frozen terms, royalty paid
+by the asset, one marketplace at a time — are **sound and buildable on Kadena today**, and the spike
+demonstrates them end-to-end with conservation asserted. The **per-NFT-module identity model was not
+carried into production** (see the outcome note at the top): the production build anchors identity in
+a shared ledger, where the guard-based authorization patterns proven here continue to apply.


### PR DESCRIPTION
Two catalog-story fixes surfaced by the NFT-lineage consistency review:

- **Root README**: the product map said the catalog ships two products; `contracts/standards/` (the Kadena NFT interface standard v1) is a third and now has its own entry.
- **`nft-consignment-spike/SPIKE.md`**: the spike read as the adopted forward architecture ("Result: the architecture works... recommended next step: build the production standard"). It now records the actual outcome: the consignment-guard mechanics stand as proven reference, but the per-NFT-module identity model was not carried into production — forgery/double-mint impossibility requires token ids derived and enforced in one shared ledger, which is the architecture the production NFT framework builds on. The verdict section is reconciled to the same story.

Docs only; no contract changes. Suites and gates unaffected.