### PR TITLE
docs: NFT ecosystem truth sweep — four-product framing, Marmalade naming, campaign coverage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,10 +4,14 @@
 
 Provide a layered, dependency-aware catalog of production Pact smart contracts on KDA-CE. Each contract entry ships with its source code (as deployed on-chain), human-readable documentation, machine-readable metadata, and an audit record.
 
-The catalog is split into
-two product trees: **`contracts/registry/`** (the observatory — verbatim observed
-contracts, read-only reference) and **`contracts/library/`** (the product —
-PCO-authored deployable templates with a strict quality gate).
+The catalog ships four product trees: **`contracts/library/`** (PCO-authored
+deployable templates with a strict quality gate), **`contracts/registry/`** (the
+observatory — verbatim observed contracts, read-only reference),
+**`contracts/standards/`** (the Kadena NFT interface standard v1 — a normative
+SPEC, three un-upgradeable interfaces, and a runnable conformance suite), and
+**`contracts/nft/`** (the NFT Framework — the PCO-authored shared-ledger NFT
+ecosystem: one hardened ledger, a conservation-asserted settlement manager, six
+policies, two auction sale contracts, and cross-chain relocation).
 
 ---
 
@@ -25,9 +29,11 @@ contracts/
   registry/            — observed contracts, grouped by dependency layer
     kip/               — KIP standard interfaces (no executable logic)
     core/              — Pre-deployed KDA-CE chain infrastructure
-    marmalade/         — Marmalade v2 NFT framework (pre-deployed)
+    marmalade/         — Marmalade v2 NFT stack (pre-deployed, verbatim reference)
     ecosystem/         — production third-party modules (deployment breadth + call-frequency census)
     community/         — census-observed community free-namespace modules
+  standards/           — Kadena NFT interface standard v1 (normative SPEC + conformance suite)
+  nft/                 — the NFT Framework (PCO-authored shared-ledger NFT ecosystem)
 scripts/               — validation, index generation
 docs/                  — onboarding, policies, index output (index.md, index.json)
 ```
@@ -57,7 +63,7 @@ Layer 1 — Core Infrastructure (registry/core/)
     core/ns                    namespace registry; called by define-namespace
     core/fungible-util         implements kip.account-protocols-v1; used by coin
 
-Layer 2 — NFT Framework (registry/marmalade/)
+Layer 2 — Marmalade v2 NFT Stack (registry/marmalade/)
   Marmalade v2 pre-deployed NFT stack.
   Depends on kip/ interfaces and core/coin for payments.
 
@@ -110,8 +116,24 @@ Library — Deployable Templates (contracts/library/)
   audit_status self-reviewed or better. Entries with open CRITICAL
   findings can never live here.
 
-    library/hello-world                tutorial entry point
-    library/token-fungible             implements kip/fungible-v2
+    Ten templates: hello-world, token-fungible, gas-station,
+    multisig-treasury, vesting, dao-voting, nft-collection-policy,
+    oracle-feed, property-lease, royalty-sale
+    (see contracts/library/README.md for the full table)
+
+Standards — Kadena NFT Interface Standard v1 (contracts/standards/)
+  PCO-authored, normative. Outside the registry layer stack.
+  Three un-upgradeable interfaces (nft-asset-v1, nft-market-v1,
+  nft-xchain-v1) + a normative SPEC + a modref-driven conformance
+  suite. royalty-sale is the reference implementation.
+
+NFT Framework (contracts/nft/)
+  PCO-authored shared-ledger NFT ecosystem. Outside the registry
+  layer stack; an original implementation (not a Marmalade fork).
+  One hardened ledger (token identity), a policy-manager with a
+  single conservation-asserted settlement, six policies, two
+  auction sale contracts, cross-chain relocation via policy
+  passports. Gate: 14 REPL suites + static analysis on every change.
 ```
 
 ### Full dependency graph
@@ -186,7 +208,7 @@ license: 'Apache-2.0'
 authors:
   - name: 'Author Name'
     email: 'author@example.org'
-audit_status: 'audited'   # audited | in-review | not-audited
+audit_status: 'self-reviewed'   # reference | unaudited | self-reviewed | community-reviewed | independently-audited (docs/CONTRACT_POLICIES.md §3.1)
 tags: ['token', 'finance']
 keywords: ['pact', 'smart-contract']
 ```
@@ -211,6 +233,8 @@ keywords: ['pact', 'smart-contract']
 | `registry/ecosystem/` | Third-party projects | Various (see each module's `metadata.yaml`) — verified from mainnet01 blockchain census Jan 2025 / Mar 2026 |
 | `registry/community/` | Community projects | Census-observed free-namespace modules (see each module's `metadata.yaml`) |
 | `library/` | PCO contributors | [Pact-Community-Organization/pact-contract-catalog](https://github.com/Pact-Community-Organization/pact-contract-catalog) |
+| `standards/` | PCO-authored | This repository (normative interface standard, un-upgradeable once deployed) |
+| `nft/` | PCO-authored | This repository (original implementation; Marmalade sources were read-only reference) |
 
 > All `registry/` entries are **observed entries** — verbatim snapshots of upstream or on-chain code, catalogued to document what community modules build upon and integrate with. PCO makes no security claim beyond the recorded audit status. Only `library/` entries are authored, maintained, and quality-gated by PCO.
 
@@ -222,4 +246,6 @@ keywords: ['pact', 'smart-contract']
 - Additions to `registry/ecosystem/` and `registry/community/` require evidence of deployment on mainnet01 (module hash, describe-module output, or block explorer link) plus a PR matching the census methodology in `contracts/registry/ecosystem/README.md`.
 - Additions to `library/` require a PR linking a GitHub issue, passing CI (including the library quality gate: schema-A metadata, co-located `.repl` tests, `audit_status` of `self-reviewed` or better), and approval per `CONTRIBUTING.md`.
 - Entries with an open CRITICAL finding live in `registry/`, never `library/`.
+- `contracts/standards/` is normative: the three interfaces are un-upgradeable (`CannotUpgradeInterface`) and the SPEC's clauses are versioned — breaking changes ship as `-v2`, never as edits. Changes go through maintainer PRs.
+- `contracts/nft/` changes require every suite under `contracts/nft/test/` green and the static gate at 0 violations (see the Gates section of [contracts/nft/README.md](contracts/nft/README.md)); cross-chain behavior classes additionally require multi-chain devnet evidence.
 - Audit promotions follow the ladder in `docs/CONTRACT_POLICIES.md` §3.1 (`reference` / `unaudited` / `self-reviewed` / `community-reviewed` / `independently-audited`) and require evidence in `AUDIT.md`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The catalog ships four clearly separated products:
 
 ## The Library
 
-Eight production-grade templates covering the foundations most projects need. Every one shipped through the same three gates: a **blocking CI test suite**, a **static-analysis pass**, and an **independent adversarial security review** whose findings and fixes are documented in the entry's `AUDIT.md` — including the attacks that were tried and defeated.
+Ten production-grade templates covering the foundations most projects need. Every one shipped through the same three gates: a **blocking CI test suite**, a **static-analysis pass**, and an **independent adversarial security review** whose findings and fixes are documented in the entry's `AUDIT.md` — including the attacks that were tried and defeated.
 
 | Template | What it is |
 |---|---|
@@ -22,6 +22,8 @@ Eight production-grade templates covering the foundations most projects need. Ev
 | [dao-voting](contracts/library/dao-voting/) | Membership voting with quorum + threshold: per-proposal snapshot of the passage bar, rotation revokes a compromised member's in-flight votes. Pairs with the treasury. |
 | [nft-collection-policy](contracts/library/nft-collection-policy/) | A marmalade-v2 concrete policy: creator-gated collections with size caps and a strict one-of-one NFT invariant, tested against the real marmalade ledger. |
 | [oracle-feed](contracts/library/oracle-feed/) | Median data/price feed with fail-closed consumption: chain-assigned timestamps, staleness windows, publisher rotation as instant revocation, plus a worked consumer pattern. |
+| [property-lease](contracts/library/property-lease/) | Rental rails: escrowed deposit, rent buckets with a revenue split, party-authenticated notice, and vault conservation across every mutating path. |
+| [royalty-sale](contracts/library/royalty-sale/) | A conservation-checked NFT marketplace: 1-of-1 tokens with immutable creator royalties, state-bound listing economics, one atomic settlement. The reference implementation of the [NFT interface standard](contracts/standards/). |
 | [hello-world](contracts/library/hello-world/) | The minimal starter: module shape, governance, a real test suite. |
 
 All entries currently carry `audit_status: self-reviewed` — a defined claim, not a vibe: see the [audit-status ladder](docs/CONTRACT_POLICIES.md) (§3.1) for exactly what each level means and what evidence it requires. Nothing in this catalog calls itself "audited" without naming who audited it.
@@ -32,7 +34,7 @@ All entries currently carry `audit_status: self-reviewed` — a defined claim, n
 2. Copy the template directory into your project; adapt the namespace, keysets, and business rules.
 3. Read the entry's `README.md` (usage, deployment checklist, known limits) and `AUDIT.md` (threat model, findings history) — they are short and written to be read.
 4. Run and extend the co-located test suite (below).
-5. **Validate on devnet before mainnet.** Every entry's README says this because it is load-bearing: one class of KDA-CE bug (table reads inside `enforce` conditions) is invisible in the REPL. The templates are written to the node-safe pattern — and all six deployable ones have been [driven on a live devnet](docs/DEVNET-VALIDATION.md) to prove it — but your adaptations need the same proof.
+5. **Validate on devnet before mainnet.** Every entry's README says this because it is load-bearing: one class of KDA-CE bug (table reads inside `enforce` conditions) is invisible in the REPL. The templates are written to the node-safe pattern — and seven of them have been [driven on a live devnet](docs/DEVNET-VALIDATION.md) to prove it (the report records per-entry status) — but your adaptations need the same proof.
 
 ### Testing
 
@@ -47,7 +49,7 @@ CI runs every library suite as a blocking check on every PR, plus the catalog va
 
 ## The Registry
 
-[`contracts/registry/`](contracts/registry/) catalogues contracts that already exist, grouped by dependency layer: `kip/` (standard interfaces), `core/` (pre-deployed chain infrastructure), `marmalade/` (the NFT framework), `ecosystem/` (census-selected third-party mainnet modules), and `community/`. These are **verbatim snapshots** — read-only reference for integration, education, and due diligence, not starting points. See [ARCHITECTURE.md](ARCHITECTURE.md) for the layer model and the census methodology.
+[`contracts/registry/`](contracts/registry/) catalogues contracts that already exist, grouped by dependency layer: `kip/` (standard interfaces), `core/` (pre-deployed chain infrastructure), `marmalade/` (the deployed Marmalade v2 NFT stack — verbatim reference), `ecosystem/` (census-selected third-party mainnet modules), and `community/`. These are **verbatim snapshots** — read-only reference for integration, education, and due diligence, not starting points. See [ARCHITECTURE.md](ARCHITECTURE.md) for the layer model and the census methodology.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,9 @@ smart contracts. Security reporting is central to that promise.
 This policy covers:
 
 - The catalog tooling (`scripts/`, CI workflows, validation logic).
-- Contract entries **authored by PCO** (the `contracts/library/` tree).
+- Contracts **authored by PCO**: the `contracts/library/` templates, the NFT
+  interface standard (`contracts/standards/`), and the NFT Framework
+  (`contracts/nft/`).
 
 Contract entries under `contracts/registry/` are catalogued
 **verbatim** from upstream or on-chain sources and carry the `reference` or

--- a/contracts/library/README.md
+++ b/contracts/library/README.md
@@ -9,9 +9,17 @@ This tree contains **Pact Community Organization (PCO)** contract templates: dep
 | Contract | Directory | Description |
 |---------|-----------|-------------|
 | Hello World | [hello-world/](hello-world/README.md) | Introductory contract — entry point for new Pact developers |
-| Token (fungible-v2) | [token-fungible/](token-fungible/README.md) | Reference fungible token implementation (PCO template) |
+| Token (fungible-v2 + fungible-xchain-v1) | [token-fungible/](token-fungible/README.md) | Hardened fungible token: coin-pattern guard enforcement, governed mint, cross-chain steps |
+| Gas Station | [gas-station/](gas-station/README.md) | Drain-defended gas sponsorship with a per-user on-chain allowlist |
+| Multisig Treasury | [multisig-treasury/](multisig-treasury/README.md) | M-of-N treasury: capability-guarded vault, propose/approve/execute, stale-approval revocation |
+| Token Vesting | [vesting/](vesting/README.md) | Cliff + linear vesting, escrowed upfront; revoke returns only the unvested part |
+| DAO Voting | [dao-voting/](dao-voting/README.md) | Membership voting with quorum + threshold and per-proposal passage snapshots |
+| NFT Collection Policy | [nft-collection-policy/](nft-collection-policy/README.md) | marmalade-v2 concrete policy: creator-gated collections, size caps, strict 1-of-1 |
+| Oracle Feed | [oracle-feed/](oracle-feed/README.md) | Median data/price feed with fail-closed staleness windows and publisher rotation |
+| Property Lease | [property-lease/](property-lease/README.md) | Rental rails: escrowed deposit, rent buckets with revenue split, vault conservation |
+| Royalty Sale | [royalty-sale/](royalty-sale/README.md) | Conservation-checked NFT marketplace; reference implementation of the [NFT interface standard](../standards/SPEC.md) |
 
-Planned templates: gas-station, NFT collection + policy, multisig treasury, vesting escrow, DAO voting, oracle consumer.
+The [NFT Framework](../nft/README.md) (`contracts/nft/`) generalizes `royalty-sale`'s settlement discipline behind a shared-ledger policy architecture — it is a separate product tree, not a library template.
 
 ---
 

--- a/contracts/library/royalty-sale/README.md
+++ b/contracts/library/royalty-sale/README.md
@@ -1,6 +1,6 @@
 # Royalty Sale — conservation-checked NFT marketplace
 
-PCO library template: a **self-contained NFT with an enforceable-royalty marketplace**, built as the hardened answer to the flaws documented in our [Marmalade V2 security & architecture analysis](../../docs/). It owns both its token ledger and its sale escrow end to end — which is the only way to *prove* the safe settlement patterns rather than inherit a shared-escrow sweep.
+PCO library template: a **self-contained NFT with an enforceable-royalty marketplace**, built as the hardened answer to the failure modes our Marmalade V2 analysis documented — restated as the normative clauses of the [NFT interface standard](../../standards/SPEC.md), of which this template is the reference implementation. It owns both its token ledger and its sale escrow end to end — which is the only way to *prove* the safe settlement patterns rather than inherit a shared-escrow sweep.
 
 On-chain royalty enforcement is genuinely the strongest model in the NFT market (Ethereum's EIP-2981 is metadata-only and its enforcement collapsed; Solana keeps re-platforming transfer-restriction). Marmalade had the right idea; this template keeps the idea and fixes the execution.
 
@@ -66,7 +66,7 @@ cd contracts/library/royalty-sale/examples && pact royalty-sale-test.repl
 
 ## Known limits
 
-- **Instant fixed-price sales only.** Auctions, Dutch auctions, and time-escrowed offers are a future extension; the conservation-checked settlement generalizes to them.
+- **Instant fixed-price sales only.** Auctions and Dutch auctions exist in the catalog as part of the [NFT Framework](../../nft/README.md) (`contracts/nft/`), which generalizes this template's conservation-checked settlement behind a shared-ledger policy architecture; this template stays the minimal standalone reference.
 - **Sale-only tokens cannot be gifted or freely migrated** — that is the cost of enforceable royalties, and it is the creator's explicit opt-in, not a default.
 - **1-of-1 NFTs.** Fractional / multi-edition supply is out of scope for this template.
 - **The escrow is shared across sales but nets to zero each sale** (conservation is asserted per sale). Do not send funds to the escrow account directly.

--- a/contracts/nft/README.md
+++ b/contracts/nft/README.md
@@ -47,7 +47,7 @@ proving-ground record.
 | `core/` | `ledger` (identity + balances + the offer/withdraw/buy sale defpact + policy-mediated `update-uri` + the `transfer-crosschain` defpact), `policy-manager` (dispatch, the single conservation-asserted settlement, the governance-registered sale-contract whitelist, the attachment-authoritative uri-update routing) |
 | `policies/` | `royalty-policy`, `guard-policy`, `non-fungible-policy` (strict 1/1, minted once ever), `collection-policy`, `guarded-uri-policy` (guard-bound uri updates), `non-updatable-uri-policy` (unconditional uri veto) |
 | `sale/` | `conventional-auction` (escrowed ascending bids, increment-enforced outbidding with full refunds, winner-only settlement, grace-windowed withdrawal), `dutch-auction` (interval-stepped declining curve) |
-| `test/` | one adversarial suite per policy and per sale contract + `identity`, `settlement`, `composition`, `update-uri` (incl. the veto composition case), `xchain` (the passport mechanics) and `marketplace-sim` (create on chain 0 -> sell on marketplace A -> relocate to chain 1 -> auction on marketplace B, all legs reconciled) |
+| `test/` | **14 suites**: `identity`, `settlement`, `negative-payout` (non-positive policy legs rejected), an adversarial suite per policy (`royalty-policy`, `guard-policy`, `non-fungible-policy`, `collection-policy`, `non-updatable-uri-policy`; `guarded-uri-policy` is exercised in `update-uri` and `xchain`), one per sale contract (`conventional-auction`, `dutch-auction`), `composition`, `update-uri` (incl. the veto composition case), `xchain` (the passport mechanics) and `marketplace-sim` (create on chain 0 -> sell on marketplace A -> relocate to chain 1 -> auction on marketplace B, all legs reconciled) |
 
 ## Price-discovery sales (auctions)
 
@@ -69,7 +69,9 @@ uri guard) — which yields to the target chain with the token's metadata. On th
 SPV-continued step, the only way to reach it) the token row is materialized on first arrival and
 every policy re-binds its passport, so **the token's rules travel with it**: the creator's royalty
 is enforced on every chain the token ever sells on. A sale-only token relocates owner-to-owner only
-(a cross-chain ownership change would be a free transfer in two hops). The id needs no re-derivation
+(a cross-chain ownership change would be a free transfer in two hops), and for a transfer-guarded
+token (`guard-policy`) a relocation that changes the owner must satisfy the **transfer-guard** —
+same-chain parity — while an owner relocating to themselves stays ungated. The id needs no re-derivation
 on arrival and cannot be forged there: `create-token` re-derives with the LOCAL chain-id, so the
 relocated id fails the protocol check for everyone, on every other chain, forever. The uri is
 chain-local mutable state — a returning token keeps the local uri; all other passport state is

--- a/contracts/registry/marmalade/README.md
+++ b/contracts/registry/marmalade/README.md
@@ -1,6 +1,6 @@
-# marmalade/ — Marmalade v2 NFT Framework
+# marmalade/ — Marmalade v2 NFT Stack
 
-This layer contains the **Marmalade v2** NFT framework pre-deployed on all KDA-CE chains. Marmalade is KDA-CE's production NFT standard — it powers token creation, minting, burning, and multi-step sales with composable policies.
+This layer contains the **Marmalade v2** NFT stack pre-deployed on all KDA-CE chains. Marmalade is KDA-CE's production NFT standard — it powers token creation, minting, burning, and multi-step sales with composable policies. These are **verbatim snapshots**, read-only reference; the analysis of this stack produced the design principles behind the PCO-authored [NFT Framework](../../nft/README.md) (`contracts/nft/`), which is an original implementation, not a fork.
 
 ---
 

--- a/contracts/registry/marmalade/ledger/README.md
+++ b/contracts/registry/marmalade/ledger/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-`marmalade-v2.ledger` is the core ledger module of KDA-CE's Marmalade v2 NFT framework. It manages token definitions, account balances, and the SALE defpact (offer → buy/withdraw). Policies are attached per token and enforced by `marmalade-v2.policy-manager`.
+`marmalade-v2.ledger` is the core ledger module of KDA-CE's Marmalade v2 NFT stack. It manages token definitions, account balances, and the SALE defpact (offer → buy/withdraw). Policies are attached per token and enforced by `marmalade-v2.policy-manager`.
 
 Marmalade v2 significantly upgrades v1:
 - Multiple policies per token (composable policy slots)

--- a/contracts/standards/SPEC.md
+++ b/contracts/standards/SPEC.md
@@ -28,8 +28,10 @@ the same events, and obeys the same royalty and settlement rules, external
 software treats them uniformly. This is the `fungible-v2` model — every token
 contract is its own ledger, yet one wallet handles them all. Full asset
 portability across a shared ledger (a token minted in marketplace A, held in
-marketplace B's ledger) is explicitly **not** a v1 goal; if the ecosystem ever
-needs it, that is a v2 track with its own shared-ledger design.
+marketplace B's ledger) is explicitly **not** a v1 goal; that shared-ledger
+track now exists as the PCO [`nft` framework](../nft/README.md)
+(`contracts/nft/`) — a separate product with its own design, which does not
+change v1's custody model or any clause below.
 
 ## The rules (normative)
 
@@ -141,6 +143,7 @@ document plus the three interfaces.
 
 Auctions and offers/bids; bundles/collections as first-class sale units; lazy
 minting; fractional ownership; a shared cross-marketplace ledger (full
-portability); metadata schema standardization beyond a `uri` string. Each is a
+portability — delivered outside v1 by the PCO `nft` framework,
+`contracts/nft/`); metadata schema standardization beyond a `uri` string. Each is a
 separate, additive interface so v1 stays small and every clause above stays
 mechanically checkable.

--- a/docs/DEVNET-VALIDATION.md
+++ b/docs/DEVNET-VALIDATION.md
@@ -22,6 +22,7 @@ node-critical paths driven to mined confirmation.
 | [gas-station](../contracts/library/gas-station/) | ✅ PASS | `free.gas-station` | 7 | A **zero-KDA user** ran a tx the **station paid for** via `GAS_PAYER`; spend bounded/accounted against `(chain-data)` actual gas; non-enrolled user denied. |
 | [royalty-sale](../contracts/library/royalty-sale/) | ✅ PASS | `free.royalty-sale` | 13 | `buy` settlement on-node: **fresh escrow** (fund-then-plain-`let` baseline read, primary-sale payout merge, escrow → 0) and **dust-carrying escrow** (conservation returns to the donated baseline, not zero) — the auditor's F1 node-only class, proven. |
 | [nft-collection-policy](../contracts/library/nft-collection-policy/) | ⏸ deferred | — | — | Needs a marmalade-v2 deployment (absent on the campaign devnet). Its REPL suite already runs against the **real** marmalade sources; the outstanding on-chain **buy** is a follow-on. |
+| [property-lease](../contracts/library/property-lease/) | ⏸ pending | — | — | Deployable but not yet driven: its `AUDIT.md` names a devnet run of `give-notice` plus the full create → deposit → rent → claim → settle cycle as **required evidence before any production use** (its F1 class is REPL-invisible). |
 | [hello-world](../contracts/library/hello-world/) | n/a | — | — | No node-only behavior; the REPL suite is sufficient. |
 
 Every deployed module's source hash and every confirmed transaction's request
@@ -30,7 +31,7 @@ validation*).
 
 ## What this establishes — and what it doesn't
 
-**Establishes:** the read-in-enforce class is closed for all six deployable
+**Establishes:** the read-in-enforce class is closed for the seven driven
 templates. Every `SIGNER-AUTH` / `CLAIM-AUTH` / `MEMBER-AUTH` / `PUBLISH-AUTH`
 capability, the treasury/vesting/gas-station capability-guarded vaults, the
 token's `DEBIT`, and the gas-station's full drain-defense executed correctly
@@ -43,6 +44,12 @@ independent audit and not a cross-chain exercise. It does not replace the
 ladder, and it does not cover the token's `TRANSFER_XCHAIN` SPV path (which
 needs a multi-chain devnet). Templates remain `self-reviewed`; devnet
 validation is corroborating evidence for the node-safety claim, cited as such.
+
+The same harness also carries the [NFT Framework](../contracts/nft/README.md)'s
+own campaign (`npm run nft-framework`) — a genuinely **multi-chain** run with
+real SPV relocation; see
+[scripts/devnet-validate/README.md](../scripts/devnet-validate/README.md). That
+run does not close the token template's `TRANSFER_XCHAIN` gap above.
 
 ## Reproducing
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -15,6 +15,7 @@ This guide outlines the process for onboarding a new Pact smart contract to the 
 
 2. **Create Contract Structure**:
    - Deployable templates go to `contracts/library/<contract-name>/`; observed on-chain modules go to `contracts/registry/ecosystem/` or `contracts/registry/community/` with deployment evidence (see [ARCHITECTURE.md](../ARCHITECTURE.md))
+   - `contracts/standards/` (the normative NFT interface standard) and `contracts/nft/` (the NFT Framework) are PCO-maintained products, not onboarding targets — changes there go through maintainer PRs and those trees' own gates
    - Create metadata at `<contract-dir>/metadata.yaml` (co-located YAML, not JSON)
    - Add a `README.md` and `AUDIT.md` in the same directory
    - Library entries: add tests to `<contract-dir>/examples/` using the `.repl` extension (mandatory)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ _Generated from `contracts/**/metadata.yaml`._
 
 - **Library** — PCO-authored deployable templates: copy, adapt, deploy.
 - **Registry** — observed contracts (upstream standards + on-chain census): read-only reference.
+- **Standards** — the Kadena NFT interface standard v1: not metadata-indexed; see [contracts/standards/](../contracts/standards/SPEC.md).
+- **NFT Framework** — the PCO shared-ledger NFT ecosystem: not metadata-indexed; see [contracts/nft/](../contracts/nft/README.md).
 
 ## Library — Deployable Templates (`library/`)
 
@@ -38,7 +40,7 @@ _Generated from `contracts/**/metadata.yaml`._
 | util.fungible-util | util-fungible-util | 1.0.0 | reference | utility, fungible, validation, helper, pre-deployed |
 | ns | ns | 1.0.0 | reference | namespace, governance, registry, core, pre-deployed |
 
-## Registry — Marmalade NFT Framework (`registry/marmalade/`)
+## Registry — Marmalade v2 NFT Stack (`registry/marmalade/`)
 
 | Name | Slug | Version | Audit Status | Tags |
 |------|------|---------|--------------|------|

--- a/scripts/devnet-validate/README.md
+++ b/scripts/devnet-validate/README.md
@@ -1,6 +1,6 @@
 # Devnet Validation Campaign
 
-On-chain validation of the PCO library templates against a **real KDA-CE devnet node** — the one evidence class the REPL cannot produce.
+On-chain validation of the PCO library templates **and the [NFT Framework](../../contracts/nft/README.md)** against a **real KDA-CE devnet node** — the one evidence class the REPL cannot produce.
 
 ## Why this exists
 
@@ -18,8 +18,21 @@ Each script deploys the template under the `free` namespace (governance keyset n
 | `oracle-feed` | `PUBLISH-AUTH` binds a config read before `enforce`; the `get-price` median pipeline runs both via `/local` and inside a mined consumer tx; staleness fails closed against real block timestamps. |
 | `token-fungible` | `DEBIT` let-binds the sender's stored guard (the v0.2.0 CRITICAL fix) — an authorized transfer succeeds, a foreign-key transfer is rejected, and rotation updates the guard the DEBIT reads. |
 | `gas-station` | A **zero-KDA user** runs a real transaction the **station pays for** via `GAS_PAYER`: the allowlist read is bound before `enforce-guard`, spend is bounded/accounted against `(chain-data)` actual gas, and a non-enrolled user is denied. |
+| `royalty-sale` | `buy` settlement on-node: fresh escrow (fund-then-plain-`let` baseline read, primary-sale payout merge, escrow → 0) and dust-carrying escrow (conservation returns to the donated baseline, not zero). |
+| `royalty-sale-sim` | The full-marketplace economic simulation replayed on-node — 32 mined txs: a 4-hop resale chain with royalty to the original creator on every hop, a sale in a second fungible-v2 currency, and the adversarial rejections. Results in the template's [SIMULATION.md](../../contracts/library/royalty-sale/SIMULATION.md). |
 
 Each script also runs the negative cases (wrong key, non-member, below threshold, non-enrolled) to prove the guards reject on-node, not just in the REPL.
+
+## The NFT Framework campaign (`npm run nft-framework`)
+
+The one **multi-chain** campaign: it deploys the framework stack the scenario needs (`contracts/nft/` — the five interfaces, util, ledger, policy-manager, royalty + non-fungible policies, conventional-auction) on chains 0 **and** 1 and drives the marketplace-hop scenario end to end on real chains: create on chain 0 (10% royalty, strict 1/1) → fixed-price sale through marketplace A's fee identity (defpact continuation) → **relocation to chain 1 via `transfer-crosschain` with a real SPV proof** → ascending auction through marketplace B's fee identity → third-party settlement. What it proves that no REPL can: SPV verification, the **first-arrival materialization** of the token row on a chain that had never seen it, the policy passports re-binding on arrival, the creator royalty paid on **both** chains, node-mode table-read semantics, and real gas per entry point (max observed ~39k vs the 150k ceiling — a deploy step; every operational leg runs in the low thousands).
+
+Runner notes:
+
+- Requires a **multi-chain** devnet (the single-chain default is not enough) and the framework personas funded **on each chain explicitly** — chain 0 funds do not exist on chain 1.
+- **One-shot per devnet**: module names are fixed by cross-module references, so a re-run needs a devnet reset.
+- The framework deploys under `free` (its namespace is a deploy-time parameter).
+- Results land in `results/nft-framework.json` (30 confirmed transactions per run).
 
 ## Running
 
@@ -29,7 +42,9 @@ Requires a local KDA-CE devnet (default `http://localhost:8090`, network `recap-
 cd scripts/devnet-validate
 npm install
 npm run treasury      # or vesting | dao-voting | oracle-feed | token-fungible | gas-station
-npm run all           # everything, sequentially
+                      #    | royalty-sale | royalty-sale-sim
+npm run nft-framework # the multi-chain NFT Framework campaign (see above)
+npm run all           # every single-chain template campaign, sequentially
 ```
 
 Environment overrides: `DEVNET_HOST`, `DEVNET_NETWORK_ID`, `DEVNET_CHAIN`.
@@ -40,4 +55,5 @@ Each run writes `results/<template>.json` (deployed module name, source hash, an
 
 - **`nft-collection-policy`** requires the full marmalade-v2 stack (ledger, policy-manager, kip interfaces) deployed on the target devnet, which this shared devnet does not carry. Its REPL suite already runs against the **real** marmalade sources from the registry tree (stronger than a mock), and its specific devnet mandate — an on-chain **buy** through the sale defpact — is a follow-on for a marmalade-provisioned devnet. See that template's `AUDIT.md`.
 - **`hello-world`** carries no node-only behavior (no table-read-in-enforce, no managed caps), so a devnet run adds nothing its REPL suite doesn't already show.
-- **Cross-chain** paths (token `TRANSFER_XCHAIN`) need a multi-chain SPV exercise; the single-chain campaign does not cover them.
+- **`property-lease`** — deployable but not yet driven; its `AUDIT.md` names the devnet run (a `give-notice` by either party plus the full lifecycle) as required evidence before any production use.
+- The **token template's `TRANSFER_XCHAIN`** path still needs its own multi-chain SPV exercise; the single-chain template campaigns do not cover it (the NFT Framework campaign above proves SPV for the framework, not for this template).

--- a/scripts/generate_index.sh
+++ b/scripts/generate_index.sh
@@ -39,6 +39,8 @@ echo "_Generated from \`contracts/**/metadata.yaml\`._" >> "$INDEX_MD"
 echo "" >> "$INDEX_MD"
 echo "- **Library** — PCO-authored deployable templates: copy, adapt, deploy." >> "$INDEX_MD"
 echo "- **Registry** — observed contracts (upstream standards + on-chain census): read-only reference." >> "$INDEX_MD"
+echo "- **Standards** — the Kadena NFT interface standard v1: not metadata-indexed; see [contracts/standards/](../contracts/standards/SPEC.md)." >> "$INDEX_MD"
+echo "- **NFT Framework** — the PCO shared-ledger NFT ecosystem: not metadata-indexed; see [contracts/nft/](../contracts/nft/README.md)." >> "$INDEX_MD"
 echo "" >> "$INDEX_MD"
 
 # emit_section <dir> <heading> <style>
@@ -89,7 +91,7 @@ emit_section() {
 emit_section "contracts/library"            "Library — Deployable Templates (\`library/\`)"                       "tags"
 emit_section "contracts/registry/kip"       "Registry — KIP Standards (\`registry/kip/\`)"                        "tags"
 emit_section "contracts/registry/core"      "Registry — Core Infrastructure (\`registry/core/\`)"                 "tags"
-emit_section "contracts/registry/marmalade" "Registry — Marmalade NFT Framework (\`registry/marmalade/\`)"        "tags"
+emit_section "contracts/registry/marmalade" "Registry — Marmalade v2 NFT Stack (\`registry/marmalade/\`)"        "tags"
 emit_section "contracts/registry/ecosystem" "Registry — Ecosystem Modules (\`registry/ecosystem/\`) — census"     "census"
 emit_section "contracts/registry/community" "Registry — Community On-Chain Modules (\`registry/community/\`) — census" "census"
 


### PR DESCRIPTION
Documentation truth sweep: with the NFT Framework (`contracts/nft/`), the interface standard, and the devnet campaigns all merged, several docs still described the pre-merge repository (two/eight products, no framework campaign, "NFT framework" meaning Marmalade). This PR makes every living doc describe the current state. **Docs only — no `.pact`/`.repl`/TypeScript changes.**

Naming convention enforced repo-wide: **"the NFT Framework" = `contracts/nft/`**; the deployed Marmalade tree is always **"the Marmalade v2 NFT stack"**.

## Files changed

| File | Was stale | Now says |
|---|---|---|
| `README.md` | "Eight production-grade templates" (table missing property-lease, royalty-sale); "all six deployable ones" devnet-driven; registry map called `marmalade/` "(the NFT framework)" | Ten templates, both rows added; "seven of them" driven (report has per-entry status); "(the deployed Marmalade v2 NFT stack — verbatim reference)" |
| `ARCHITECTURE.md` | "split into two product trees"; layout tree omitted `standards/` + `nft/`; "Layer 2 — NFT Framework (registry/marmalade/)"; library block listed 2 templates; `audit_status` example enum (`audited \| in-review \| not-audited`) contradicted §3.1; provenance/governance silent on the new trees | Four product trees; layout rows added; "Layer 2 — Marmalade v2 NFT Stack"; ten templates + Standards + NFT Framework blocks in the layer diagram; §3.1 ladder enum; provenance rows + governance bullets for `standards/` and `nft/` |
| `scripts/generate_index.sh` + `docs/index.md` (regenerated) | Index intro knew only Library/Registry; section heading "Registry — Marmalade NFT Framework" | Intro lines for Standards + NFT Framework (not metadata-indexed, with pointers); heading "Registry — Marmalade v2 NFT Stack" |
| `docs/DEVNET-VALIDATION.md` | Prose said "all six deployable templates" while its own table has seven PASS rows; property-lease absent; no mention the harness now carries a multi-chain campaign | "the seven driven templates"; property-lease row (⏸ pending, per its AUDIT.md); pointer to the NFT Framework campaign, with the token-template `TRANSFER_XCHAIN` gap kept explicit |
| `scripts/devnet-validate/README.md` | Script table stopped at 6 templates; no `royalty-sale`/`royalty-sale-sim` rows; zero mention of `npm run nft-framework`; "Not covered" said cross-chain entirely uncovered | Both royalty-sale rows; a full NFT Framework campaign section (what it proves: real SPV, first-arrival materialization, both marketplaces, royalty on both chains, max gas ~39k deploy / operational legs in low thousands) + runner notes (multi-chain devnet, fund each chain, one-shot per devnet, deploys under `free`); "Not covered" reworked (property-lease pending; token `TRANSFER_XCHAIN` still open) |
| `docs/ONBOARDING.md` | No placement guidance for the two new trees | `standards/` + `nft/` are PCO-maintained products, not onboarding targets |
| `SECURITY.md` | Scope listed only `contracts/library/` as PCO-authored | Scope includes `contracts/standards/` and `contracts/nft/` |
| `contracts/library/README.md` | Contents table had 2 rows + "Planned templates: gas-station, … oracle consumer" (all shipped long ago) | Full 10-row table; planned line dropped; one line placing royalty-sale relative to the NFT Framework |
| `contracts/nft/README.md` | `test/` row omitted `negative-payout` and miscounted ("one per policy" — guarded-uri has no dedicated suite); cross-chain section stated sale-only rule but not the transfer-guard rule | "14 suites" enumerated exactly (incl. `negative-payout`, and where guarded-uri is exercised); transfer-guard sentence: an owner-changing relocation must satisfy the transfer-guard, self-relocation ungated. `interfaces/` row verified already correct |
| `contracts/library/royalty-sale/README.md` | Analysis link pointed at `../../docs/` (doesn't exist); "Auctions … are a future extension" | Anchored to the standard's SPEC (which restates the analysis failure modes as clauses); auctions exist in the catalog as part of the NFT Framework, this template stays the standalone reference |
| `contracts/standards/SPEC.md` | Non-normative prose: shared-ledger portability "if the ecosystem ever needs it, that is a v2 track" | The track now exists (`contracts/nft/`), stated in "What compatible means" and the non-goals list. **No clause, signature, or Status change** |
| `contracts/registry/marmalade/README.md` | Title/intro "Marmalade v2 NFT Framework" (naming collision) | "Marmalade v2 NFT Stack"; verbatim-snapshot framing + pointer to `contracts/nft/` as the original implementation its analysis produced |
| `contracts/registry/marmalade/ledger/README.md` | "core ledger module of KDA-CE's Marmalade v2 NFT framework" | "…NFT stack" |

## Checked and left alone

- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `docs/CONTRACT_POLICIES.md` — generic/process docs, nothing describing a superseded state.
- `contracts/standards/conformance/README.md` — accurate (the gallery-side suite it references exists).
- `contracts/standards/nft-consignment-spike/SPIKE.md` — already carries the dated outcome note; historical record.
- `contracts/library/royalty-sale/SIMULATION.md` + `AUDIT.md`, and all other library `README.md`/`AUDIT.md` pairs — accurate or historical records. (`nft-collection-policy`'s mention of `kip.updatable-uri-policy-v1` is the pre-deployed KIP interface, unrelated to the framework.)
- All `contracts/registry/**` module docs — verbatim-snapshot territory; references to Marmalade's own `non-updatable-uri-policy-v1`/`updatable-uri-policy-v1` are that stack's real modules.

## Gates

- No `.pact`/`.repl` touched (`git diff --name-only` clean of both).
- Static gate over the full `contracts/nft/` Pact surface: **0 VIOLATIONs, PASS** (44 standing WARNs, previously dispositioned).
- `docs/index.md`/`index.json` regenerated via `scripts/generate_index.sh` (freshness gate will pass).

## Found, not fixed (code, out of scope for a docs sweep)

1. `scripts/devnet-validate/package.json` defines `"hello-world": "tsx src/hello-world.ts"` and chains it inside `"all"`, but `src/hello-world.ts` has never existed — `npm run all` fails at that step (and hello-world is documented as n/a for devnet). One-line fix: drop the script and its `all` segment.
2. `scripts/devnet-validate/src/nft-framework.ts` comment says "deploy the six interfaces"; the list has five files (comment-only).
3. **Flag for the maintainer:** `contracts/standards/SPEC.md` still carries `Status: proposed` while the standard is implemented by two conformance-gated implementations. Left untouched deliberately — changing a normative doc's status is not a sweep decision.
