### PR TITLE
PCO owns the NFT standard on-chain: publish namespace, qualified consumers, freeze review

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,10 +108,13 @@ Library — Deployable Templates (contracts/library/)
     (see contracts/library/README.md for the full table)
 
 Standards — Kadena NFT Interface Standard v1 (contracts/standards/)
-  PCO-authored, normative. Outside the registry layer stack.
+  PCO-authored, PCO-owned, normative. Outside the registry layer stack.
   Three un-upgradeable interfaces (nft-asset-v1, nft-market-v1,
   nft-xchain-v1) + a normative SPEC + a modref-driven conformance
-  suite. royalty-sale is the reference implementation.
+  suite. Published once per network into the PCO-owned principal
+  namespace (testnet06: n_e82dd10f74b7e8c253553de95629fdfa35cf8379);
+  every marketplace implements them fully qualified from there.
+  royalty-sale is the reference implementation.
 
 NFT Framework (contracts/nft/)
   The catalog's NFT architecture: a PCO-authored shared-ledger NFT
@@ -214,7 +217,7 @@ keywords: ['pact', 'smart-contract']
 | `registry/ecosystem/` | Third-party projects | Various (see each module's `metadata.yaml`) — verified from mainnet01 blockchain census Jan 2025 / Mar 2026 |
 | `registry/community/` | Community projects | Census-observed free-namespace modules (see each module's `metadata.yaml`) |
 | `library/` | PCO contributors | [Pact-Community-Organization/pact-contract-catalog](https://github.com/Pact-Community-Organization/pact-contract-catalog) |
-| `standards/` | PCO-authored | This repository (normative interface standard, un-upgradeable once deployed) |
+| `standards/` | PCO-authored & PCO-owned on-chain | This repository (normative interface standard, un-upgradeable; published in the PCO principal namespace per network) |
 | `nft/` | PCO-authored | This repository (original, independent implementation) |
 
 > All `registry/` entries are **observed entries** — verbatim snapshots of upstream or on-chain code, catalogued to document what community modules build upon and integrate with. PCO makes no security claim beyond the recorded audit status. Only `library/` entries are authored, maintained, and quality-gated by PCO.
@@ -227,6 +230,6 @@ keywords: ['pact', 'smart-contract']
 - Additions to `registry/ecosystem/` and `registry/community/` require evidence of deployment on mainnet01 (module hash, describe-module output, or block explorer link) plus a PR matching the census methodology in `contracts/registry/ecosystem/README.md`.
 - Additions to `library/` require a PR linking a GitHub issue, passing CI (including the library quality gate: schema-A metadata, co-located `.repl` tests, `audit_status` of `self-reviewed` or better), and approval per `CONTRIBUTING.md`.
 - Entries with an open CRITICAL finding live in `registry/`, never `library/`.
-- `contracts/standards/` is normative: the three interfaces are un-upgradeable (`CannotUpgradeInterface`) and the SPEC's clauses are versioned — breaking changes ship as `-v2`, never as edits. Changes go through maintainer PRs.
+- `contracts/standards/` is normative and canonical: the three interfaces are un-upgradeable (`CannotUpgradeInterface`) and the SPEC's clauses are versioned — breaking changes ship as `-v2`, never as edits. On-chain the standard lives in the PCO-owned principal namespace (one publication per network; consumers implement fully qualified); every vendored copy elsewhere is a byte-identical fixture of this directory. Changes go through maintainer PRs.
 - `contracts/nft/` changes require every suite under `contracts/nft/test/` green and the static gate at 0 violations (see the Gates section of [contracts/nft/README.md](contracts/nft/README.md)); cross-chain behavior classes additionally require multi-chain devnet evidence.
 - Audit promotions follow the ladder in `docs/CONTRACT_POLICIES.md` §3.1 (`reference` / `unaudited` / `self-reviewed` / `community-reviewed` / `independently-audited`) and require evidence in `AUDIT.md`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The catalog ships four clearly separated products:
 
 - **[`contracts/library/`](contracts/library/) — the Library**: PCO-authored, deployable templates. Start here.
 - **[`contracts/registry/`](contracts/registry/) — the Registry**: an observatory of contracts that already exist on-chain, catalogued verbatim for reference.
-- **[`contracts/standards/`](contracts/standards/) — the Standards**: the Kadena NFT interface standard v1 — a normative [SPEC](contracts/standards/SPEC.md), three un-upgradeable interfaces, and a runnable conformance suite that independent marketplaces implement to stay compatible.
+- **[`contracts/standards/`](contracts/standards/) — the Standards**: the Kadena NFT interface standard v1 — a normative [SPEC](contracts/standards/SPEC.md), three un-upgradeable interfaces, and a runnable conformance suite. PCO owns the standard on-chain: the interfaces are published once per network into the PCO principal namespace, and independent marketplaces implement them fully qualified from there to stay compatible.
 - **[`contracts/nft/`](contracts/nft/) — the NFT Framework**: **the catalog's NFT architecture** — one hardened ledger anchoring token identity (forgery/double-mint structurally impossible), a conservation-asserted settlement engine, a composable policy set (royalties, guards, 1/1, collections, uri rules), auctions, and cross-chain relocation where a token's rules travel with it. For anything NFT, start here.
 
 ## The Library

--- a/contracts/library/royalty-sale/AUDIT.md
+++ b/contracts/library/royalty-sale/AUDIT.md
@@ -135,3 +135,17 @@ The economic follow-up — a full-marketplace simulation (resale chain,
 multi-currency, adversarial sweep, global conservation) — is documented in
 [SIMULATION.md](SIMULATION.md) (`examples/royalty-sale-market-sim.repl` +
 `npm run royalty-sale-sim`).
+
+## Addendum — PCO-namespace qualification (2026-07-08)
+
+The two `implements` lines and the two projected schema types were re-pointed
+from bare interface names to the PCO-namespace-qualified form
+(`n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1` / `.nft-market-v1`),
+matching where the standard is published on testnet06. **No logic, guard,
+settlement, or schema change** — a qualification-only diff, so no new audit
+pass was required. All evidence re-run green against the qualified source with
+the real two-namespace topology (interfaces in one namespace, module in
+another): `royalty-sale-test.repl`, `royalty-sale-market-sim.repl` (149
+assertions), the standard conformance suite, static gate 0 VIOLATIONs, and the
+on-node devnet validations (`npm run royalty-sale` 13 txs, `npm run
+royalty-sale-sim` 32 txs, gas max 13,939 vs the 150k ceiling).

--- a/contracts/library/royalty-sale/README.md
+++ b/contracts/library/royalty-sale/README.md
@@ -33,8 +33,9 @@ Each hardened property maps directly to a finding in the analysis:
 ## Deployment checklist
 
 1. Wrap the module in your namespace; replace the `"royalty-sale-gov"` keyset with your deployed, namespace-qualified governance keyset (**multi-sig recommended**; governance is upgrade-only and touches no funds).
-2. Deploy and `create-table` (`tokens`, `listings`).
-3. Validate on **devnet** before mainnet — **mandatory** (the auth capability reads on-chain tables; that class of bug is invisible in the REPL).
+2. The `implements` lines (and the two projected schema types) are qualified against the PCO namespace the NFT standard is published in — `n_e82dd10f74b7e8c253553de95629fdfa35cf8379` on testnet06. On another network, patch that one literal to that network's published PCO namespace (see [contracts/standards/SPEC.md](../../standards/SPEC.md)); never deploy a private copy of the interfaces — same-text interfaces in different namespaces are different Pact types.
+3. Deploy and `create-table` (`tokens`, `listings`).
+4. Validate on **devnet** before mainnet — **mandatory** (the auth capability reads on-chain tables; that class of bug is invisible in the REPL).
 
 ## Usage
 

--- a/contracts/library/royalty-sale/examples/royalty-sale-market-sim.repl
+++ b/contracts/library/royalty-sale/examples/royalty-sale-market-sim.repl
@@ -97,7 +97,26 @@
 (token.mint "k:6666666666666666666666666666666666666666666666666666666666666666" (read-keyset "frank") 300.0)
 (commit-tx)
 
-(begin-tx "load NFT standard interfaces")
+;; Interfaces live in the PCO-owned principal namespace (testnet06:
+;; n_e82dd10f…); royalty-sale implements them fully qualified.
+(begin-tx "load NFT standard interfaces (PCO namespace)")
+;; env-data REPLACES the whole map — carry the personas forward for later txs
+(env-data
+  { "pco-sim": { "keys": ["pco"], "pred": "keys-all" }
+  , "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "carol": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+  , "mkt1":  { "keys": ["4444444444444444444444444444444444444444444444444444444444444444"], "pred": "keys-all" }
+  , "eve":   { "keys": ["5555555555555555555555555555555555555555555555555555555555555555"], "pred": "keys-all" }
+  , "frank": { "keys": ["6666666666666666666666666666666666666666666666666666666666666666"], "pred": "keys-all" }
+  , "gina":  { "keys": ["7777777777777777777777777777777777777777777777777777777777777777"], "pred": "keys-all" }
+  , "mkt2":  { "keys": ["8888888888888888888888888888888888888888888888888888888888888888"], "pred": "keys-all" }
+  , "gov":   { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" }
+  , "dana":  { "keys": ["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"], "pred": "keys-all" } })
+(env-sigs [ { "key": "pco", "caps": [] } ])
+(define-namespace "n_e82dd10f74b7e8c253553de95629fdfa35cf8379"
+  (read-keyset "pco-sim") (read-keyset "pco-sim"))
+(namespace "n_e82dd10f74b7e8c253553de95629fdfa35cf8379")
 (load "../../../standards/nft-asset-v1.pact")
 (load "../../../standards/nft-market-v1.pact")
 (commit-tx)

--- a/contracts/library/royalty-sale/examples/royalty-sale-test.repl
+++ b/contracts/library/royalty-sale/examples/royalty-sale-test.repl
@@ -35,8 +35,23 @@
 (coin.credit "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol") 1000.0)
 (commit-tx)
 
-;; NFT standard interfaces (royalty-sale implements nft-asset-v1 + nft-market-v1)
-(begin-tx "load NFT standard interfaces")
+;; NFT standard interfaces, in the PCO-owned principal namespace (testnet06:
+;; n_e82dd10f…) — royalty-sale implements them FULLY QUALIFIED, so the suite
+;; loads them into that namespace exactly as they live on-chain.
+(begin-tx "load NFT standard interfaces (PCO namespace)")
+;; env-data REPLACES the whole map — carry the personas forward for later txs
+(env-data
+  { "pco-sim": { "keys": ["pco"], "pred": "keys-all" }
+  , "alice": { "keys": ["1111111111111111111111111111111111111111111111111111111111111111"], "pred": "keys-all" }
+  , "bob":   { "keys": ["2222222222222222222222222222222222222222222222222222222222222222"], "pred": "keys-all" }
+  , "carol": { "keys": ["3333333333333333333333333333333333333333333333333333333333333333"], "pred": "keys-all" }
+  , "mkt":   { "keys": ["4444444444444444444444444444444444444444444444444444444444444444"], "pred": "keys-all" }
+  , "eve":   { "keys": ["5555555555555555555555555555555555555555555555555555555555555555"], "pred": "keys-all" }
+  , "gov":   { "keys": ["9999999999999999999999999999999999999999999999999999999999999999"], "pred": "keys-all" } })
+(env-sigs [ { "key": "pco", "caps": [] } ])
+(define-namespace "n_e82dd10f74b7e8c253553de95629fdfa35cf8379"
+  (read-keyset "pco-sim") (read-keyset "pco-sim"))
+(namespace "n_e82dd10f74b7e8c253553de95629fdfa35cf8379")
 (load "../../../standards/nft-asset-v1.pact")
 (load "../../../standards/nft-market-v1.pact")
 (commit-tx)

--- a/contracts/library/royalty-sale/royalty-sale.pact
+++ b/contracts/library/royalty-sale/royalty-sale.pact
@@ -41,8 +41,8 @@
   ;; surface (token, ownership, royalty, event vocabulary) and the fixed-price
   ;; market surface. No cross-chain (single-chain template) — nft-xchain-v1 is
   ;; not implemented. See contracts/standards/SPEC.md.
-  (implements nft-asset-v1)
-  (implements nft-market-v1)
+  (implements n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1)
+  (implements n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1)
 
   ;; -----------------------------
   ;; Governance (upgrade-only; no fund paths)
@@ -378,12 +378,12 @@
 
   ;; nft-asset-v1.token is exactly this module's 7 token columns, so get-token
   ;; returns the interface schema directly.
-  (defun get-token:object{nft-asset-v1.token} (id:string) (read tokens id))
+  (defun get-token:object{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1.token} (id:string) (read tokens id))
 
   ;; nft-market-v1.listing is the currency-agnostic 5-field public projection;
   ;; the seller-named marketplace payee/guard stay private to this module.
   ;; fee-bps is the marketplace rate (0 for a standard fee-free listing).
-  (defun get-listing:object{nft-market-v1.listing} (id:string)
+  (defun get-listing:object{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1.listing} (id:string)
     (with-read listings id
       { 'seller := seller, 'price := price, 'currency := currency:module{fungible-v2}
       , 'marketplace-bps := mk-bps, 'active := active }

--- a/contracts/nft/DEPLOYMENT.md
+++ b/contracts/nft/DEPLOYMENT.md
@@ -31,6 +31,14 @@ interface name, not an edit. Validate the full train on a devnet first, always.
 
 ## Order, per chain
 
+0. **The v1 standard interfaces come first (separate train).** PCO publishes
+   the Kadena NFT interface standard v1 (`contracts/standards/`:
+   `nft-asset-v1`, `nft-market-v1`, `nft-xchain-v1`) into the PCO-owned
+   principal namespace **before** any framework or marketplace deployment on
+   that network — standalone marketplaces implement those interfaces fully
+   qualified, so they must already exist everywhere a marketplace can deploy.
+   The framework's own interfaces (step 2 below) are a separate, internal set;
+   the two trains are independent, but the standard-v1 train runs first.
 1. **Admin keyset** — `(namespace "<ns>") (define-keyset "<ns>.<admin>" ...)`.
    This keyset is the framework governance gate; on a real network it should be
    hardware-backed.

--- a/contracts/nft/README.md
+++ b/contracts/nft/README.md
@@ -95,7 +95,9 @@ policy is immutable by default.
 ## Relationship to the rest of the catalog
 
 - **`contracts/standards/` (NFT interface standard v1)** — the compatibility standard for
-  *standalone* marketplaces, each custodying its own tokens (the `fungible-v2` model). This
+  *standalone* marketplaces, each custodying its own tokens (the `fungible-v2` model). PCO owns
+  the standard on-chain: the three interfaces are published once per network into the PCO
+  principal namespace and marketplaces implement them fully qualified from there. This
   framework is the **shared-ledger track** that SPEC.md explicitly scopes out of v1: tokens live in
   one ledger, marketplaces are sale contracts, portability is native. The two coexist; conforming
   standalone marketplaces and this framework emit compatible economics by construction (state-bound

--- a/contracts/nft/TECHNICAL.md
+++ b/contracts/nft/TECHNICAL.md
@@ -71,7 +71,13 @@ flaws each mechanism exists to fix — the framework sources carry the same name
 [`contracts/standards/`](../standards/SPEC.md) is the **Kadena NFT interface
 standard v1**: three deliberately un-upgradeable interfaces (`nft-asset-v1`,
 `nft-market-v1`, `nft-xchain-v1`) plus normative clauses S1–S6 and a
-modref-driven conformance suite. In that model each marketplace is its **own
+modref-driven conformance suite. PCO owns the standard on-chain: the three
+interfaces are published once per network into the **PCO-owned principal
+namespace** (testnet06: `n_e82dd10f74b7e8c253553de95629fdfa35cf8379`), and
+every marketplace implements them **fully qualified** from there — same-text
+interfaces in different namespaces are different Pact types, so one shared
+publication is what makes independent implementations actually compatible.
+In that model each marketplace is its **own
 module custodying its own tokens** — the `fungible-v2` model of compatibility:
 every token contract is its own ledger, yet one wallet, one indexer, and one
 aggregator work across all of them, because every implementation exposes the
@@ -98,11 +104,11 @@ flowchart TB
         MGR --> AUC
     end
     subgraph STANDALONE["Standalone track — contracts/standards"]
-        SPEC["Kadena NFT standard v1<br/>nft-asset-v1 · nft-market-v1 · nft-xchain-v1<br/>+ SPEC.md S1–S6 + conformance driver"]
+        SPEC["Kadena NFT standard v1<br/>nft-asset-v1 · nft-market-v1 · nft-xchain-v1<br/>+ SPEC.md S1–S6 + conformance driver<br/>published in the PCO namespace<br/>(testnet06: n_e82dd10f…)"]
         RS["royalty-sale<br/>(reference implementation,<br/>contracts/library)"]
         GAL["smartpacts-gallery<br/>(production implementation,<br/>Smart Pacts)"]
-        SPEC -->|implements + passes<br/>the same modref suite| RS
-        SPEC -->|implements + passes<br/>the same modref suite| GAL
+        SPEC -->|"implements FULLY QUALIFIED +<br/>passes the same modref suite"| RS
+        SPEC -->|"implements FULLY QUALIFIED +<br/>passes the same modref suite"| GAL
     end
     FEE["A standalone marketplace can ALSO be a framework marketplace:<br/>a fee identity in framework quotes — zero contract changes, no custody.<br/>Gallery is the first."]
     GAL -.-> FEE

--- a/contracts/standards/SPEC.md
+++ b/contracts/standards/SPEC.md
@@ -1,11 +1,51 @@
 # Kadena NFT Standard v1 — Normative Specification
 
-**Status:** proposed · **Version:** 1 · **Language:** Pact 5.4ce / KDA-CE
+**Status:** frozen for v1 publication (freeze review 2026-07-08) · **Version:** 1 · **Language:** Pact 5.4ce / KDA-CE
 
 Three interfaces define a 1-of-1 NFT with enforceable creator royalties,
 trustless fixed-price sales, and cross-chain portability, such that independent
 marketplaces built by different teams are **compatible**: one wallet, one
 indexer, and one aggregator work across every conforming implementation.
+
+## Canonical source and on-chain home
+
+**This directory is the single canonical source of the standard.** Every copy
+of these interfaces anywhere else — vendored into a marketplace repo, embedded
+in a test fixture — is a **fixture**: byte-identical to the files here
+(verify with `sha256sum`), re-snapshotted from this directory, never hand-edited.
+
+**On-chain, the standard has exactly one home per network: the PCO-owned
+principal namespace.** PCO publishes the three interfaces once per chain, and
+every implementation — including PCO's own — references them there. This is the
+`fungible-v2` model applied to namespaces: one authoritative interface
+deployment that all token contracts share (KDA-CE locks the root namespace, so
+a governed principal namespace is the strongest available equivalent).
+
+| Network | PCO namespace |
+|---|---|
+| testnet06 | `n_e82dd10f74b7e8c253553de95629fdfa35cf8379` |
+| mainnet | not yet published |
+
+Consumers implement the interfaces **fully qualified**:
+
+```pact
+(module my-marketplace GOV
+  (implements n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1)
+  (implements n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1)
+  ...)
+```
+
+This matters because **same-text interfaces in different namespaces are
+different types** in Pact. A module implementing a private copy of
+`nft-asset-v1` is *not* compatible with tooling that dispatches
+`module{<pco-ns>.nft-asset-v1}` — it merely looks similar. Deploying your own
+copy of these interfaces produces an island, not a conforming marketplace.
+
+The interface signatures are **frozen**: interfaces cannot be upgraded
+(`CannotUpgradeInterface`), so what PCO publishes is permanent per network. A
+freeze review (2026-07-08) checked every signature against the reference
+implementation, the production implementation, and the conformance drivers
+before publication; any future change ships as `-v2`.
 
 | Interface | File | Role | Required? |
 |---|---|---|---|

--- a/contracts/standards/conformance/README.md
+++ b/contracts/standards/conformance/README.md
@@ -2,21 +2,34 @@
 
 A candidate module conforms to the Kadena NFT standard (see [../SPEC.md](../SPEC.md)) iff:
 
-1. it declares `(implements nft-asset-v1)` (and `nft-market-v1` / `nft-xchain-v1` as applicable) and
-   **loads** — Pact checks every function/cap/schema signature matches exactly; and
-2. it passes the **conformance suite** below, which drives the module **through a `module{X}`
-   reference** — proving the surface is polymorphically usable, not merely name-compatible; and
+1. it declares `(implements <pco-ns>.nft-asset-v1)` (and `nft-market-v1` / `nft-xchain-v1` as
+   applicable) **fully qualified against the PCO namespace the standard is published in**
+   (testnet06: `n_e82dd10f74b7e8c253553de95629fdfa35cf8379`) and **loads** — Pact checks every
+   function/cap/schema signature matches exactly; and
+2. it passes the **conformance suite** below, which drives the module **through a
+   `module{<pco-ns>.X}` reference** — proving the surface is polymorphically usable, not merely
+   name-compatible; and
 3. for `nft-xchain-v1`, it additionally passes a **multi-chain devnet** run of the SPV round trip
    (the REPL cannot prove SPV — a green cross-chain `.repl` is a false positive).
+
+A module that implements a *private copy* of the interfaces does **not** conform: same-text
+interfaces in different namespaces are different types in Pact, so tooling that dispatches
+`module{<pco-ns>.nft-asset-v1}` cannot use it.
 
 ## How it works
 
 [`conformance-driver.pact`](conformance-driver.pact) is a module that knows only
-`module{nft-asset-v1}` / `module{nft-market-v1}` — it never names a concrete implementation. Each
-`d-*` function forwards one interface call through the modref. A conformance suite names the
-candidate module **once** (as the modref argument) and makes every assertion through the driver, so
-the assertions are implementation-agnostic. If a suite passes, the candidate is usable through the
-standard by any tool that knows only the interface.
+`module{<pco-ns>.nft-asset-v1}` / `module{<pco-ns>.nft-market-v1}` — it never names a concrete
+implementation. Each `d-*` function forwards one interface call through the modref. A conformance
+suite names the candidate module **once** (as the modref argument) and makes every assertion through
+the driver, so the assertions are implementation-agnostic. If a suite passes, the candidate is
+usable through the standard by any tool that knows only the interface.
+
+The suites reproduce the real deployment topology inside the REPL: the interfaces load into the PCO
+namespace, the driver loads into `user`, and the candidate loads into its own namespace — every
+dispatch crosses namespaces exactly as it does on-chain. The PCO namespace literal in the driver
+and suites is the testnet06 value; targeting another network means patching that one literal to
+that network's published PCO namespace (the same deploy-literal treatment as an admin keyset name).
 
 ## Suites
 
@@ -30,12 +43,16 @@ interface. That is the "compatible between marketplaces" guarantee, demonstrated
 
 ## Writing a conformance suite for your marketplace
 
-1. Load `coin` + the three interfaces + `conformance-driver`.
-2. Deploy your module (into a namespace — KDA-CE locks root; a module and an interface in the same
-   namespace resolve by bare name).
-3. Name your module **once** and pass it to each `conformance-driver.d-*` call; assert only on the
-   projected interface schemas and the event amounts.
+1. Load `coin`, then the three interfaces **into the PCO namespace** (in the REPL:
+   `define-namespace` the PCO namespace name, `(namespace ...)`, load the interface files — signed
+   as the namespace owner), then `conformance-driver` into `user`.
+2. Deploy your module into its own namespace, with the `implements` lines fully qualified.
+3. Name your module **once** and pass it to each `user.conformance-driver.d-*` call; assert only on
+   the projected interface schemas and the event amounts.
 4. If you implement `nft-xchain-v1`, add a multi-chain devnet run for the SPV round trip.
+
+On a live network you do not deploy the interfaces — they are already published in the PCO
+namespace; your module simply implements them qualified.
 
 ## Note on the reference implementation
 

--- a/contracts/standards/conformance/conformance-driver.pact
+++ b/contracts/standards/conformance/conformance-driver.pact
@@ -1,71 +1,89 @@
 ;; conformance-driver — exercises an NFT implementation through interface
 ;; modrefs ONLY. It never names royalty-sale or smartpacts-gallery; every call
-;; goes through module{nft-asset-v1} / module{nft-market-v1}. If a driver
-;; function typechecks and runs against a candidate module, that candidate's
-;; surface is polymorphically usable — the whole point of the standard.
+;; goes through module{<pco-ns>.nft-asset-v1} / module{<pco-ns>.nft-market-v1},
+;; fully qualified against the PCO namespace the standard is published in
+;; (testnet06: n_e82dd10f74b7e8c253553de95629fdfa35cf8379 — a different network
+;; patches this literal, see README). If a driver function typechecks and runs
+;; against a candidate module, that candidate's surface is polymorphically
+;; usable through the deployed standard — the whole point.
 ;;
 ;; This is test scaffolding, not a library template: it lives under standards/
-;; and is loaded only by the conformance .repl suites.
+;; and is loaded only by the conformance .repl suites (into the `user`
+;; namespace, so the dispatch crosses namespaces exactly as it does on-chain).
 
 (module conformance-driver GOV
   ;; Test scaffolding, not a deployable artifact — but governance is a real
   ;; keyset (not a `true` body) so the driver holds itself to the same bar the
-  ;; standard demands of implementers. The suite defines `conformance-gov`.
-  (defcap GOV () (enforce-guard (keyset-ref-guard "conformance-gov")))
+  ;; standard demands of implementers. The suite defines `user.conformance-gov`.
+  (defcap GOV () (enforce-guard (keyset-ref-guard "user.conformance-gov")))
 
   ;; --- nft-asset-v1 surface ---
   (defun d-mint:string
-    ( m:module{nft-asset-v1}
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1}
       id:string owner:string owner-guard:guard
       creator:string creator-guard:guard
       royalty-bps:integer transferable:bool uri:string )
     (m::mint id owner owner-guard creator creator-guard royalty-bps transferable uri))
 
   (defun d-transfer:string
-    (m:module{nft-asset-v1} id:string receiver:string receiver-guard:guard)
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1}
+      id:string receiver:string receiver-guard:guard )
     (m::transfer id receiver receiver-guard))
 
-  (defun d-get-token:object{nft-asset-v1.token} (m:module{nft-asset-v1} id:string)
+  (defun d-get-token:object{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1.token}
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1} id:string )
     (m::get-token id))
 
-  (defun d-owner-of:string (m:module{nft-asset-v1} id:string)
+  (defun d-owner-of:string
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1} id:string )
     (m::owner-of id))
 
-  (defun d-is-listed:bool (m:module{nft-asset-v1} id:string)
+  (defun d-is-listed:bool
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1} id:string )
     (m::is-listed id))
 
   ;; project a single field so a suite can assert royalty immutability etc.
   ;; through the modref without re-declaring the schema inline
-  (defun d-royalty-bps:integer (m:module{nft-asset-v1} id:string)
+  (defun d-royalty-bps:integer
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1} id:string )
     (at 'royalty-bps (m::get-token id)))
 
-  (defun d-transferable:bool (m:module{nft-asset-v1} id:string)
+  (defun d-transferable:bool
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-asset-v1} id:string )
     (at 'transferable (m::get-token id)))
 
   ;; --- nft-market-v1 surface ---
   (defun d-list:string
-    (m:module{nft-market-v1} id:string price:decimal currency:module{fungible-v2})
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1}
+      id:string price:decimal currency:module{fungible-v2} )
     (m::list-token id price currency))
 
-  (defun d-delist:string (m:module{nft-market-v1} id:string)
+  (defun d-delist:string
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1} id:string )
     (m::delist id))
 
   (defun d-buy:string
-    (m:module{nft-market-v1} id:string buyer:string buyer-guard:guard)
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1}
+      id:string buyer:string buyer-guard:guard )
     (m::buy id buyer buyer-guard))
 
-  (defun d-get-listing:object{nft-market-v1.listing} (m:module{nft-market-v1} id:string)
+  (defun d-get-listing:object{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1.listing}
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1} id:string )
     (m::get-listing id))
 
-  (defun d-listing-price:decimal (m:module{nft-market-v1} id:string)
+  (defun d-listing-price:decimal
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1} id:string )
     (at 'price (m::get-listing id)))
 
-  (defun d-listing-fee-bps:integer (m:module{nft-market-v1} id:string)
+  (defun d-listing-fee-bps:integer
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1} id:string )
     (at 'fee-bps (m::get-listing id)))
 
-  (defun d-listing-active:bool (m:module{nft-market-v1} id:string)
+  (defun d-listing-active:bool
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1} id:string )
     (at 'active (m::get-listing id)))
 
-  (defun d-escrow:string (m:module{nft-market-v1})
+  (defun d-escrow:string
+    ( m:module{n_e82dd10f74b7e8c253553de95629fdfa35cf8379.nft-market-v1} )
     (m::get-escrow-account))
 )

--- a/contracts/standards/conformance/royalty-sale-conformance.repl
+++ b/contracts/standards/conformance/royalty-sale-conformance.repl
@@ -1,7 +1,8 @@
 ;; Conformance suite — royalty-sale vs the Kadena NFT standard.
 ;;
-;; Every operation goes through conformance-driver, which knows only
-;; module{nft-asset-v1} / module{nft-market-v1}. royalty-sale is named exactly
+;; Every operation goes through conformance-driver, which knows only the
+;; PCO-namespace-qualified module{n_e82dd10f….nft-asset-v1} /
+;; module{n_e82dd10f….nft-market-v1}. royalty-sale is named exactly
 ;; ONCE per driver call (as the modref argument) and NOWHERE else — the
 ;; assertions never touch a royalty-sale-specific function. If this suite
 ;; passes, royalty-sale's surface is polymorphically usable through the
@@ -14,15 +15,28 @@
 ;; Run: pact contracts/standards/conformance/royalty-sale-conformance.repl
 
 ;; --- dependencies ----------------------------------------------------------
+;; Real deployment topology: the interfaces live in the PCO-owned principal
+;; namespace (testnet06: n_e82dd10f74b7e8c253553de95629fdfa35cf8379); the
+;; driver — any third-party tool — lives in `user`; the candidate lives in
+;; `free`. Every dispatch crosses namespaces exactly as it does on-chain.
 (begin-tx "coin + interfaces + driver")
 (load "../../registry/kip/fungible-v2/fungible-v2.pact")
 (load "../../registry/kip/fungible-xchain-v1/fungible-xchain-v1.pact")
 (load "../../registry/core/coin/coin-v6.pact")
 (create-table coin.coin-table)
+(env-data { "pco-sim": { "keys": ["pco"], "pred": "keys-all" }
+          , "cg":      { "keys": ["ck"],  "pred": "keys-all" } })
+;; installing into a namespace enforces its user guard — sign as its owner,
+;; exactly as the real PCO deploy tx is signed by the PCO key
+(env-sigs [ { "key": "pco", "caps": [] }, { "key": "ck", "caps": [] } ])
+(define-namespace "n_e82dd10f74b7e8c253553de95629fdfa35cf8379"
+  (read-keyset "pco-sim") (read-keyset "pco-sim"))
+(namespace "n_e82dd10f74b7e8c253553de95629fdfa35cf8379")
 (load "../nft-asset-v1.pact")
 (load "../nft-market-v1.pact")
-(env-data { "cg": { "keys": ["ck"], "pred": "keys-all" } })
-(define-keyset "conformance-gov" (read-keyset "cg"))
+(define-namespace "user" (read-keyset "cg") (read-keyset "cg"))
+(namespace "user")
+(define-keyset "user.conformance-gov" (read-keyset "cg"))
 (load "conformance-driver.pact")
 (commit-tx)
 
@@ -64,7 +78,7 @@
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] } ])
 (expect-failure "non-principal owner rejected at mint"
   "owner must be a principal"
-  (conformance-driver.d-mint free.royalty-sale
+  (user.conformance-driver.d-mint free.royalty-sale
     "c-bad" "alice-not-a-principal" (read-keyset "alice")
     "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") 500 true "ipfs://x"))
 (rollback-tx)
@@ -76,23 +90,23 @@
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [] }
           , { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [] } ])
 (expect "mint sale-only returns id" "c-so"
-  (conformance-driver.d-mint free.royalty-sale
+  (user.conformance-driver.d-mint free.royalty-sale
     "c-so" "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice") "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
     500 false "ipfs://so"))
 (expect "mint transferable returns id" "c-tr"
-  (conformance-driver.d-mint free.royalty-sale
+  (user.conformance-driver.d-mint free.royalty-sale
     "c-tr" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob") "k:1111111111111111111111111111111111111111111111111111111111111111" (read-keyset "alice")
     250 true "ipfs://tr"))
 (commit-tx)
 
 ;; views project the interface schema
 (begin-tx "asset views through the modref")
-(expect "owner-of (modref) = alice" "k:1111111111111111111111111111111111111111111111111111111111111111" (conformance-driver.d-owner-of free.royalty-sale "c-so"))
-(expect "royalty-bps projected via get-token" 500 (conformance-driver.d-royalty-bps free.royalty-sale "c-so"))
-(expect "transferable projected via get-token" false (conformance-driver.d-transferable free.royalty-sale "c-so"))
-(expect "is-listed total on unlisted token" false (conformance-driver.d-is-listed free.royalty-sale "c-so"))
+(expect "owner-of (modref) = alice" "k:1111111111111111111111111111111111111111111111111111111111111111" (user.conformance-driver.d-owner-of free.royalty-sale "c-so"))
+(expect "royalty-bps projected via get-token" 500 (user.conformance-driver.d-royalty-bps free.royalty-sale "c-so"))
+(expect "transferable projected via get-token" false (user.conformance-driver.d-transferable free.royalty-sale "c-so"))
+(expect "is-listed total on unlisted token" false (user.conformance-driver.d-is-listed free.royalty-sale "c-so"))
 ;; get-token returns exactly the interface's token schema (5 named fields we probe)
-(let ((tk (conformance-driver.d-get-token free.royalty-sale "c-tr")))
+(let ((tk (user.conformance-driver.d-get-token free.royalty-sale "c-tr")))
   (expect "get-token owner" "k:2222222222222222222222222222222222222222222222222222222222222222" (at 'owner tk))
   (expect "get-token creator" "k:1111111111111111111111111111111111111111111111111111111111111111" (at 'creator tk))
   (expect "get-token royalty" 250 (at 'royalty-bps tk))
@@ -104,15 +118,15 @@
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "c-so")] } ])
 (expect-failure "sale-only token cannot be free-transferred"
   "token is sale-only"
-  (conformance-driver.d-transfer free.royalty-sale "c-so" "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+  (user.conformance-driver.d-transfer free.royalty-sale "c-so" "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
 (rollback-tx)
 
 ;; transferable token CAN be gifted through the modref
 (begin-tx "transferable gift via modref")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(free.royalty-sale.OWNER "c-tr")] } ])
 (expect "gift returns id" "c-tr"
-  (conformance-driver.d-transfer free.royalty-sale "c-tr" "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
-(expect "carol now owns c-tr" "k:3333333333333333333333333333333333333333333333333333333333333333" (conformance-driver.d-owner-of free.royalty-sale "c-tr"))
+  (user.conformance-driver.d-transfer free.royalty-sale "c-tr" "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")))
+(expect "carol now owns c-tr" "k:3333333333333333333333333333333333333333333333333333333333333333" (user.conformance-driver.d-owner-of free.royalty-sale "c-tr"))
 (commit-tx)
 
 ;; ===========================================================================
@@ -125,23 +139,23 @@
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "c-so")] } ])
 (expect-failure "dust price whose royalty floors to zero is rejected"
   "royalty"
-  (conformance-driver.d-list free.royalty-sale "c-so" 0.00000000001 coin))
+  (user.conformance-driver.d-list free.royalty-sale "c-so" 0.00000000001 coin))
 (rollback-tx)
 
 ;; list c-so via the STANDARD 3-arg list-token (no marketplace fee)
 (begin-tx "list c-so (standard, fee-free) via modref")
 (env-sigs [ { "key": "1111111111111111111111111111111111111111111111111111111111111111", "caps": [(free.royalty-sale.OWNER "c-so")] } ])
 (expect "standard list returns id" "c-so"
-  (conformance-driver.d-list free.royalty-sale "c-so" 100.0 coin))
-(expect "is-listed true after list" true (conformance-driver.d-is-listed free.royalty-sale "c-so"))
+  (user.conformance-driver.d-list free.royalty-sale "c-so" 100.0 coin))
+(expect "is-listed true after list" true (user.conformance-driver.d-is-listed free.royalty-sale "c-so"))
 ;; listing projects the 5-field interface schema
-(let ((lst (conformance-driver.d-get-listing free.royalty-sale "c-so")))
+(let ((lst (user.conformance-driver.d-get-listing free.royalty-sale "c-so")))
   (expect "listing price" 100.0 (at 'price lst))
   (expect "listing fee-bps 0 (standard fee-free)" 0 (at 'fee-bps lst))
   (expect "listing active" true (at 'active lst))
   (expect "listing seller" "k:1111111111111111111111111111111111111111111111111111111111111111" (at 'seller lst)))
 (expect "escrow account is published" true
-  (> (length (conformance-driver.d-escrow free.royalty-sale)) 0))
+  (> (length (user.conformance-driver.d-escrow free.royalty-sale)) 0))
 (commit-tx)
 
 ;; S3 + S2 — buy through the modref: economics come from state, escrow conserves.
@@ -150,19 +164,19 @@
 ;; she doesn't pay (she's not the buyer). bob is the buyer.
 (begin-tx "S3: buy reads economics from state (modref)")
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
-                (conformance-driver.d-escrow free.royalty-sale) 100.0)] } ])
+                (user.conformance-driver.d-escrow free.royalty-sale) 100.0)] } ])
 ;; alice has no coin account before the sale (she was never funded) — her
 ;; account is created by the payout, so baseline is 0.
 (expect "buy via modref returns id" "c-so"
-  (conformance-driver.d-buy free.royalty-sale "c-so" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
-(expect "bob owns c-so after buy" "k:2222222222222222222222222222222222222222222222222222222222222222" (conformance-driver.d-owner-of free.royalty-sale "c-so"))
-(expect "is-listed false after sale" false (conformance-driver.d-is-listed free.royalty-sale "c-so"))
+  (user.conformance-driver.d-buy free.royalty-sale "c-so" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob")))
+(expect "bob owns c-so after buy" "k:2222222222222222222222222222222222222222222222222222222222222222" (user.conformance-driver.d-owner-of free.royalty-sale "c-so"))
+(expect "is-listed false after sale" false (user.conformance-driver.d-is-listed free.royalty-sale "c-so"))
 ;; alice was creator AND seller: she receives royalty(5) + proceeds(95) = 100
 (expect "seller+creator (alice) received the full price" 100.0
   (coin.get-balance "k:1111111111111111111111111111111111111111111111111111111111111111"))
 ;; escrow returned to baseline (0) — conservation, asserted inside buy too
 (expect "escrow empty after settlement" 0.0
-  (coin.get-balance (conformance-driver.d-escrow free.royalty-sale)))
+  (coin.get-balance (user.conformance-driver.d-escrow free.royalty-sale)))
 (commit-tx)
 
 ;; ===========================================================================
@@ -175,14 +189,14 @@
 ;; ===========================================================================
 (begin-tx "mint + list c-s3 (10% royalty to carol, price 200)")
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [] } ])
-(conformance-driver.d-mint free.royalty-sale
+(user.conformance-driver.d-mint free.royalty-sale
   "c-s3" "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")
   "k:3333333333333333333333333333333333333333333333333333333333333333" (read-keyset "carol")
   1000 true "ipfs://s3")
 (commit-tx)
 (begin-tx "carol lists c-s3 at 200, fee-free")
 (env-sigs [ { "key": "3333333333333333333333333333333333333333333333333333333333333333", "caps": [(free.royalty-sale.OWNER "c-s3")] } ])
-(conformance-driver.d-list free.royalty-sale "c-s3" 200.0 coin)
+(user.conformance-driver.d-list free.royalty-sale "c-s3" 200.0 coin)
 (commit-tx)
 
 (begin-tx "S3-ADV: buy c-s3 with a MALICIOUS economic override payload")
@@ -196,16 +210,16 @@
   , "royalty-bps": 0, "royalty": 0.0, "price": 1.0
   , "marketplace": "k:2222222222222222222222222222222222222222222222222222222222222222" })
 (env-sigs [ { "key": "2222222222222222222222222222222222222222222222222222222222222222", "caps": [(coin.TRANSFER "k:2222222222222222222222222222222222222222222222222222222222222222"
-                (conformance-driver.d-escrow free.royalty-sale) 200.0)] } ])
+                (user.conformance-driver.d-escrow free.royalty-sale) 200.0)] } ])
 (let ((carol-before (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333")))
-  (conformance-driver.d-buy free.royalty-sale "c-s3" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
+  (user.conformance-driver.d-buy free.royalty-sale "c-s3" "k:2222222222222222222222222222222222222222222222222222222222222222" (read-keyset "bob"))
   ;; carol is creator+seller: STATE says royalty 10% of 200 = 20, proceeds 180,
   ;; total 200. If the impl had honored the payload (royalty 0, price 1) she'd
   ;; net far less. The full 200 proves economics came from STATE.
   (expect "S3: payout is the STATE-derived 200 (tx economic overrides ignored)" 200.0
     (- (coin.get-balance "k:3333333333333333333333333333333333333333333333333333333333333333") carol-before)))
 (expect "S3: escrow still conserves under the adversarial payload" 0.0
-  (coin.get-balance (conformance-driver.d-escrow free.royalty-sale)))
+  (coin.get-balance (user.conformance-driver.d-escrow free.royalty-sale)))
 (commit-tx)
 
 (print "")

--- a/scripts/devnet-validate/src/lib.ts
+++ b/scripts/devnet-validate/src/lib.ts
@@ -177,6 +177,44 @@ export function loadTemplate(slug: string, file: string, govConst: string, uniq:
   return { code: `(namespace "free")\n${patched}`, govKeyset };
 }
 
+// The NFT standard interfaces live in the PCO-owned principal namespace on
+// real networks (testnet06: n_e82dd10f…). The recap devnet cannot create that
+// namespace (its `ns` module lacks create-principal-namespace, and past the
+// height-700 migration the ns keysets are no longer open), so the devnet
+// rehearsal substitutes the pre-existing open `user` namespace — the same
+// cross-namespace topology: interfaces in one namespace, module in another,
+// implements/dispatch fully qualified.
+export const PCO_NS = 'n_e82dd10f74b7e8c253553de95629fdfa35cf8379';
+export const DEVNET_IFACE_NS = 'user';
+
+// Substitute the PCO namespace literal for the devnet interface namespace,
+// asserting the exact occurrence count so a source drift is caught, not masked.
+export function substPcoNs(code: string, expected: number): string {
+  const hits = code.split(PCO_NS).length - 1;
+  if (hits !== expected) {
+    throw new Error(`expected ${expected} PCO-ns literal occurrence(s), found ${hits} — review before deploying`);
+  }
+  return code.split(PCO_NS).join(DEVNET_IFACE_NS);
+}
+
+// Deploy nft-asset-v1 + nft-market-v1 into the devnet interface namespace.
+// Idempotent: interfaces are frozen (CannotUpgradeInterface), so if a prior
+// run already published them we must skip, not redeploy.
+export async function ensureStandardInterfaces(signer: Keypair): Promise<void> {
+  try {
+    await localCall(`(describe-module "${DEVNET_IFACE_NS}.nft-asset-v1")`);
+    console.log(`  standard interfaces already present in ${DEVNET_IFACE_NS}/ — skipping deploy`);
+    return;
+  } catch { /* not deployed yet */ }
+  const asset = readFileSync(join(ROOT, 'contracts', 'standards', 'nft-asset-v1.pact'), 'utf8');
+  const market = readFileSync(join(ROOT, 'contracts', 'standards', 'nft-market-v1.pact'), 'utf8');
+  await send({
+    code: `(namespace "${DEVNET_IFACE_NS}")\n${asset}\n${market}`,
+    label: `deploy nft-asset-v1 + nft-market-v1 into ${DEVNET_IFACE_NS}/`,
+    signers: [{ kp: signer }],
+  });
+}
+
 // Fund a persona account from sender00.
 export async function fund(kp: Keypair, amount: number): Promise<void> {
   await send({

--- a/scripts/devnet-validate/src/royalty-sale-market-sim.ts
+++ b/scripts/devnet-validate/src/royalty-sale-market-sim.ts
@@ -19,6 +19,7 @@
 import {
   send, sendExpectFail, localCall, coinBalance, fund, persona, ksData,
   loadTemplate, saveResults, recordSteps,
+  ensureStandardInterfaces, substPcoNs,
 } from './lib.js';
 
 const SLUG = 'royalty-sale-market-sim';
@@ -46,7 +47,8 @@ const main = async () => {
   const T = `free.${TOK}`;
 
   const rs = loadTemplate('royalty-sale', 'royalty-sale.pact', 'royalty-sale-gov', MOD);
-  const rsSrc = rs.code.replace('(module royalty-sale GOV', `(module ${MOD} GOV`);
+  // 4 = the two implements lines + the two projected schema types
+  const rsSrc = substPcoNs(rs.code, 4).replace('(module royalty-sale GOV', `(module ${MOD} GOV`);
   const tk = loadTemplate('token-fungible', 'token.pact', 'token-gov', TOK);
   const tkSrc = tk.code.replace('(module token GOV', `(module ${TOK} GOV`);
 
@@ -65,6 +67,9 @@ const main = async () => {
   await fund(bob, 120.0); await fund(carol, 210.0); await fund(frank, 120.0);
   await fund(gina, 300.0); await fund(mkt1, 2.0); await fund(mkt2, 2.0);
   await fund(eve, 3.0);
+
+  // the standard interfaces must exist before a qualified implements can load
+  await ensureStandardInterfaces(gov);
 
   // ---- deploy both templates under free/ ----------------------------------
   await send({
@@ -118,8 +123,8 @@ const main = async () => {
   for (const [i, h] of hops.entries()) {
     const n = i + 1;
     const listCode = h.mkt
-      ? `(${M}.list-token "chain-1" ${h.price.toFixed(1)} coin "${h.mkt.account}" (read-keyset "m") ${h.bps})`
-      : `(${M}.list-token "chain-1" ${h.price.toFixed(1)} coin "" (read-keyset "m") 0)`;
+      ? `(${M}.list-token-with-fee "chain-1" ${h.price.toFixed(1)} coin "${h.mkt.account}" (read-keyset "m") ${h.bps})`
+      : `(${M}.list-token-with-fee "chain-1" ${h.price.toFixed(1)} coin "" (read-keyset "m") 0)`;
     await send({
       code: listCode,
       label: `hop ${n}: list chain-1 at ${h.price} (${h.mkt ? `${h.mktName} ${h.bps} bps` : 'no fee'})`,
@@ -175,7 +180,7 @@ const main = async () => {
     data: { ...ksData('c', carol), ...ksData('f', frank) },
   });
   await send({
-    code: `(${M}.list-token "dna-tok" 500.0 ${T} "${mkt2.account}" (read-keyset "m") 500)`,
+    code: `(${M}.list-token-with-fee "dna-tok" 500.0 ${T} "${mkt2.account}" (read-keyset "m") 500)`,
     label: `dana lists dna-tok at 500.0 ${TOK} (mkt2 5%)`,
     signers: [{ kp: dana, caps: (wc) => [wc(`${M}.OWNER`, 'dna-tok'), wc('coin.GAS')] }],
     data: ksData('m', mkt2),
@@ -193,7 +198,7 @@ const main = async () => {
   assert(near(await tokBal(escrow), 0.0), `token-side escrow settled to 0 on-node`);
 
   await send({
-    code: `(${M}.list-token "dna-tok" 200.0 ${T} "" (read-keyset "m") 0)`,
+    code: `(${M}.list-token-with-fee "dna-tok" 200.0 ${T} "" (read-keyset "m") 0)`,
     label: `carol re-lists dna-tok at 200.0 ${TOK} (no fee)`,
     signers: [{ kp: carol, caps: (wc) => [wc(`${M}.OWNER`, 'dna-tok'), wc('coin.GAS')] }],
     data: ksData('m', carol),
@@ -217,7 +222,7 @@ const main = async () => {
   // =====================================================================
   // gina (current owner) lists chain-1 at 30 — a buyer will commit to this
   await send({
-    code: `(${M}.list-token "chain-1" 30.0 coin "" (read-keyset "m") 0)`,
+    code: `(${M}.list-token-with-fee "chain-1" 30.0 coin "" (read-keyset "m") 0)`,
     label: 'gina lists chain-1 at 30.0',
     signers: [{ kp: gina, caps: (wc) => [wc(`${M}.OWNER`, 'chain-1'), wc('coin.GAS')] }],
     data: ksData('m', gina),
@@ -235,7 +240,7 @@ const main = async () => {
   }, 'sale-only');
   // FRONT-RUN: gina reprices to 40 AFTER carol signed a 30-cap
   await send({
-    code: `(${M}.list-token "chain-1" 40.0 coin "" (read-keyset "m") 0)`,
+    code: `(${M}.list-token-with-fee "chain-1" 40.0 coin "" (read-keyset "m") 0)`,
     label: 'FRONT-RUN: gina reprices the live listing to 40.0',
     signers: [{ kp: gina, caps: (wc) => [wc(`${M}.OWNER`, 'chain-1'), wc('coin.GAS')] }],
     data: ksData('m', gina),

--- a/scripts/devnet-validate/src/royalty-sale.ts
+++ b/scripts/devnet-validate/src/royalty-sale.ts
@@ -8,6 +8,7 @@
 // creator+marketplace+seller payout split end to end.
 import {
   send, localCall, coinBalance, fund, persona, loadTemplate, saveResults, CHAIN,
+  ensureStandardInterfaces, substPcoNs,
 } from './lib.js';
 
 const SLUG = 'royalty-sale';
@@ -26,7 +27,8 @@ const main = async () => {
   const MOD = await pickName('royalty-sale');
   const { code, govKeyset } = loadTemplate(SLUG, 'royalty-sale.pact', 'royalty-sale-gov', MOD);
   const M = `free.${MOD}`;
-  const src = code.replace('(module royalty-sale GOV', `(module ${MOD} GOV`);
+  // 4 = the two implements lines + the two projected schema types
+  const src = substPcoNs(code, 4).replace('(module royalty-sale GOV', `(module ${MOD} GOV`);
 
   const gov = persona('gov');
   const creator = persona('creator');   // mints + is the primary seller
@@ -36,6 +38,9 @@ const main = async () => {
   for (const kp of [gov, creator, mkt]) await fund(kp, 5.0);
   await fund(buyer1, 60.0);  // pays for a purchase
   await fund(buyer2, 60.0);
+
+  // the standard interfaces must exist before a qualified implements can load
+  await ensureStandardInterfaces(gov);
 
   await send({
     code: `(namespace "free") (define-keyset "${govKeyset}" (read-keyset "g"))`,
@@ -59,7 +64,7 @@ const main = async () => {
 
   // list at 40 with a 2.5% marketplace fee to mkt
   await send({
-    code: `(${M}.list-token "art-1" 40.0 coin "${mkt.account}" (read-keyset "m") 250)`,
+    code: `(${M}.list-token-with-fee "art-1" 40.0 coin "${mkt.account}" (read-keyset "m") 250)`,
     label: 'list art-1 at 40 (2.5% fee)',
     signers: [{ kp: creator, caps: (wc) => [wc(`${M}.OWNER`, 'art-1'), wc('coin.GAS')] }],
     data: { m: { keys: [mkt.publicKey], pred: 'keys-all' } },
@@ -100,7 +105,7 @@ const main = async () => {
 
   // buyer1 (now owner) lists, buyer2 buys — over the DUST-carrying escrow.
   await send({
-    code: `(${M}.list-token "art-1" 20.0 coin "" (read-keyset "b1") 0)`,
+    code: `(${M}.list-token-with-fee "art-1" 20.0 coin "" (read-keyset "b1") 0)`,
     label: 'buyer1 re-lists art-1 at 20 (no fee)',
     signers: [{ kp: buyer1, caps: (wc) => [wc(`${M}.OWNER`, 'art-1'), wc('coin.GAS')] }],
     data: { b1: { keys: [buyer1.publicKey], pred: 'keys-all' } },


### PR DESCRIPTION
## What

The Kadena NFT interface standard v1 now has a declared **canonical source** (`contracts/standards/`) and a declared **on-chain home**: the PCO-owned principal namespace (testnet06: `n_e82dd10f74b7e8c253553de95629fdfa35cf8379`). Marketplaces implement the interfaces **fully qualified** — same-text interfaces in different namespaces are different Pact types, so one shared publication is what makes independent implementations compatible.

## Changes

- **SPEC.md** — canonical-source + on-chain-home section, publication table, qualified-implements example, and the freeze-review record (2026-07-08). Status moves to *frozen for v1 publication*.
- **Freeze review** — every signature checked against every known consumer (royalty-sale, smartpacts-gallery, conformance drivers, framework integration): no missing function in any marketplace/xchain flow, no signature regret. The three interface files are **byte-untouched**.
- **Conformance** — driver + suite dispatch `module{<pco-ns>.nft-*-v1}`; the suite now reproduces the real deployment topology in the REPL (interfaces in the PCO namespace, driver in `user`, candidate in `free`). README explains the one-literal-per-network rule and why a private interface copy is an island, not conformance.
- **royalty-sale** — the two `implements` lines + two projected schema types qualified (qualification-only diff — AUDIT addendum records it; no logic change). Deployment checklist updated.
- **devnet-validate** — the royalty-sale scripts now deploy the interfaces into `user/` (the recap devnet cannot host the principal namespace) and ns-subst the module source with an occurrence-count assert; also repairs the stale pre-adoption 6-arg `list-token` calls (`list-token-with-fee`).
- **Doc sweep** — root README, ARCHITECTURE, `contracts/nft/{README,TECHNICAL,DEPLOYMENT}` (mermaid diagram included) state PCO ownership and the standard-first deploy order (DEPLOYMENT step 0).

## Evidence

- `royalty-sale-conformance.repl` PASS — 227 lines / 29 asserts, cross-namespace dispatch
- `royalty-sale-test.repl` PASS — 482 lines / 53 asserts
- `royalty-sale-market-sim.repl` PASS — 953 lines / 149 asserts
- static gate: **0 VIOLATIONs** (1 pre-existing WARN in test scaffolding, reviewed)
- `tsc --noEmit` clean
- **on-node** (KDA-CE recap devnet): `npm run royalty-sale` PASSED (13 txs, both F1 escrow classes) and `npm run royalty-sale-sim` PASSED (32 txs, gas max 13,939 vs the 150k ceiling) — first node proof of the cross-namespace `implements` + qualified modref dispatch for the catalog

No interface byte changed; every vendored copy elsewhere re-snapshots from this directory.