### PR TITLE
docs(nft): network-reset notes, marketplace quickstart, and the visual map

### DIFF
--- a/contracts/nft/DEPLOYMENT.md
+++ b/contracts/nft/DEPLOYMENT.md
@@ -31,6 +31,27 @@ interface name, not an edit. Validate the full train on a devnet first, always.
 
 ## Order, per chain
 
+The full sequence, per chain (each step confirmed mined before the next —
+cross-references resolve at load time):
+
+```mermaid
+flowchart TD
+    subgraph T0["Train 0 — the v1 standard (once per network, PCO)"]
+        NS["create the PCO principal namespace<br/>(ns.create-principal-namespace)"] --> IF["publish nft-asset-v1 + nft-market-v1 + nft-xchain-v1<br/>(one tx — frozen forever at deploy)"]
+    end
+    subgraph T1["Train 1 — the framework"]
+        KS["1 · admin keyset"] --> FWIF["2 · framework interfaces<br/>(account-protocols, token-policy,<br/>poly-fungible, ledger-iface, sale)"]
+        FWIF --> UTIL["3 · util"]
+        UTIL --> PM["4 · policy-manager + tables"]
+        PM --> LED["5 · ledger + tables"]
+        LED --> POL["6 · policies + tables<br/>(royalty, non-fungible, … as needed)"]
+        POL --> AUC["7 · sale contracts + tables<br/>(conventional-auction, dutch-auction)"]
+        AUC --> WIRE["8 · governance wiring<br/>(policy-manager.init + register-sale-contract)"]
+    end
+    IF --> KS
+    WIRE --> VER["verify: describe-module hash per chain<br/>+ run the test suites against the deployed sources"]
+```
+
 0. **The v1 standard interfaces come first (separate train).** PCO publishes
    the Kadena NFT interface standard v1 (`contracts/standards/`:
    `nft-asset-v1`, `nft-market-v1`, `nft-xchain-v1`) into the PCO-owned
@@ -73,10 +94,20 @@ interface name, not an edit. Validate the full train on a devnet first, always.
 
 ## Published deployments
 
-**testnet06** (2026-07-08): the full framework is live on **all 20 chains** in the
-PCO principal namespace `n_e82dd10f74b7e8c253553de95629fdfa35cf8379`, deployed in
-the order above (standard-v1 interfaces first, framework train after). Hashes are
-identical on every chain — verify with `(at 'hash (describe-module "<ns>.<module>"))`:
+**testnet06** (2026-07-08): the full framework was deployed to **all 20 chains** in
+the PCO principal namespace `n_e82dd10f74b7e8c253553de95629fdfa35cf8379`, in the
+order above (standard-v1 interfaces first, framework train after).
+
+> **Network-reset note (2026-07-18).** testnet06 was reset to a fresh genesis
+> shortly after this deployment, which removed it along with everything else on
+> the network. The framework itself is unchanged; re-deployment follows the same
+> train once the network is back and namespace creation is available on the new
+> genesis. Because the namespace derives from the PCO keyset and module hashes
+> derive from source, the table below records the **expected values** for the
+> re-deployment (byte-identical sources reproduce identical hashes).
+
+Hashes are identical on every chain — verify with
+`(at 'hash (describe-module "<ns>.<module>"))`:
 
 | Module | Hash (×20 chains) |
 |---|---|

--- a/contracts/nft/QUICKSTART.md
+++ b/contracts/nft/QUICKSTART.md
@@ -1,0 +1,125 @@
+# Launch your NFT marketplace — quickstart
+
+You run a business and want your own NFT market on Kadena (KDA-CE). This page
+is the whole onboarding journey in plain language. Deep detail lives in
+[TECHNICAL.md](TECHNICAL.md) (section 10 is the field-by-field integration
+surface); the deploy procedure lives in [DEPLOYMENT.md](DEPLOYMENT.md).
+
+There are **two ways to be a marketplace**, both built on PCO-published,
+frozen on-chain interfaces. Most businesses want the first.
+
+```mermaid
+flowchart TD
+    START(["I want my own NFT market"]) --> Q{"Do you need your own<br/>token ledger and custody?"}
+    Q -->|"No — sell tokens, collect a fee<br/>(most marketplaces)"| FWTRACK["FRAMEWORK track<br/>deploy: nothing"]
+    Q -->|"Yes — my own module,<br/>my own rules"| STTRACK["STANDALONE track<br/>deploy: one module"]
+    FWTRACK --> F1["1 · create your revenue account<br/>(a principal account in the sale currency)"]
+    F1 --> F2["2 · build the listing flow<br/>(seller-signed offer carrying YOUR fee identity)"]
+    F2 --> F3["3 · build the buy flow<br/>(buyer signs payment + continuation)"]
+    F3 --> F4["4 · optional: auctions<br/>(registered sale contracts + your crank)"]
+    F4 --> F5["5 · index the events"]
+    F5 --> LIVE(["your market is live —<br/>fees land on your account,<br/>settled and conservation-checked on-chain"])
+    STTRACK --> S1["1 · copy the reference implementation<br/>(contracts/library/royalty-sale)"]
+    S1 --> S2["2 · adapt namespace, keysets, fee policy —<br/>implement the v1 interfaces fully qualified"]
+    S2 --> S3["3 · pass the conformance suite<br/>(contracts/standards/conformance)"]
+    S3 --> S4["4 · validate on devnet, then deploy<br/>your module (one train)"]
+    S4 --> LIVE
+```
+
+## Track 1 — a marketplace on the framework (deploy nothing)
+
+In the shared-ledger framework, tokens live in one hardened ledger and the
+policy-manager settles every sale. A marketplace is **not a contract** — it is:
+
+1. **a fee identity**: your revenue account, named in every seller-signed
+   listing (the quote). The settlement pays your cut automatically;
+2. optionally **an auction venue**: listings may name the registered
+   `conventional-auction` / `dutch-auction` for price discovery, and your
+   service runs the settlement crank;
+3. **a frontend** that builds the offer and buy transactions.
+
+You write no Pact, custody no tokens, and touch no settlement math. The
+conservation assert (`escrow-in = Σ payouts`) and the creator's royalty are
+enforced by the framework on every sale, including yours.
+
+### The steps
+
+1. **Create your revenue account** in the sale currency (e.g. `coin`). It must
+   be a **principal account** (`k:`/`w:`/`c:`). At listing time, always fetch
+   its **live guard** from the fungible's `details` — never hand-build one.
+2. **Listing (fixed price)**: your frontend builds the seller's offer — the
+   ledger's `sale` defpact — with a quote naming the price, the seller's payout
+   principal, and *your* `fee-account` / `fee-guard` / `fee-bps` (≤ 1000 bps —
+   the framework's cap; charge less as policy). Economics bind in state at
+   offer, signed by the seller. Nothing in the later buy transaction can change
+   them.
+3. **Buying**: the buyer signs exactly two things — a `TRANSFER` of the price
+   into the sale's escrow, and the buy continuation with their own account.
+   The manager settles royalty + your fee + seller remainder in one
+   conservation-asserted step; your fee lands on your account with no
+   marketplace code in the loop.
+4. **Auctions (optional)**: the same quote with `price: 0.0` and
+   `sale-contract` naming a **governance-registered** auction; the seller then
+   creates the auction (schedule / reserve / increment). Anyone may settle a
+   finished auction — your crank does it as a service. Your fee is carved from
+   the winning bid; auctions are not a royalty bypass.
+5. **Index the events**: `QUOTE` and `SETTLED` from the policy-manager;
+   `TOKEN`, `SALE`, `TRANSFER`, `RECONCILE`, `SUPPLY` from the ledger;
+   `ROYALTY` from the royalty policy; `AUCTION-CREATED` / `BID` /
+   `BID-REFUNDED` from the auctions. That is the complete data surface a
+   catalog UI needs.
+
+### What a token's life looks like
+
+```mermaid
+flowchart LR
+    CREATE["create-token<br/>(policies + royalty terms<br/>fixed forever at creation)"] --> MINT["mint<br/>(owner's guard binds)"]
+    MINT --> OFFER["offer / list<br/>(seller-signed quote:<br/>price + marketplace fee)"]
+    OFFER --> BUY["buy<br/>(buyer pays into escrow)"]
+    BUY --> SETTLE["one settlement<br/>royalty → creator<br/>fee → marketplace<br/>remainder → seller<br/>(escrow-in = Σ payouts, asserted)"]
+    SETTLE --> OWNER["new owner"]
+    OWNER -->|"relist anywhere —<br/>royalty travels with the token"| OFFER
+    OWNER -->|"optional: relocate cross-chain<br/>(rules travel as a policy passport)"| XCHAIN["another chain"]
+    XCHAIN --> OFFER
+```
+
+The royalty is the creator's, enforced at settlement on **every** marketplace
+and **every** chain the token ever sells on — that is the framework's promise,
+and why listing on it makes your market trustworthy on day one.
+
+### What you still build yourself
+
+Honesty section: the framework gives you settlement, custody, royalties, and
+auctions — it does **not** ship a frontend, an indexer, wallet integration, or
+a minting UI. Those are your product. The devnet campaign
+(`scripts/devnet-validate`, `npm run nft-framework`) is a working end-to-end
+reference for every transaction your frontend must build.
+
+## Track 2 — a standalone marketplace (deploy one module)
+
+If you want your own module — your own ledger, custody, and rules — implement
+the **Kadena NFT interface standard v1** instead:
+
+1. Copy [`contracts/library/royalty-sale/`](../library/royalty-sale/) (the
+   audited reference implementation) and adapt namespace, keysets, and fee
+   policy.
+2. Implement `nft-asset-v1` / `nft-market-v1` (/ `nft-xchain-v1`) **fully
+   qualified against the PCO namespace** — a private copy of the interfaces is
+   a different Pact type and does not conform
+   ([SPEC](../standards/SPEC.md) explains why).
+3. Pass the [conformance suite](../standards/conformance/README.md) — it
+   drives your module through a `module{...}` reference with adversarial
+   vectors, the same suite every conforming marketplace passes.
+4. Validate on devnet (one class of node-side bug is invisible in the REPL),
+   then deploy — your module only, the interfaces are already published.
+
+Conforming standalone marketplaces are compatible by construction: one wallet,
+one indexer, one aggregator works across all of them.
+
+## Which network, which namespace
+
+The standard and the framework are published per network into the PCO
+principal namespace — the current publication state (and expected hashes) is
+recorded in [SPEC.md](../standards/SPEC.md) and
+[DEPLOYMENT.md](DEPLOYMENT.md). Everything above works identically on a local
+devnet; validate there first, always.

--- a/contracts/nft/README.md
+++ b/contracts/nft/README.md
@@ -8,10 +8,44 @@ settlement and policy layers that analysis found unsound. This is an original, i
 implementation: it shares no code with and does not depend on that stack, which this catalog does
 not carry.
 
+> **Launching your own market?** Start with the [marketplace quickstart](QUICKSTART.md) —
+> what to deploy (usually: nothing), what to configure, and the whole onboarding journey in
+> plain language.
+>
 > **Deep technical reference:** [TECHNICAL.md](TECHNICAL.md) — every mechanism down to the code:
 > identity derivation, the policy system and its `-CALL` handshake, the conservation-asserted
 > settlement worked to 12 dp, defpacts, auctions, cross-chain passports, the marketplace
 > integration surface, the full capability inventory, and the test that proves each claim.
+
+## The map — interfaces, framework, and your marketplace
+
+```mermaid
+flowchart LR
+    subgraph STD["The v1 standard — PCO namespace (frozen interfaces)"]
+        SIF["nft-asset-v1<br/>nft-market-v1<br/>nft-xchain-v1"]
+    end
+    subgraph FW["The nft framework — shared ledger (this directory)"]
+        LEDGER["ledger<br/>(token identity + custody)"]
+        PM["policy-manager<br/>(one conservation-asserted settlement)"]
+        POL["policies<br/>(royalty, guards, 1/1, collections, uri)"]
+        AUC["auctions<br/>(conventional, dutch)"]
+        LEDGER --- PM
+        PM --- POL
+        PM --- AUC
+    end
+    subgraph MKT["A marketplace (yours)"]
+        FEE["fee identity in the seller's quote<br/>+ frontend + auction crank"]
+        STAND["…or a standalone module implementing<br/>the v1 interfaces fully qualified"]
+    end
+    FEE -->|"offer / buy transactions"| PM
+    STAND -->|"implements"| SIF
+    SIF -.->|"one wallet / indexer works across every<br/>conforming standalone marketplace"| STAND
+```
+
+Two independent tracks, both PCO-owned: a **standalone** marketplace custodies its own tokens and
+implements the frozen v1 interfaces from the PCO namespace ([`contracts/standards/`](../standards/));
+a **framework** marketplace holds no custody at all — it is a fee identity in seller-signed quotes,
+settled by the shared ledger's policy-manager. The quickstart walks both.
 
 ## Identity: why a shared ledger
 

--- a/contracts/standards/SPEC.md
+++ b/contracts/standards/SPEC.md
@@ -23,8 +23,18 @@ a governed principal namespace is the strongest available equivalent).
 
 | Network | PCO namespace | Published |
 |---|---|---|
-| testnet06 | `n_e82dd10f74b7e8c253553de95629fdfa35cf8379` | 2026-07-08, all 20 chains |
+| testnet06 | `n_e82dd10f74b7e8c253553de95629fdfa35cf8379` | 2026-07-08, all 20 chains — **wiped by the subsequent network reset; re-publication pending** (see note) |
 | mainnet | not yet published | — |
+
+> **Network-reset note (2026-07-18).** testnet06 was reset to a fresh genesis
+> shortly after publication, which removed every deployed contract including
+> this standard. Nothing about the standard changed: the namespace name derives
+> deterministically from the PCO keyset (it will re-derive identically), and a
+> module hash derives from its source (byte-identical interfaces re-publish to
+> the same hashes). The tables here are therefore the **expected values** for
+> the re-publication, which follows once the network is back and namespace
+> creation (`ns.create-principal-namespace`) is available on the new genesis.
+> Until then, no on-chain copy of the standard exists on testnet06.
 
 Deployed interface hashes on testnet06 (identical on every chain; verify with
 `(at 'hash (describe-module "<ns>.<interface>"))`):


### PR DESCRIPTION
## What

testnet06 was reset to a fresh genesis shortly after the 2026-07-08 publication, and the catalog's deployment claims had gone stale. This PR restores documentation truth and closes the newcomer-path gap with a quickstart and a set of native Mermaid diagrams.

| File | Change |
|---|---|
| `contracts/standards/SPEC.md` | Network-reset note on the publication table; hashes re-labeled as expected re-publication values (namespace and module hashes are deterministic) |
| `contracts/nft/DEPLOYMENT.md` | Same reset note on the published-deployments table; new deploy-train sequence diagram (both trains + verification) |
| `contracts/nft/README.md` | New architecture map (interfaces ↔ framework ↔ a consumer marketplace) + pointer to the quickstart |
| `contracts/nft/QUICKSTART.md` | **New** — "launch your NFT marketplace" for a business audience: the two tracks (framework = deploy nothing; standalone = one module), step-by-step, with the onboarding-journey and token-lifecycle diagrams, and an honest "what you still build yourself" section |

## Notes

- Docs only — no contract, test, or script changes. Interfaces untouched (frozen text verified byte-identical to the freeze review before writing).
- Diagrams are native Mermaid blocks — GitHub renders them, no external assets.
- All suites re-run green before this PR: 14 framework + 9 red-team + conformance, and the devnet campaign passed end-to-end (30 confirmed txs, max gas 39,153 / 150k).