### PR TITLE
feat(library): fixed-supply token templates — frozen one-shot-mint fungible, plain + advisory governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ The catalog ships four clearly separated products:
 
 ## The Library
 
-Nine production-grade templates covering the foundations most projects need. Every one shipped through the same three gates: a **blocking CI test suite**, a **static-analysis pass**, and an **independent adversarial security review** whose findings and fixes are documented in the entry's `AUDIT.md` — including the attacks that were tried and defeated.
+Eleven production-grade templates covering the foundations most projects need. Every one shipped through the same three gates: a **blocking CI test suite**, a **static-analysis pass**, and an **independent adversarial security review** whose findings and fixes are documented in the entry's `AUDIT.md` — including the attacks that were tried and defeated.
 
 | Template | What it is |
 |---|---|
 | [token-fungible](contracts/library/token-fungible/) | A hardened `fungible-v2` + `fungible-xchain-v1` token: coin-pattern guard enforcement, governed mint, reserved-name protection, cross-chain step semantics. |
+| [token-fixed-supply](contracts/library/token-fixed-supply/) | A frozen, non-upgradeable `fungible-v2` token: one-shot exact-distribution mint, self-burn only, no admin surface — immutability as the product. |
+| [token-fixed-supply-gov](contracts/library/token-fixed-supply-gov/) | The fixed-supply token plus advisory live-vote governance: weight = current balance, balance decreases release recorded votes, permanent tallies, executes nothing. |
 | [gas-station](contracts/library/gas-station/) | Drain-defended gas sponsorship: bounds and accounting against *actual* chain gas (never signer-supplied values), per-user on-chain allowlist. |
 | [multisig-treasury](contracts/library/multisig-treasury/) | M-of-N treasury: KDA in a capability-guarded vault, asynchronous propose/approve/execute, rotation that revokes stale approvals. |
 | [vesting](contracts/library/vesting/) | Cliff + linear vesting, escrowed upfront: the beneficiary never depends on the funder's solvency; revoke returns only the unvested part; governance has zero fund paths. |

--- a/contracts/library/token-fixed-supply-gov/AUDIT.md
+++ b/contracts/library/token-fixed-supply-gov/AUDIT.md
@@ -1,0 +1,108 @@
+# AUDIT — library/token-fixed-supply-gov
+
+## Summary
+
+| | |
+|---|---|
+| Version | 1.0.0 |
+| Audit status | `self-reviewed` (see §What self-reviewed means here) |
+| Review | Independent adversarial review, fresh context, 2026-07-18 |
+| Initial verdict | NO-GO as written: 1 MEDIUM (F1) + 2 LOW (F2, F3) |
+| Final verdict | **GO** after the reviewer-prescribed F1/F2 fixes landed and the suite re-ran green; F3 documented |
+| Suite | `examples/fixed-supply-token-gov-test.repl` — green; worst-case governance-loaded transfer gas measured AND asserted (489 ≪ 150k) |
+| Static analysis | 0 VIOLATIONs; WARNs dispositioned (guard enforcement lives in defcap bodies) |
+
+## Purpose
+
+The fixed-supply, non-upgradeable token extended with **advisory** governance:
+proposals + live balance-weighted voting with permanent tallies and **no
+execution surface**. Claims under review: tallies can never be forged or
+amplified; sold/moved/burned tokens can never keep voting; the public
+`release-votes` sync is harmless; governance load on transfers is bounded;
+closed tallies are immutable.
+
+## Capability model (reviewer's summary, post-fix, re-verified)
+
+> The module's authority model is minimal and terminal: `GOV` is
+> unsatisfiable (`enforce false`), so no upgrade, admin, or table-creation
+> surface exists after the deploy transaction. All value movement flows
+> through the managed `TRANSFER` capability (linear budget via
+> `TRANSFER-mgr`), composing `DEBIT` — the sender's own account guard — with
+> the weak-body internal `CREDIT` token; `credit`, `debit`, and
+> `cast-vote-internal` are sealed behind `require-capability`, and `CREDIT`
+> is only ever acquired under a real upstream guard (the one-shot `MINT`
+> keyset, made unrepeatable by the supply-row insert, or `TRANSFER`'s debit
+> guard), so no free-mint path exists. Every user-facing authorization —
+> `TRANSFER`, `BURN`, `ROTATE`, `PROPOSE`, and per-proposal `VOTE` — enforces
+> the account's own guard inside a capability body, so wallets can sign with
+> capability-scoped signatures throughout and never need to expose an
+> unscoped key. Governance adds no authority at all: tallies derive
+> exclusively from real balances (weight = current balance, shrink-only
+> public sync on every balance decrease, credits never vote), the proposal
+> threshold is deploy-enforced positive, and no capability, function, or
+> module surface consumes a tally — votes are permanently recorded advisory
+> signals with no execution lever. Independently exercised attack harnesses
+> (vote-transfer-revote cycles, hostile syncs, scoped-signature spoofing,
+> degenerate deploy parameters, worst-case governance-loaded gas at
+> 489/150,000) produced no violation.
+
+## Findings and dispositions
+
+| # | Sev | Finding | Disposition |
+|---|---|---|---|
+| F1 | **MED** | Voting/proposing/rotation used bare `enforce-guard` in defun bodies — capability-scoped signatures could never satisfy them, forcing every voter to sign UNSCOPED (a wallet-security anti-pattern a public template would teach). | **FIXED** as prescribed: `PROPOSE`/`VOTE`/`ROTATE` defcaps added; write paths wrapped; `cast-vote-internal` sealed with `require-capability`. Suite now proves scoped-sig proposing and voting positively, plus the negative (attacker key carrying a scoped VOTE cap for another account still fails). Base template got `ROTATE` for parity. |
+| F2 | LOW | `proposal-threshold` could floor to 0.0 under legal deploy parameters (e.g. precision 0, small supply, minimum fraction), silently letting zero-balance accounts propose. Reviewer-proven in a probe. | **FIXED** as prescribed: `PROPOSAL-THRESHOLD` is a load-time defconst with `(enforce (> t 0.0))` — the degenerate parameter combination now refuses to deploy. |
+| F3 | LOW | Proposal-slot squatting: a threshold-holder can occupy all 3 active slots with 720h windows and race re-grabs at expiry, crowding the advisory channel. Recoverable, contestable, advisory-only. | Documented in README §Known limits (including the gov-threshold sizing advice). Per-account limits/deposits left to forks — a deliberate simplicity trade-off. |
+| F4 | INFO | `release-votes` mutates tallies without an event; indexers must replay transfers/burns against the open set to reconstruct tallies. | Documented here. No event added: a per-shrink event would charge every transfer for indexer convenience, and the source-of-truth tallies are always readable on-chain (`get-proposal`/`get-results`). |
+| F5 | INFO | Suite's gas measurement was not worst case (1 live vote, not 3). | **FIXED**: suite votes on all 3 open proposals, measures 489 gas, and asserts the bound instead of printing it. |
+| F6 | INFO | Duplicated fungible core under-covered vs the base suite (no crosschain/rotate checks). | **FIXED**: crosschain-disabled assertion + rotate coverage (scoped-sig vanity rotate, principal-rotation rejection) added. |
+| F7 | INFO | No AUDIT.md at review time. | This file. |
+| F8 | INFO | Closed pids persist in `gov-actives` until the next `create-proposal` prunes (≤3 stale reads per transfer meanwhile; self-heals). | Accepted as-is; cosmetic, provably bounded. |
+
+## Attacks attempted and defeated (reviewer-executed)
+
+- **Vote→transfer→re-vote double-count** across split accounts and circular
+  transfers: tally always equals the sum of voters' current balances; never
+  amplified; tally ≤ circulating supply held throughout. Release is computed
+  on the **post-debit** balance.
+- **Hostile `release-votes`**: no-op on healthy and nonexistent accounts
+  (byte-identical state); the shrink math cannot underflow a tally column
+  (column = Σ row-weights maintained in lockstep).
+- **Tally-freeze bypass**: no post-close write path; `cast-vote` and
+  `open-ids` use the same strict time bound, so no closed-but-mutable window.
+- **Index wedge**: proposal insert + active-index write are same-tx atomic;
+  the stored index is provably ≤ 3 entries; `open-ids`' filter can never read
+  a missing row.
+- **vkey forgery**: digit-only pids + reserved-name account rules make
+  `"<pid>:<account>"` keys unambiguous.
+- **Free-mint / squat / rotation / managed-budget attacks** on the duplicated
+  core: as the base template (see its AUDIT.md); shared core diffed against
+  the base — byte-identical except the two `release-votes` call sites.
+- **Node-vs-REPL divergence**: every enforce condition uses pre-bound values;
+  guard reads only in `enforce-guard` argument position.
+
+## Liveness
+
+Transfers and burns are holder-guarded, compose with no governance state
+beyond the bounded (≤3, 489-gas) release work, and can never be wedged by
+proposals. Closed proposals, vote rows, and the supply row persist forever by
+design (the permanent record is the product). No trapped value.
+
+## What self-reviewed means here
+
+Adversarial and independent of the implementation session (fresh context,
+cold read, reviewer-authored probe harnesses for scoped signatures, the
+zero-threshold edge, and worst-case gas), but performed within the PCO. Per
+docs/CONTRACT_POLICIES.md §3.1 that is `self-reviewed`, not "audited". A
+qualifying independent community review promotes the entry.
+
+## Reproduce the review
+
+```bash
+cd examples && pact fixed-supply-token-gov-test.repl   # suite green, gas asserted
+```
+
+Same REPL discipline note as the base template: `expect-failure` does not
+roll back partial writes and cannot wrap `load` — negative write-capable
+cases live in `(rollback-tx)` transactions; bad-deploy aborts (including the
+zero-threshold refusal) are verified manually.

--- a/contracts/library/token-fixed-supply-gov/README.md
+++ b/contracts/library/token-fixed-supply-gov/README.md
@@ -1,0 +1,108 @@
+# Fixed-Supply Token with Advisory Governance
+
+The [fixed-supply, non-upgradeable token](../token-fixed-supply/) extended
+with **advisory on-chain governance**: proposals plus live balance-weighted
+yes/no/abstain voting with permanent tallies. Votes are the community's
+recorded voice — **they execute nothing**, because in a frozen token there is
+nothing for them to execute: the mint is one-shot, the module cannot be
+upgraded, and no admin surface exists.
+
+## The live-vote discipline
+
+The governance design closes the classic token-voting exploits *by
+construction* rather than by snapshotting:
+
+- **Weight = current balance.** A vote records the voter's balance at cast
+  time; re-voting updates the recorded vote in place.
+- **Balance decreases release weight.** Every transfer-out and burn
+  automatically shrinks the account's recorded weight on every OPEN proposal
+  down to the new balance. Sold or moved tokens can never keep voting — the
+  vote-then-transfer double-count is impossible.
+- **Credits never vote.** Received tokens arrive unvoted; tallies only ever
+  grow from an explicit `cast-vote` by the holder.
+- **`release-votes` is public on purpose.** It derives everything from the
+  account's real balance, so a permissionless call can only correct stale
+  weights downward — never forge or grow a vote. Anyone may sync anyone.
+- **Bounded governance load.** At most `MAX-ACTIVE-PROPOSALS` (3) proposals
+  are open at once, so the release work a transfer or burn carries is small
+  and bounded — measured and asserted in the suite: a transfer at true worst
+  case (3 open proposals, live votes on all 3) costs ~489 gas against the
+  150k ceiling.
+- **Scoped-signature governance.** Proposing, voting, and guard rotation are
+  authorized through dedicated capabilities (`PROPOSE`, `VOTE`, `ROTATE`), so
+  a wallet can sign a vote scoped to exactly one proposal — no unscoped
+  signatures required anywhere in the module.
+- **Tallies freeze at close.** After `close-at`, votes are rejected and
+  balance changes no longer touch the proposal — the result is a permanent
+  on-chain record. The open-proposal index self-prunes.
+
+**Disclosure duty:** if you attach off-chain or cross-module meaning to a
+tally (listing decisions, treasury actions run by other modules), state
+prominently that votes here are advisory signals, not levers.
+
+## Deployment checklist
+
+Everything from the base template applies (namespace wrap, transaction-data
+parameters, `create-table` stays in the deploy transaction, `init-mint`
+once, devnet validation), plus one extra deploy-time parameter:
+
+- `gov-threshold` — fraction of `TOTAL-SUPPLY` a holder needs to open a
+  proposal, enforced into `[0.001, 0.1]` (0.1%–10%).
+
+Voting windows are 24h–720h per proposal, chosen by the proposer.
+
+## Usage
+
+```pact
+;; open a proposal (balance >= threshold; your guard authorizes)
+(fixed-supply-token-gov.create-proposal "k:holder" "Title" "Body" 72)
+
+;; vote / re-vote (weight = your current balance)
+(fixed-supply-token-gov.cast-vote "1" "k:holder" "yes")
+
+;; anyone can sync a stale vote weight down to the real balance
+(fixed-supply-token-gov.release-votes "k:whale")
+
+;; read the permanent record
+(fixed-supply-token-gov.get-results "1")
+```
+
+## Testing
+
+```bash
+cd examples
+pact fixed-supply-token-gov-test.repl
+```
+
+The suite re-proves a compact core sanity block (one-shot mint, managed
+transfers, reserved names) and then exercises the full governance delta:
+threshold and duration bounds, guard-authorized proposing/voting, re-vote
+tally exactness, the release rule on transfer AND burn, the public
+release-votes no-op property, the active-proposal cap, transfer gas under
+maximum governance load, tally freeze at close, and index self-pruning.
+
+## Known limits
+
+- All base-template limits apply (load-time validation, irreversibility,
+  single chain, devnet mandate, exact-JSON deploy parameters, first-come
+  vanity names — see the base README; distribute the mint to principal
+  `k:`/`w:` accounts or mint in the deploy transaction).
+- **Proposal slots can be squatted.** Any holder above the threshold can
+  occupy all 3 active slots with 720h windows and race to re-grab them at
+  expiry. Advisory-only and recoverable (slots free at close, races are
+  contestable), but a determined threshold-holder can crowd the channel.
+  Pick `gov-threshold` with that in mind; a deposit or per-account limit
+  would need a fork of the template.
+- The deploy aborts if `floor(total-supply × gov-threshold, precision)` is
+  zero (e.g. tiny supply at precision 0) — a zero threshold would let
+  zero-balance accounts propose, so the module refuses the combination.
+- **Advisory only.** No quorum is enforced and no execution is wired —
+  readers judge turnout themselves via `get-results`. This is deliberate;
+  wiring execution to tallies would require a governed surface and a
+  different trust model.
+- Proposal titles/bodies live on-chain forever (120/2000 char bounds);
+  moderation is impossible by design.
+
+## License
+
+Apache-2.0 — see the repository [LICENSE](../../../LICENSE).

--- a/contracts/library/token-fixed-supply-gov/examples/fixed-supply-token-gov-test.repl
+++ b/contracts/library/token-fixed-supply-gov/examples/fixed-supply-token-gov-test.repl
@@ -1,0 +1,303 @@
+;; fixed-supply-token-gov-test.repl — PCO library template test suite
+;;
+;; Self-contained: loads the fungible-v2 interface from this repository's
+;; registry tree. No external sandbox required.
+;;
+;; The fungible core mirrors library/token-fixed-supply (a compact sanity
+;; block re-proves it here); the bulk of this suite exercises the governance
+;; delta: proposal threshold, duration/active bounds, live-vote weight with
+;; re-vote, the RELEASE rule on transfer and burn, the permissionless
+;; release-votes sync, tally freeze at close, index self-pruning, and the
+;; bounded transfer gas under maximum governance load.
+
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-01-01T00:00:00Z") })
+
+;; NOTE on deploy-time parameter validation: the precision/total-supply/
+;; gov-threshold bounds are enforced inside defconsts, i.e. AT MODULE LOAD.
+;; A REPL limitation prevents asserting failing loads in-suite, so
+;; bad-deploy rejection is verified manually: load this module with e.g.
+;; "gov-threshold": 0.5 and observe the abort. See README "Known limits".
+
+;; ---------------------------------------------------------------------------
+;; Setup: interface + deploy (tables created by the file - frozen governance)
+;; ---------------------------------------------------------------------------
+(env-data
+  { "symbol": "FSG", "precision": 12, "total-supply": 900000.0
+  , "gov-threshold": 0.01
+  , "token-minter": ["minter-key"]
+  , "whale": ["whale-key"], "holder": ["holder-key"], "carol": ["carol-key"]
+  , "attacker": ["attacker-key"]
+  , "k-ks": ["deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"] })
+
+(begin-tx "setup")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../fixed-supply-token-gov.pact")
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Core sanity: one-shot mint + reserved-name protocol + managed transfer
+;; ---------------------------------------------------------------------------
+;; REPL discipline used throughout: expect-failure does NOT roll back the
+;; partial writes of the failed action in this Pact version, so every
+;; negative case that could write before failing lives in its own
+;; transaction ended with (rollback-tx).
+
+(begin-tx "mint auth")
+(env-sigs [{"key": "attacker-key", "caps": []}])
+(expect-failure "non-minter cannot init-mint" "Keyset failure"
+  (fixed-supply-token-gov.init-mint
+    [ { "account": "whale", "guard": (read-keyset "whale"), "amount": 900000.0 } ]))
+(rollback-tx)
+
+(begin-tx "distribution must be exact")
+(env-sigs [{"key": "minter-key", "caps": []}])
+(expect-failure "distribution must be exact" "exactly TOTAL-SUPPLY"
+  (fixed-supply-token-gov.init-mint
+    [ { "account": "whale", "guard": (read-keyset "whale"), "amount": 899999.0 } ]))
+(rollback-tx)
+
+(begin-tx "the one mint")
+(env-sigs [{"key": "minter-key", "caps": []}])
+(expect "mint succeeds" "minted"
+  (fixed-supply-token-gov.init-mint
+    [ { "account": "whale",  "guard": (read-keyset "whale"),  "amount": 500000.0 }
+    , { "account": "holder", "guard": (read-keyset "holder"), "amount": 1000.0 }
+    , { "account": "carol",  "guard": (read-keyset "carol"),  "amount": 399000.0 } ]))
+(commit-tx)
+
+(begin-tx "second mint impossible + squat rejected")
+(env-sigs [{"key": "minter-key", "caps": []}])
+(expect-failure "second mint impossible" "already found"
+  (fixed-supply-token-gov.init-mint
+    [ { "account": "whale", "guard": (read-keyset "whale"), "amount": 900000.0 } ]))
+(expect-failure "k: squat rejected" "Single-key account protocol violation"
+  (fixed-supply-token-gov.create-account
+    "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    (read-keyset "attacker")))
+(rollback-tx)
+
+(begin-tx "managed transfer sanity")
+(env-sigs [ { "key": "whale-key"
+            , "caps": [ (fixed-supply-token-gov.TRANSFER "whale" "holder" 10.0) ] } ])
+(fixed-supply-token-gov.transfer "whale" "holder" 10.0)
+(expect-failure "managed budget exhausted" "TRANSFER exceeded"
+  (fixed-supply-token-gov.transfer "whale" "holder" 1.0))
+(expect "holder credited" 1010.0 (fixed-supply-token-gov.get-balance "holder"))
+(commit-tx)
+
+;; put the 10 back so governance numbers stay round
+(begin-tx "restore round balances")
+(env-sigs [ { "key": "holder-key"
+            , "caps": [ (fixed-supply-token-gov.TRANSFER "holder" "whale" 10.0) ] } ])
+(fixed-supply-token-gov.transfer "holder" "whale" 10.0)
+(expect "whale at 500000" 500000.0 (fixed-supply-token-gov.get-balance "whale"))
+(expect "holder at 1000" 1000.0 (fixed-supply-token-gov.get-balance "holder"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Governance constants
+;; ---------------------------------------------------------------------------
+(begin-tx "governance constants")
+(expect "threshold = 1% of supply" 9000.0 (fixed-supply-token-gov.proposal-threshold))
+(expect "no open proposals yet" [] (fixed-supply-token-gov.open-ids))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Proposal creation: threshold, duration bounds, guard
+;; ---------------------------------------------------------------------------
+(env-sigs [{"key": "holder-key", "caps": []}])
+(begin-tx "below-threshold holder cannot propose")
+(expect-failure "threshold enforced" "balance below proposal threshold"
+  (fixed-supply-token-gov.create-proposal "holder" "t" "b" 48))
+(commit-tx)
+
+(env-sigs [{"key": "whale-key", "caps": []}])
+(begin-tx "duration bounds")
+(expect-failure "too short" "duration outside"
+  (fixed-supply-token-gov.create-proposal "whale" "t" "b" 23))
+(expect-failure "too long" "duration outside"
+  (fixed-supply-token-gov.create-proposal "whale" "t" "b" 721))
+(expect-failure "empty title" "title 1..120 chars"
+  (fixed-supply-token-gov.create-proposal "whale" "" "b" 48))
+(commit-tx)
+
+(begin-tx "wrong signer cannot propose for the whale")
+(env-sigs [{"key": "holder-key", "caps": []}])
+(expect-failure "guard enforced" "Keyset failure"
+  (fixed-supply-token-gov.create-proposal "whale" "t" "b" 48))
+(commit-tx)
+
+;; SCOPED-signature proposing: wallets never need an unscoped signature
+(env-sigs [ { "key": "whale-key"
+            , "caps": [ (fixed-supply-token-gov.PROPOSE "whale") ] } ])
+(begin-tx "whale opens proposal 1 with a capability-scoped signature")
+(expect "pid 1" "1"
+  (fixed-supply-token-gov.create-proposal
+    "whale" "List on the community page?" "Advisory signal only." 72))
+(expect "open ids [1]" ["1"] (fixed-supply-token-gov.open-ids))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Voting: weight = current balance; re-vote updates in place.
+;; The first vote uses a SCOPED signature (caps: [(VOTE "1" "whale")]) - a
+;; wallet can authorize exactly one vote on one proposal and nothing else.
+;; ---------------------------------------------------------------------------
+(env-sigs [ { "key": "whale-key"
+            , "caps": [ (fixed-supply-token-gov.VOTE "1" "whale") ] } ])
+(begin-tx "whale votes yes with a capability-scoped signature")
+(fixed-supply-token-gov.cast-vote "1" "whale" "yes")
+(expect "yes tally == whale balance" 500000.0
+  (at 'yes (fixed-supply-token-gov.get-proposal "1")))
+(expect-failure "bad choice rejected" "choice: yes|no|abstain"
+  (fixed-supply-token-gov.cast-vote "1" "whale" "maybe"))
+(commit-tx)
+
+(env-sigs [ { "key": "attacker-key"
+            , "caps": [ (fixed-supply-token-gov.VOTE "1" "whale") ] } ])
+(begin-tx "a scoped cap under the wrong key is worthless")
+(expect-failure "voter guard still enforced inside the cap" "Keyset failure"
+  (fixed-supply-token-gov.cast-vote "1" "whale" "no"))
+(rollback-tx)
+
+(env-sigs [{"key": "whale-key", "caps": []}])
+
+(begin-tx "re-vote moves the full weight to no")
+(fixed-supply-token-gov.cast-vote "1" "whale" "no")
+(expect "yes back to 0" 0.0 (at 'yes (fixed-supply-token-gov.get-proposal "1")))
+(expect "no == whale balance" 500000.0
+  (at 'no (fixed-supply-token-gov.get-proposal "1")))
+(commit-tx)
+
+(env-sigs [{"key": "holder-key", "caps": []}])
+(begin-tx "small holder votes yes")
+(fixed-supply-token-gov.cast-vote "1" "holder" "yes")
+(expect "yes == 1000" 1000.0 (at 'yes (fixed-supply-token-gov.get-proposal "1")))
+(commit-tx)
+
+(begin-tx "zero-balance account cannot vote")
+(env-sigs [{"key": "attacker-key", "caps": []}])
+(expect-failure "no account row, no vote" "No value found"
+  (fixed-supply-token-gov.cast-vote "1" "attacker" "yes"))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; THE RELEASE RULE: balance decreases shrink the recorded vote
+;; ---------------------------------------------------------------------------
+(env-sigs [ { "key": "whale-key"
+            , "caps": [ (fixed-supply-token-gov.TRANSFER "whale" "carol" 50000.0) ] } ])
+(begin-tx "transfer releases the moved weight")
+(let ((before (at 'no (fixed-supply-token-gov.get-proposal "1"))))
+  (fixed-supply-token-gov.transfer "whale" "carol" 50000.0)
+  (expect "no tally shrank by exactly the moved amount" (- before 50000.0)
+    (at 'no (fixed-supply-token-gov.get-proposal "1")))
+  (expect "vote row synced to the new balance" 450000.0
+    (at 'weight (fixed-supply-token-gov.get-vote "1" "whale"))))
+(commit-tx)
+
+(env-sigs [{"key": "whale-key", "caps": []}])
+(begin-tx "burn releases too; credits stay unvoted; public sync is a no-op")
+(let ((before (at 'no (fixed-supply-token-gov.get-proposal "1"))))
+  (fixed-supply-token-gov.burn "whale" 10000.0)
+  (expect "no tally shrank by the burn" (- before 10000.0)
+    (at 'no (fixed-supply-token-gov.get-proposal "1"))))
+(let ((t (at 'no (fixed-supply-token-gov.get-proposal "1"))))
+  (fixed-supply-token-gov.release-votes "whale")
+  (expect "public release-votes is a harmless sync" t
+    (at 'no (fixed-supply-token-gov.get-proposal "1"))))
+;; carol received 50k but never voted - tallies never grow from a credit
+(expect "turnout = yes + no only (credits never vote)"
+  (+ (at 'yes (fixed-supply-token-gov.get-proposal "1"))
+     (at 'no (fixed-supply-token-gov.get-proposal "1")))
+  (at 'turnout (fixed-supply-token-gov.get-results "1")))
+(expect "supply accounting after burn" 890000.0
+  (fixed-supply-token-gov.circulating-supply))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; MAX-ACTIVE bound
+;; ---------------------------------------------------------------------------
+(env-sigs [{"key": "whale-key", "caps": []}])
+(begin-tx "at most 3 active proposals")
+(fixed-supply-token-gov.create-proposal "whale" "p2" "" 168)
+(fixed-supply-token-gov.create-proposal "whale" "p3" "" 168)
+(expect-failure "4th active rejected" "too many active proposals"
+  (fixed-supply-token-gov.create-proposal "whale" "p4" "" 48))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Transfer gas at TRUE worst case - 3 open proposals, live votes on ALL 3 -
+;; stays far under the 150k ceiling (asserted, not just printed)
+;; ---------------------------------------------------------------------------
+(env-sigs [{"key": "whale-key", "caps": []}])
+(begin-tx "whale votes on p2 and p3 too")
+(fixed-supply-token-gov.cast-vote "2" "whale" "yes")
+(fixed-supply-token-gov.cast-vote "3" "whale" "abstain")
+(commit-tx)
+
+(env-gasmodel "table") (env-gaslimit 150000)
+(env-sigs [ { "key": "whale-key"
+            , "caps": [ (fixed-supply-token-gov.TRANSFER "whale" "carol" 100.0) ] } ])
+(begin-tx "worst-case transfer gas: 3 active proposals, 3 live votes")
+(env-gas 0)
+(fixed-supply-token-gov.transfer "whale" "carol" 100.0)
+(print (format "GAS worst-case transfer (3 open, 3 live votes): {}" [(env-gas)]))
+(expect "worst-case governance-loaded transfer well under the 150k ceiling" true
+  (< (env-gas) 5000))
+(commit-tx)
+(env-sigs [])
+
+;; ---------------------------------------------------------------------------
+;; Core parity with the base template: rotation safety + disabled cross-chain
+;; ---------------------------------------------------------------------------
+(begin-tx "principal account for rotation checks")
+(env-sigs [])
+(fixed-supply-token-gov.create-account
+  "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  (read-keyset "k-ks"))
+(commit-tx)
+
+(begin-tx "rotate is scoped-signable; principals cannot rotate away")
+(env-sigs [ { "key": "carol-key"
+            , "caps": [ (fixed-supply-token-gov.ROTATE "carol") ] } ])
+(expect "vanity rotate under a scoped signature" "rotated carol"
+  (fixed-supply-token-gov.rotate "carol" (read-keyset "attacker")))
+(commit-tx)
+(begin-tx "principal rotation rejected")
+(env-sigs [ { "key": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            , "caps": [] } ])
+(expect-failure "principal rotation forbidden" "unsafe for principal accounts"
+  (fixed-supply-token-gov.rotate
+    "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    (read-keyset "attacker")))
+(rollback-tx)
+
+(begin-tx "xchain disabled")
+(env-sigs [{"key": "whale-key", "caps": []}])
+(expect-failure "transfer-crosschain step 0 always aborts" "cross-chain transfers are disabled"
+  (fixed-supply-token-gov.transfer-crosschain
+    "whale" "carol" (read-keyset "carol") "1" 10.0))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Tally freeze at close + index self-pruning
+;; ---------------------------------------------------------------------------
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-01-04T00:00:01Z") })
+(begin-tx "voting closed; tallies frozen")
+(env-sigs [{"key": "holder-key", "caps": []}])
+(expect-failure "vote after close rejected" "voting closed"
+  (fixed-supply-token-gov.cast-vote "1" "holder" "no"))
+(expect "results closed" true (at 'closed (fixed-supply-token-gov.get-results "1")))
+(commit-tx)
+
+(env-sigs [ { "key": "holder-key"
+            , "caps": [ (fixed-supply-token-gov.TRANSFER "holder" "carol" 1000.0) ] } ])
+(begin-tx "post-close transfer does NOT touch the frozen tally")
+(let ((frozen (at 'yes (fixed-supply-token-gov.get-proposal "1"))))
+  (fixed-supply-token-gov.transfer "holder" "carol" 1000.0)
+  (expect "closed tally unchanged" frozen
+    (at 'yes (fixed-supply-token-gov.get-proposal "1"))))
+;; the index self-prunes: p1 closed, p2/p3 still open
+(expect "open ids pruned to p2,p3" ["2" "3"] (fixed-supply-token-gov.open-ids))
+(commit-tx)
+
+(print "fixed-supply-token-gov suite complete")

--- a/contracts/library/token-fixed-supply-gov/fixed-supply-token-gov.pact
+++ b/contracts/library/token-fixed-supply-gov/fixed-supply-token-gov.pact
@@ -1,0 +1,506 @@
+(module fixed-supply-token-gov GOV
+
+  @doc "PCO library template: the fixed-supply, non-upgradeable fungible-v2  \
+  \token (see library/token-fixed-supply) extended with ADVISORY governance: \
+  \proposals plus live balance-weighted yes/no/abstain voting with permanent \
+  \on-chain tallies.                                                         \
+  \                                                                          \
+  \The live-vote discipline, in full:                                        \
+  \  * A vote's weight is the voter's CURRENT balance; re-voting updates the \
+  \    recorded vote in place.                                               \
+  \  * Every balance DECREASE (transfer out, burn) automatically releases    \
+  \    the moved weight from the account's votes on every OPEN proposal, so  \
+  \    tokens that were sold or moved can never keep voting - the classic    \
+  \    vote-then-transfer double-count is impossible by construction.        \
+  \  * Received tokens arrive UNVOTED: credits never touch tallies.          \
+  \  * release-votes is deliberately PUBLIC: it derives everything from the  \
+  \    account's REAL balance, so calling it is a harmless permissionless    \
+  \    vote-weight sync - it can only shrink stale weights, never forge or   \
+  \    grow votes.                                                           \
+  \  * At most MAX-ACTIVE-PROPOSALS are open at once, so the release work    \
+  \    added to a transfer or burn is bounded (<= 3 proposal/vote row pairs).\
+  \                                                                          \
+  \Votes EXECUTE NOTHING. The token is frozen and the mint is one-shot, so   \
+  \there is no governed surface in this module - tallies are the community's \
+  \permanently recorded voice, and readers judge turnout themselves (no      \
+  \quorum is enforced). If you attach off-chain or cross-module meaning to a \
+  \result, disclose prominently that votes are advisory signals.             \
+  \                                                                          \
+  \Deploy-time parameterization: symbol, precision, total-supply and         \
+  \token-minter as in the base template, PLUS gov-threshold - the fraction   \
+  \of TOTAL-SUPPLY required to open a proposal, enforced into [0.001, 0.1].  \
+  \                                                                          \
+  \Deployment checklist (see README.md):                                     \
+  \  1. Rename the module and wrap it in your namespace.                     \
+  \  2. Deploy WITH the parameters above in the same transaction - the      \
+  \     (create-table ...) calls at the end of this file MUST stay in the    \
+  \     deploy transaction: governance is frozen, so tables can never be     \
+  \     created afterwards.                                                  \
+  \  3. Call init-mint with the full distribution; a second call is          \
+  \     impossible by construction.                                          \
+  \  4. Run the co-located REPL suite, then validate on devnet before any    \
+  \     production deployment.                                               \
+  \                                                                          \
+  \Single-chain by design: transfer-crosschain is disabled, which also makes \
+  \the voting chain-local by construction (no cross-chain double-vote        \
+  \surface exists)."
+
+  (implements fungible-v2)
+
+  ;; -----------------------------
+  ;; Governance: frozen forever
+  ;; -----------------------------
+
+  (defcap GOV ()
+    @doc "Deliberately unsatisfiable: the deployed module is non-upgradeable."
+    (enforce false "frozen: this token is non-upgradeable"))
+
+  ;; -----------------------------
+  ;; Deploy-time constants
+  ;; -----------------------------
+
+  (defconst SYMBOL (read-string 'symbol)
+    "Display symbol, fixed at deploy.")
+
+  (defconst PRECISION:integer
+    (let ((p (read-integer 'precision)))
+      (enforce (and (>= p 0) (<= p 12)) "precision must be in 0..12")
+      p)
+    "Decimal precision, fixed at deploy (12 matches coin).")
+
+  (defconst TOTAL-SUPPLY:decimal
+    (let ((s (read-decimal 'total-supply)))
+      (enforce (> s 0.0) "total-supply must be positive")
+      (enforce (= (floor s PRECISION) s) "total-supply must respect precision")
+      s)
+    "The fixed supply: minted exactly once, only ever decreased by burns.")
+
+  (defconst MINT-GUARD:guard (read-keyset 'token-minter)
+    "The keyset allowed to perform the ONE initial mint. Powerless afterwards.")
+
+  (defconst GOV-THRESHOLD-FRACTION:decimal
+    (let ((f (read-decimal 'gov-threshold)))
+      (enforce (and (>= f 0.001) (<= f 0.1)) "gov-threshold in [0.001, 0.1]")
+      f)
+    "Fraction of TOTAL-SUPPLY required to open a proposal, fixed at deploy.")
+
+  (defconst PROPOSAL-THRESHOLD:decimal
+    (let ((t (floor (* TOTAL-SUPPLY GOV-THRESHOLD-FRACTION) PRECISION)))
+      (enforce (> t 0.0)
+        "proposal threshold floors to zero at this precision/supply - refuse the deploy")
+      t)
+    "Minimum balance to open a proposal. Enforced positive at deploy so the \
+    \spam gate can never silently vanish on low-precision/low-supply tokens.")
+
+  (defconst MIN-VOTE-HOURS 24
+    "Shortest allowed voting window.")
+
+  (defconst MAX-VOTE-HOURS 720
+    "Longest allowed voting window (30 days).")
+
+  (defconst MAX-ACTIVE-PROPOSALS 3
+    "Open-proposal cap: bounds the release work on every balance decrease.")
+
+  (defconst MINIMUM_ACCOUNT_LENGTH 3
+    "Minimum account name length")
+
+  (defconst MAXIMUM_ACCOUNT_LENGTH 256
+    "Maximum account name length")
+
+  (defconst SUPPLY-KEY "supply")
+  (defconst ACTIVE-KEY "active")
+  (defconst COUNT-KEY "n")
+
+  ;; -----------------------------
+  ;; Schemas and Tables
+  ;; -----------------------------
+
+  (defschema account
+    @doc "Account row with balance and guard"
+    @model [(invariant (>= balance 0.0))]
+    balance:decimal
+    guard:guard)
+
+  (deftable accounts:{account})
+
+  (defschema supply-row
+    @doc "Singleton supply ledger: the one-shot insert here is what makes a \
+         \second init-mint impossible (insert fails on an existing key)."
+    initial:decimal
+    burned:decimal)
+
+  (deftable supply:{supply-row})
+
+  (defschema recipient
+    @doc "One initial-distribution entry for init-mint."
+    account:string
+    guard:guard
+    amount:decimal)
+
+  (defschema gov-proposal
+    creator:string
+    title:string
+    body:string
+    created:time
+    close-at:time
+    yes:decimal
+    no:decimal
+    abstain:decimal)
+
+  (deftable gov-proposals:{gov-proposal})   ; key = proposal id (counter)
+
+  (defschema gov-vote
+    choice:string
+    weight:decimal)
+
+  (deftable gov-votes:{gov-vote})           ; key = "<pid>:<account>"
+
+  (defschema gov-active
+    ids:[string])
+
+  (deftable gov-actives:{gov-active})       ; singleton: open-proposal index
+
+  (defschema gov-count
+    n:integer)
+
+  (deftable gov-counts:{gov-count})         ; singleton: id counter
+
+  ;; -----------------------------
+  ;; Capabilities
+  ;; -----------------------------
+
+  (defcap DEBIT (sender:string)
+    @doc "Internal debit permission: enforces the sender's account guard."
+    (enforce-guard (at 'guard (read accounts sender))))
+
+  (defcap CREDIT (receiver:string)
+    @doc "Internal credit permission. Safe as a weak-body cap: only ever \
+         \required by code paths that already validated the credit."
+    true)
+
+  (defcap MINT ()
+    @doc "The one-shot initial mint, guarded by the deploy-time minter keyset."
+    (enforce-guard MINT-GUARD))
+
+  (defcap BURN (account:string)
+    @doc "Self-burn permission: the account's own guard, nobody else's."
+    (enforce-guard (at 'guard (read accounts account))))
+
+  (defcap BURNED (account:string amount:decimal)
+    @event
+    true)
+
+  (defcap ROTATE (account:string)
+    @doc "Guard-rotation authorization: the account's CURRENT guard. A       \
+         \capability-scoped signature can target exactly this rotation."
+    (enforce-guard (at 'guard (read accounts account))))
+
+  (defcap PROPOSE (account:string)
+    @doc "Proposal authorization: the proposer's own account guard, scoped   \
+         \so wallets never need an unscoped signature to open a proposal."
+    (enforce-guard (at 'guard (read accounts account))))
+
+  (defcap VOTE (pid:string account:string)
+    @doc "Vote authorization: the voter's own account guard, scoped to one   \
+         \proposal so wallets never need an unscoped signature to vote."
+    (enforce-guard (at 'guard (read accounts account))))
+
+  (defcap GOV-PROPOSED (id:string creator:string title:string close-at:time)
+    @event
+    true)
+
+  (defcap GOV-VOTED (id:string account:string choice:string weight:decimal)
+    @event
+    true)
+
+  (defcap TRANSFER:bool (sender:string receiver:string amount:decimal)
+    @managed amount TRANSFER-mgr
+    (enforce (!= sender receiver) "same sender and receiver")
+    (enforce (> amount 0.0) "amount must be positive")
+    (enforce-unit amount)
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver)))
+
+  (defun TRANSFER-mgr:decimal (managed:decimal requested:decimal)
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0) "TRANSFER exceeded for balance")
+      newbal))
+
+  ;; -----------------------------
+  ;; Account name protocol
+  ;; -----------------------------
+
+  (defun validate-account (account:string)
+    @doc "Enforce account name length bounds and latin-1 charset."
+    (enforce (is-charset CHARSET_LATIN1 account)
+      (format "Account does not conform to the token contract charset: {}" [account]))
+    (let ((account-length (length account)))
+      (enforce (>= account-length MINIMUM_ACCOUNT_LENGTH)
+        (format "Account name does not conform to the min length requirement: {}" [account]))
+      (enforce (<= account-length MAXIMUM_ACCOUNT_LENGTH)
+        (format "Account name does not conform to the max length requirement: {}" [account]))))
+
+  (defun check-reserved:string (account:string)
+    @doc "Return reserved-name protocol prefix ('k' for 'k:...'), or ''."
+    (let ((pfx (take 2 account)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account name protocols: a 'k:'-prefixed account \
+         \must be the principal of its guard (prevents account squatting)."
+    (if (validate-principal guard account)
+      true
+      (let ((r (check-reserved account)))
+        (if (= r "")
+          true
+          (if (= r "k")
+            (enforce false "Single-key account protocol violation")
+            (enforce false
+              (format "Reserved protocol guard violation: {}" [r])))))))
+
+  ;; -----------------------------
+  ;; fungible-v2 surface (identical to the base template except the
+  ;; release-votes call sites after the two balance decreases)
+  ;; -----------------------------
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read accounts receiver { "guard" := g }
+        (credit receiver g amount))))
+
+  (defun transfer-create:string
+      (sender:string receiver:string receiver-guard:guard amount:decimal)
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount)))
+
+  (defpact transfer-crosschain:string
+      (sender:string receiver:string receiver-guard:guard
+       target-chain:string amount:decimal)
+    (step (enforce false "cross-chain transfers are disabled: single-chain token")))
+
+  (defun debit (account:string amount:decimal)
+    (require-capability (DEBIT account))
+    (with-read accounts account { "balance" := b }
+      (enforce (<= amount b) "insufficient funds")
+      (update accounts account { "balance": (- b amount) }))
+    (release-votes account))
+
+  (defun credit (account:string guard:guard amount:decimal)
+    (require-capability (CREDIT account))
+    (validate-account account)
+    (enforce-reserved account guard)
+    (with-default-read accounts account
+      { "balance": 0.0, "guard": guard }
+      { "balance" := b, "guard" := g }
+      (enforce (= g guard) "account guard mismatch")
+      (write accounts account { "balance": (+ b amount), "guard": g })))
+
+  (defun get-balance:decimal (account:string)
+    (at 'balance (read accounts account)))
+
+  (defun details:object{fungible-v2.account-details} (account:string)
+    (with-read accounts account { "balance" := b, "guard" := g }
+      { "account": account, "balance": b, "guard": g }))
+
+  (defun precision:integer ()
+    PRECISION)
+
+  (defun enforce-unit:bool (amount:decimal)
+    (enforce (= (floor amount PRECISION) amount) "precision violation"))
+
+  (defun create-account:string (account:string guard:guard)
+    (validate-account account)
+    (enforce-reserved account guard)
+    (insert accounts account { "balance": 0.0, "guard": guard })
+    (format "created {}" [account]))
+
+  (defun rotate:string (account:string new-guard:guard)
+    ;; principal accounts must not rotate away from their proper guard -
+    ;; a rotated 'k:' account would falsify the reserved-name protocol.
+    (enforce (or (not (is-principal account))
+                 (validate-principal new-guard account))
+      "It is unsafe for principal accounts to rotate their guard")
+    (with-capability (ROTATE account)
+      (update accounts account { "guard": new-guard }))
+    (format "rotated {}" [account]))
+
+  ;; -----------------------------
+  ;; One-shot mint, burn, supply views
+  ;; -----------------------------
+
+  (defun init-mint:string (recipients:[object{recipient}])
+    @doc "One-shot: mint EXACTLY TOTAL-SUPPLY across the recipients. The     \
+         \insert into the supply row makes a second call impossible by       \
+         \construction (insert fails on an existing key), so the minter      \
+         \keyset is powerless after this returns. Distribute to principal    \
+         \(k:/w:) accounts, or mint in the deploy transaction itself: a      \
+         \pre-created vanity name under a foreign guard aborts the mint      \
+         \(griefing, not theft - principal names are immune)."
+    (with-capability (MINT)
+      (insert supply SUPPLY-KEY { "initial": TOTAL-SUPPLY, "burned": 0.0 })
+      (let ((total (fold (lambda (acc:decimal r:object{recipient})
+                           (+ acc (at 'amount r)))
+                         0.0 recipients)))
+        (enforce (= total TOTAL-SUPPLY) "mint must distribute exactly TOTAL-SUPPLY"))
+      (map (lambda (r:object{recipient})
+             (let ((amt:decimal (at 'amount r)))
+               (enforce (> amt 0.0) "recipient amount must be positive")
+               (enforce-unit amt)
+               (with-capability (CREDIT (at 'account r))
+                 (credit (at 'account r) (at 'guard r) amt))))
+           recipients)
+      "minted"))
+
+  (defun burn:string (account:string amount:decimal)
+    @doc "Self-burn under the account's own guard; decrements live supply \
+         \and releases the burned weight from open votes."
+    (enforce (> amount 0.0) "amount must be positive")
+    (enforce-unit amount)
+    (with-capability (BURN account)
+      (with-read accounts account { "balance" := b }
+        (enforce (<= amount b) "insufficient funds")
+        (update accounts account { "balance": (- b amount) }))
+      (with-read supply SUPPLY-KEY { "burned" := bu }
+        (update supply SUPPLY-KEY { "burned": (+ bu amount) })))
+    (release-votes account)
+    (emit-event (BURNED account amount))
+    "burned")
+
+  (defun initial-supply:decimal ()
+    @doc "The fixed supply as minted (0.0 before init-mint)."
+    (with-default-read supply SUPPLY-KEY { "initial": 0.0 } { "initial" := i } i))
+
+  (defun burned-total:decimal ()
+    @doc "Cumulative burned amount."
+    (with-default-read supply SUPPLY-KEY { "burned": 0.0 } { "burned" := b } b))
+
+  (defun circulating-supply:decimal ()
+    @doc "initial - burned: the live supply."
+    (- (initial-supply) (burned-total)))
+
+  ;; -----------------------------
+  ;; Advisory governance
+  ;; -----------------------------
+
+  (defun curr-time:time ()
+    (at 'block-time (chain-data)))
+
+  (defun proposal-threshold:decimal ()
+    @doc "Minimum balance required to open a proposal (deploy-enforced > 0)."
+    PROPOSAL-THRESHOLD)
+
+  (defun open-ids:[string] ()
+    @doc "Currently OPEN proposal ids (pruned view of the active index)."
+    (let ((now (curr-time)))
+      (with-default-read gov-actives ACTIVE-KEY { "ids": [] } { "ids" := ids }
+        (filter (lambda (pid:string)
+                  (< now (at 'close-at (read gov-proposals pid))))
+                ids))))
+
+  (defun create-proposal:string
+      (account:string title:string body:string duration-hours:integer)
+    @doc "Open an advisory proposal. Caller must hold >= proposal-threshold. \
+         \At most MAX-ACTIVE-PROPOSALS may be open (bounds transfer gas)."
+    (enforce (and (>= duration-hours MIN-VOTE-HOURS) (<= duration-hours MAX-VOTE-HOURS))
+      "duration outside [24h, 720h]")
+    (enforce (and (> (length title) 0) (<= (length title) 120)) "title 1..120 chars")
+    (enforce (<= (length body) 2000) "body <= 2000 chars")
+    (with-capability (PROPOSE account)
+      (let ((bal (at 'balance (read accounts account))))
+        (enforce (>= bal PROPOSAL-THRESHOLD) "balance below proposal threshold"))
+      (let* ((open (open-ids))
+             (n (with-default-read gov-counts COUNT-KEY { "n": 0 } { "n" := c } c))
+             (pid (int-to-str 10 (+ n 1)))
+             (now (curr-time))
+             (close (add-time now (hours duration-hours))))
+        (enforce (< (length open) MAX-ACTIVE-PROPOSALS) "too many active proposals")
+        (write gov-counts COUNT-KEY { "n": (+ n 1) })
+        (insert gov-proposals pid
+          { "creator": account, "title": title, "body": body
+          , "created": now, "close-at": close
+          , "yes": 0.0, "no": 0.0, "abstain": 0.0 })
+        (write gov-actives ACTIVE-KEY { "ids": (+ open [pid]) })
+        (emit-event (GOV-PROPOSED pid account title close))
+        pid)))
+
+  (defun cast-vote:string (pid:string account:string choice:string)
+    @doc "Vote with weight = CURRENT balance; re-vote updates in place.     \
+         \Authorized by the account's own guard."
+    (enforce (contains choice ["yes" "no" "abstain"]) "choice: yes|no|abstain")
+    (let ((close (at 'close-at (read gov-proposals pid)))
+          (now (curr-time)))
+      (enforce (< now close) "voting closed"))
+    (with-capability (VOTE pid account)
+      (cast-vote-internal pid account choice)))
+
+  (defun cast-vote-internal:string (pid:string account:string choice:string)
+    (require-capability (VOTE pid account))
+    (let ((weight (at 'balance (read accounts account)))
+          (vkey (format "{}:{}" [pid account])))
+      (enforce (> weight 0.0) "no voting weight")
+      (with-default-read gov-votes vkey { "choice": "", "weight": 0.0 }
+        { "choice" := oc, "weight" := ow }
+        ;; remove any previous vote from its tally column, then add the new one
+        (if (> ow 0.0)
+          (with-read gov-proposals pid { "yes" := y, "no" := nn, "abstain" := a }
+            (update gov-proposals pid
+              (if (= oc "yes") { "yes": (- y ow) }
+                (if (= oc "no") { "no": (- nn ow) } { "abstain": (- a ow) }))))
+          "no prior vote")
+        (with-read gov-proposals pid { "yes" := y2, "no" := n2, "abstain" := a2 }
+          (update gov-proposals pid
+            (if (= choice "yes") { "yes": (+ y2 weight) }
+              (if (= choice "no") { "no": (+ n2 weight) } { "abstain": (+ a2 weight) }))))
+        (write gov-votes vkey { "choice": choice, "weight": weight }))
+      (emit-event (GOV-VOTED pid account choice weight))
+      "vote recorded"))
+
+  (defun release-votes:string (account:string)
+    @doc "Permissionless vote-weight sync: shrink the account's recorded    \
+         \weight on every OPEN proposal down to its CURRENT balance (the    \
+         \live-vote release rule). Derives everything from real state, so   \
+         \a public call can only correct stale weights, never forge votes.  \
+         \Called automatically after every balance decrease."
+    (let ((bal (with-default-read accounts account { "balance": 0.0 } { "balance" := b } b)))
+      (map (lambda (pid:string)
+             (let ((vkey (format "{}:{}" [pid account])))
+               (with-default-read gov-votes vkey { "choice": "", "weight": 0.0 }
+                 { "choice" := c, "weight" := w }
+                 (if (> w bal)
+                   (let ((excess (- w bal)))
+                     (with-read gov-proposals pid { "yes" := y, "no" := nn, "abstain" := a }
+                       (update gov-proposals pid
+                         (if (= c "yes") { "yes": (- y excess) }
+                           (if (= c "no") { "no": (- nn excess) } { "abstain": (- a excess) }))))
+                     (update gov-votes vkey { "weight": bal })
+                     "released")
+                   "unchanged"))))
+           (open-ids))
+      "synced"))
+
+  (defun get-proposal:object{gov-proposal} (pid:string)
+    (read gov-proposals pid))
+
+  (defun get-vote:object{gov-vote} (pid:string account:string)
+    (read gov-votes (format "{}:{}" [pid account])))
+
+  (defun get-results:object (pid:string)
+    @doc "Tallies + turnout + closed flag. ADVISORY: no quorum is enforced; \
+         \readers judge the turnout themselves."
+    (with-read gov-proposals pid
+      { "title" := t, "close-at" := ca, "yes" := y, "no" := nn, "abstain" := a }
+      { "title": t, "yes": y, "no": nn, "abstain": a
+      , "turnout": (+ y (+ nn a)), "close-at": ca
+      , "closed": (>= (curr-time) ca) }))
+)
+
+;; Frozen governance means module admin exists ONLY inside the deploy
+;; transaction - tables MUST be created here, they can never be created later.
+(create-table accounts)
+(create-table supply)
+(create-table gov-proposals)
+(create-table gov-votes)
+(create-table gov-actives)
+(create-table gov-counts)

--- a/contracts/library/token-fixed-supply-gov/metadata.yaml
+++ b/contracts/library/token-fixed-supply-gov/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'Fixed-Supply Token with Advisory Governance'
+slug: 'token-fixed-supply-gov'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['token', 'fungible', 'fixed-supply', 'governance', 'voting', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'fungible-v2', 'fixed-supply', 'live-vote', 'advisory-governance']

--- a/contracts/library/token-fixed-supply/AUDIT.md
+++ b/contracts/library/token-fixed-supply/AUDIT.md
@@ -1,0 +1,104 @@
+# AUDIT — library/token-fixed-supply
+
+## Summary
+
+| | |
+|---|---|
+| Version | 1.0.0 |
+| Audit status | `self-reviewed` (see §What self-reviewed means here) |
+| Review | Independent adversarial review, fresh context, 2026-07-18 |
+| Verdict | **GO** — 0 CRITICAL / 0 HIGH / 0 MEDIUM; 1 LOW + 2 INFO, all dispositioned below |
+| Suite | `examples/fixed-supply-token-test.repl` — green, assertion-honesty verified by the reviewer |
+| Static analysis | 0 VIOLATIONs; all WARNs dispositioned (enforce-guard positions are defcap bodies or the deliberate rotate pattern) |
+
+## Purpose
+
+A fixed-supply, non-upgradeable `fungible-v2` token: one-shot exact-distribution
+mint gated by a deploy-time keyset, self-burn as the only supply change, no
+admin surface, single-chain. The security claim under review: **after the one
+mint transaction, no party — including the deployer — holds any authority
+beyond that of an ordinary holder.**
+
+## Capability model (reviewer's summary)
+
+> Authority in `fixed-supply-token` is fully capability-scoped and frozen.
+> Governance (`GOV`) is an unsatisfiable `(enforce false)`, so the module is
+> non-upgradeable and no operational function composes with it. Value movement
+> is gated by a managed `TRANSFER` capability (budget manager enforces
+> remainder ≥ 0) that composes a real `DEBIT` guard (`enforce-guard` of the
+> sender's stored account guard) with an internal weak-body `CREDIT` token;
+> `CREDIT` is never acquired on a public path — only under `TRANSFER` or the
+> one-shot `MINT`, both of which enforce a real guard upstream — so it is an
+> internal permission token, not public authorization (verified: direct
+> `credit`/`debit`, external `with-capability`, and `install-capability` on
+> `CREDIT` all fail). Minting is a single `init-mint` guarded by the
+> deploy-time `token-minter` keyset and made one-shot by a singleton
+> supply-row `insert`; the distribution must sum to exactly `TOTAL-SUPPLY`,
+> after which the minter is powerless. Burning is self-only under the
+> account's own guard and is the sole way supply decreases. The reserved-name
+> protocol pins `k:`/`w:`/`r:` accounts to their principal guard (no
+> principal-name squatting); guard rotation is authorized by a dedicated
+> `ROTATE` capability enforcing the account's current stored guard (so
+> wallets can scope a signature to exactly one rotation), and principal
+> accounts cannot rotate their guard away. No table read occurs inside any
+> `enforce` condition, so no REPL-vs-node divergence class is present.
+
+The `ROTATE` capability was added post-initial-review (cross-template parity
+with the governance sibling) and re-verified by the same reviewer: nine
+targeted probes on the new surface (scope confinement per account, no
+privilege bleed from other caps, unscoped compatibility, module-external
+acquisition rejected), original probe batteries re-run, verdict unchanged.
+
+## Findings and dispositions
+
+| # | Sev | Finding | Disposition |
+|---|---|---|---|
+| F1 | LOW | `init-mint` griefing: a pre-created vanity recipient name under a foreign guard aborts the whole mint (no value at risk; principal names immune). | Documented in `init-mint` `@doc` and README §Deployment: distribute to principal (`k:`/`w:`) accounts, or mint in the deploy transaction. No code change (the abort is the correct behavior). |
+| F2 | INFO | `read-integer 'precision` coerces decimals by rounding — `12.4` deploys silently as `12`. Operator's own tx data, irreversible deploy footgun. | Documented in README §Known limits: send deploy parameters as exact JSON numbers. |
+| F3 | INFO | Non-principal vanity names are first-come (standard fungible-v2 behavior; squatter denies only the name string, never value). | Documented in README §Known limits. |
+
+## Attacks attempted and defeated (reviewer-executed probes)
+
+- Free-mint via the weak `CREDIT` capability: direct `credit`/`debit` fail
+  `require-capability`; external `with-capability (CREDIT …)` fails
+  `Module admin necessary`; `install-capability` fails `not managed`.
+- Second mint: blocked by the singleton supply-row insert.
+- Under/over-distribution: blocked by the exact-sum enforce.
+- Managed-budget overrun, self-transfer, precision dust, insufficient funds:
+  all rejected at capability acquisition or pre-write enforce.
+- `k:` squatting and re-guarding an existing account via `transfer-create`:
+  rejected by the reserved-name protocol and the credit guard match.
+- Principal guard rotation: rejected.
+- Scoped-signature misuse (TRANSFER-scoped sig used for rotation): rejected.
+- Node-vs-REPL divergence sweep: all 21 `enforce` conditions use pre-bound
+  values; guard reads occur only in `enforce-guard` argument position
+  (devnet-proven-safe pattern).
+
+## Liveness
+
+The only value store is per-account balances; exit paths (`transfer`,
+`transfer-create`, `burn`) are holder-guarded and compose with nothing
+admin-gated. Nothing is frozen-but-load-bearing; tables are created in the
+deploy transaction (required — `GOV` can never grant admin again).
+
+## What self-reviewed means here
+
+The review was adversarial and independent of the implementation session
+(fresh context, cold read, reviewer-authored probe harnesses), but it was
+performed within the PCO — no external party has reviewed this code. Per the
+catalog's audit-status ladder (docs/CONTRACT_POLICIES.md §3.1) that is
+`self-reviewed`, not "audited". A qualifying independent community review
+promotes the entry.
+
+## Reproduce the review
+
+```bash
+cd examples && pact fixed-supply-token-test.repl   # suite green
+pact --check-shadowing ../fixed-supply-token.pact  # clean (needs deploy env-data)
+```
+
+REPL discipline note for reviewers extending the suite: in Pact 5.4 REPL,
+`expect-failure` does NOT roll back the failed action's partial writes, and
+`expect-failure` around `load` corrupts repl state — put write-capable
+negative cases in their own transactions ended with `(rollback-tx)`, and
+verify bad-deploy aborts manually.

--- a/contracts/library/token-fixed-supply/README.md
+++ b/contracts/library/token-fixed-supply/README.md
@@ -1,0 +1,107 @@
+# Fixed-Supply Token (frozen, one-shot mint)
+
+A `fungible-v2` token whose **entire supply is minted exactly once** at
+initialization and can only ever **decrease** afterwards (holders may burn
+their own tokens). The module is **non-upgradeable by construction**: its
+governance capability is a hard `(enforce false)`, so there is no owner, no
+admin surface, and no path to mint more, freeze accounts, or rewrite rules.
+
+Use this when immutability is the product — community tokens, fair-launch
+distributions, any token whose holders should never have to trust an
+operator. If you need governed mint, cross-chain transfers, or upgradeability,
+use [`token-fungible`](../token-fungible/) instead.
+
+## Security model (what makes this safe to build on)
+
+- **One-shot mint by construction.** `init-mint` starts by `insert`-ing the
+  singleton supply row; a second call fails on the existing key before any
+  balance is touched. The distribution must sum to exactly `TOTAL-SUPPLY`.
+  After the one call, the minter keyset is powerless.
+- **Frozen governance.** `GOV` always fails, so module upgrade and any
+  admin-gated path are unreachable forever. (Corollary: tables are created in
+  the deploy transaction itself — see the checklist.)
+- **Coin-pattern ledger discipline.** Managed `TRANSFER` capability with a
+  budget manager; debit authorization = the sender's own account guard;
+  reserved-name protocol on every credit path (a `k:` account only ever binds
+  to the guard whose principal it is — no account squatting); principal
+  accounts cannot rotate their guard away.
+- **Self-burn only.** `burn` is gated on the burning account's own guard and
+  updates the supply ledger, so `circulating-supply` is always exact.
+- **Single-chain by design.** `transfer-crosschain` is disabled: a frozen
+  module cannot coordinate deployments across chains, so pretending to
+  support it would be dishonest.
+
+## Deployment checklist
+
+1. Rename the module and wrap it in your namespace.
+2. Deploy with the parameters in **transaction data** (they bake into
+   constants at load): `symbol`, `precision` (0..12), `total-supply`
+   (positive, at `precision` units), `token-minter` (keyset for the one
+   mint). Bad values abort the deploy.
+3. **Keep the `(create-table ...)` calls in the deploy transaction.** Frozen
+   governance means module admin exists only during that transaction; tables
+   can never be created later.
+4. Call `init-mint` with the full distribution (every recipient gets
+   `account`, `guard`, `amount`). **Distribute to principal (`k:`/`w:`)
+   accounts, or run `init-mint` in the deploy transaction itself**: anyone
+   can pre-create a vanity account name under their own guard, which would
+   abort a mint that targets that name (griefing only — no value moves, and
+   principal names are immune).
+5. Run the co-located REPL suite, then validate on devnet before any
+   production deployment.
+
+## Usage
+
+```pact
+;; transfer under a scoped, managed capability
+(env-sigs [{ "key": "sender-key"
+           , "caps": [(fixed-supply-token.TRANSFER "sender" "receiver" 10.0)] }])
+(fixed-supply-token.transfer "sender" "receiver" 10.0)
+
+;; burn your own tokens (signature satisfies your account guard)
+(fixed-supply-token.burn "sender" 5.0)
+
+;; supply views
+(fixed-supply-token.initial-supply)      ;; the fixed supply
+(fixed-supply-token.burned-total)        ;; cumulative burns
+(fixed-supply-token.circulating-supply)  ;; initial - burned
+```
+
+## Testing
+
+```bash
+cd examples
+pact fixed-supply-token-test.repl
+```
+
+The suite is self-contained (interfaces load from this repository's registry
+tree) and covers the one-shot mint, exact-distribution enforcement, managed
+transfer scoping, the reserved-name/principal protocol, rotation safety,
+burn supply accounting, and the disabled cross-chain path.
+
+## Known limits
+
+- **Deploy-time validation is load-time validation.** The precision and
+  supply bounds are enforced inside `defconst`s when the module loads.
+  A REPL limitation (`expect-failure` around `load` corrupts repl state)
+  prevents asserting bad deploys in-suite; verify manually by loading with,
+  e.g., `"precision": 13` and observing the abort.
+- **Send deploy parameters as exact JSON numbers.** `read-integer` coerces
+  decimals by rounding (`"precision": 12.4` silently loads as `12`); a typo
+  in the fractional part can succeed at the wrong precision instead of
+  aborting. Double-check the deploy payload — the result is irreversible.
+- **Non-principal account names are first-come.** Anyone may create a vanity
+  name under their own guard; only that guard can ever use it (standard
+  fungible-v2 behavior — no value at risk). Principal `k:`/`w:` names are
+  squat-proof: they only ever bind to the guard whose principal they are.
+- **Irreversible by design.** There is no recovery path for a wrong symbol,
+  precision, or distribution — re-deploy under a new name and abandon the
+  mistake. Treat a mainnet deploy like signing a legal document.
+- **Single chain.** No cross-chain transfers, ever. Deploying the same code
+  on two chains produces two unrelated tokens.
+- One class of node-side bug (table reads inside `enforce` conditions) is
+  invisible in the REPL — validate on devnet before production.
+
+## License
+
+Apache-2.0 — see the repository [LICENSE](../../../LICENSE).

--- a/contracts/library/token-fixed-supply/examples/fixed-supply-token-test.repl
+++ b/contracts/library/token-fixed-supply/examples/fixed-supply-token-test.repl
@@ -1,0 +1,235 @@
+;; fixed-supply-token-test.repl — PCO library template test suite
+;;
+;; Self-contained: loads the fungible-v2 interface from this repository's
+;; registry tree. No external sandbox required.
+;;
+;; Covers: deploy-time parameter validation, the ONE-SHOT mint (exactness,
+;; wrong-keyset rejection, second-call impossibility), the fungible-v2
+;; surface (managed TRANSFER scoping, guard mismatch, reserved-name/principal
+;; protocol, rotate safety), self-burn supply accounting, and the disabled
+;; cross-chain path.
+
+;; NOTE on deploy-time parameter validation: the precision/total-supply
+;; bounds are enforced inside defconsts, i.e. AT MODULE LOAD. A
+;; REPL limitation prevents asserting failing loads in-suite (expect-failure
+;; around `load` corrupts repl state), so bad-deploy rejection is verified
+;; manually: load this module with e.g. "precision": 13 and observe the
+;; abort. See README "Known limits".
+
+(env-chain-data { "chain-id": "0", "block-time": (time "2026-01-01T00:00:00Z") })
+
+;; ---------------------------------------------------------------------------
+;; Setup: interface + a good deploy (tables are created by the file itself -
+;; frozen governance means they can only ever exist via the deploy tx)
+;; ---------------------------------------------------------------------------
+(env-data
+  { "symbol": "FIX", "precision": 12, "total-supply": 1000000.0
+  , "token-minter": ["minter-key"]
+  , "alice": ["alice-key"], "bob": ["bob-key"], "carol": ["carol-key"]
+  , "attacker": ["attacker-key"]
+  , "k-ks": ["deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"] })
+
+(begin-tx "setup")
+(load "../../../registry/kip/fungible-v2/fungible-v2.pact")
+(load "../fixed-supply-token.pact")
+(commit-tx)
+
+(begin-tx "frozen governance")
+(expect-failure "module admin is unobtainable" "frozen"
+  (acquire-module-admin fixed-supply-token))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; One-shot mint
+;; ---------------------------------------------------------------------------
+;; REPL discipline used throughout: expect-failure does NOT roll back the
+;; partial writes of the failed action in this Pact version, so every
+;; negative case that could write before failing lives in its own
+;; transaction ended with (rollback-tx).
+
+(begin-tx "mint auth")
+(env-sigs [{"key": "attacker-key", "caps": []}])
+(expect-failure "non-minter cannot init-mint" "Keyset failure"
+  (fixed-supply-token.init-mint
+    [ { "account": "alice", "guard": (read-keyset "alice"), "amount": 1000000.0 } ]))
+(rollback-tx)
+
+(begin-tx "under-distribution rejected")
+(env-sigs [{"key": "minter-key", "caps": []}])
+(expect-failure "under-distribution rejected" "exactly TOTAL-SUPPLY"
+  (fixed-supply-token.init-mint
+    [ { "account": "alice", "guard": (read-keyset "alice"), "amount": 999999.0 } ]))
+(rollback-tx)
+
+(begin-tx "over-distribution rejected")
+(env-sigs [{"key": "minter-key", "caps": []}])
+(expect-failure "over-distribution rejected" "exactly TOTAL-SUPPLY"
+  (fixed-supply-token.init-mint
+    [ { "account": "alice", "guard": (read-keyset "alice"), "amount": 1000001.0 } ]))
+(rollback-tx)
+
+(begin-tx "the one mint")
+(env-sigs [{"key": "minter-key", "caps": []}])
+(expect "mint succeeds" "minted"
+  (fixed-supply-token.init-mint
+    [ { "account": "alice", "guard": (read-keyset "alice"), "amount": 600000.0 }
+    , { "account": "bob",   "guard": (read-keyset "bob"),   "amount": 300000.0 }
+    , { "account": "carol", "guard": (read-keyset "carol"), "amount": 100000.0 } ]))
+(expect "alice funded" 600000.0 (fixed-supply-token.get-balance "alice"))
+(expect "bob funded"   300000.0 (fixed-supply-token.get-balance "bob"))
+(expect "carol funded" 100000.0 (fixed-supply-token.get-balance "carol"))
+(expect "initial supply recorded" 1000000.0 (fixed-supply-token.initial-supply))
+(expect "nothing burned yet" 0.0 (fixed-supply-token.burned-total))
+(expect "circulating = initial" 1000000.0 (fixed-supply-token.circulating-supply))
+(commit-tx)
+
+(begin-tx "second mint impossible")
+(env-sigs [{"key": "minter-key", "caps": []}])
+(expect-failure "one-shot enforced by the supply-row insert" "already found"
+  (fixed-supply-token.init-mint
+    [ { "account": "alice", "guard": (read-keyset "alice"), "amount": 1000000.0 } ]))
+(rollback-tx)
+
+;; ---------------------------------------------------------------------------
+;; Account protocol: creation, duplicates, reserved names, principals
+;; ---------------------------------------------------------------------------
+(begin-tx "account protocol")
+(env-sigs [])
+(expect-failure "duplicate account rejected" "already found"
+  (fixed-supply-token.create-account "alice" (read-keyset "alice")))
+(expect-failure "too-short name rejected" "min length"
+  (fixed-supply-token.create-account "ab" (read-keyset "alice")))
+(expect-failure "k: squat rejected: guard is not the principal's"
+  "Single-key account protocol violation"
+  (fixed-supply-token.create-account
+    "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    (read-keyset "attacker")))
+(expect "proper principal account created"
+  "created k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  (fixed-supply-token.create-account
+    "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    (read-keyset "k-ks")))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Transfers: managed cap scoping and ledger rules
+;; ---------------------------------------------------------------------------
+(begin-tx "unsigned transfer fails")
+(env-sigs [])
+(expect-failure "no capability installed" "not installed"
+  (fixed-supply-token.transfer "alice" "bob" 10.0))
+(commit-tx)
+
+(begin-tx "signed transfer works and is bounded by the managed amount")
+(env-sigs [ { "key": "alice-key"
+            , "caps": [ (fixed-supply-token.TRANSFER "alice" "bob" 100.0) ] } ])
+(expect "transfer ok" "Write succeeded" (fixed-supply-token.transfer "alice" "bob" 60.0))
+(expect "second leg within the managed budget" "Write succeeded"
+  (fixed-supply-token.transfer "alice" "bob" 40.0))
+(expect-failure "managed budget exhausted" "TRANSFER exceeded"
+  (fixed-supply-token.transfer "alice" "bob" 1.0))
+(expect "alice debited" 599900.0 (fixed-supply-token.get-balance "alice"))
+(expect "bob credited" 300100.0 (fixed-supply-token.get-balance "bob"))
+(commit-tx)
+
+(begin-tx "transfer rules")
+(env-sigs [ { "key": "alice-key"
+            , "caps": [ (fixed-supply-token.TRANSFER "alice" "alice" 10.0)
+                      , (fixed-supply-token.TRANSFER "alice" "bob" 2000000.0)
+                      , (fixed-supply-token.TRANSFER "alice" "carol" 10.0) ] } ])
+(expect-failure "self-transfer rejected" "same sender and receiver"
+  (fixed-supply-token.transfer "alice" "alice" 10.0))
+(expect-failure "insufficient funds" "insufficient funds"
+  (fixed-supply-token.transfer "alice" "bob" 1000000.0))
+(expect-failure "precision violation" "precision violation"
+  (fixed-supply-token.transfer "alice" "carol" 0.0000000000001))
+(rollback-tx)
+
+;; the failing credit comes AFTER the debit wrote - rollback-tx discards the leak
+(begin-tx "guard mismatch on credit to an existing account")
+(env-sigs [ { "key": "alice-key"
+            , "caps": [ (fixed-supply-token.TRANSFER "alice" "bob" 10.0) ] } ])
+(expect-failure "cannot re-guard an existing account via transfer-create"
+  "account guard mismatch"
+  (fixed-supply-token.transfer-create "alice" "bob" (read-keyset "attacker") 10.0))
+(rollback-tx)
+
+(begin-tx "transfer-create to a new principal account")
+(env-sigs [ { "key": "alice-key"
+            , "caps": [ (fixed-supply-token.TRANSFER
+                          "alice"
+                          "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+                          25.0) ] } ])
+(fixed-supply-token.transfer-create
+  "alice"
+  "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  (read-keyset "k-ks") 25.0)
+(expect "principal account credited" 25.0
+  (fixed-supply-token.get-balance
+    "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Rotation safety
+;; ---------------------------------------------------------------------------
+(begin-tx "rotate under a capability-scoped signature")
+(env-sigs [ { "key": "carol-key"
+            , "caps": [ (fixed-supply-token.ROTATE "carol") ] } ])
+(expect "vanity account rotates under a scoped ROTATE signature" "rotated carol"
+  (fixed-supply-token.rotate "carol" (read-keyset "attacker")))
+(commit-tx)
+(begin-tx "principal accounts cannot rotate away")
+(env-sigs [ { "key": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            , "caps": [] } ])
+(expect-failure "principal rotation forbidden" "unsafe for principal accounts"
+  (fixed-supply-token.rotate
+    "k:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    (read-keyset "attacker")))
+(commit-tx)
+(begin-tx "old guard is gone after rotation")
+(env-sigs [ { "key": "carol-key"
+            , "caps": [ (fixed-supply-token.TRANSFER "carol" "bob" 1.0) ] } ])
+(expect-failure "old key no longer authorizes" "Keyset failure"
+  (fixed-supply-token.transfer "carol" "bob" 1.0))
+(commit-tx)
+(begin-tx "new guard authorizes")
+(env-sigs [ { "key": "attacker-key"
+            , "caps": [ (fixed-supply-token.TRANSFER "carol" "bob" 1.0) ] } ])
+(expect "rotated guard transfers" "Write succeeded"
+  (fixed-supply-token.transfer "carol" "bob" 1.0))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Burn: self-only, exact supply accounting
+;; ---------------------------------------------------------------------------
+(begin-tx "burn auth")
+(env-sigs [{"key": "attacker-key", "caps": []}])
+(expect-failure "only the holder can burn" "Keyset failure"
+  (fixed-supply-token.burn "bob" 10.0))
+(commit-tx)
+
+(begin-tx "burn accounting")
+(env-events true)
+(env-sigs [{"key": "bob-key", "caps": []}])
+(expect-failure "cannot burn more than balance" "insufficient funds"
+  (fixed-supply-token.burn "bob" 9999999.0))
+(expect "burn ok" "burned" (fixed-supply-token.burn "bob" 100.0))
+(expect "bob debited by the burn" 300001.0 (fixed-supply-token.get-balance "bob"))
+(expect "burned-total tracks" 100.0 (fixed-supply-token.burned-total))
+(expect "initial supply unchanged" 1000000.0 (fixed-supply-token.initial-supply))
+(expect "circulating shrank" 999900.0 (fixed-supply-token.circulating-supply))
+(expect "BURNED event emitted"
+  [ { "name": "fixed-supply-token.BURNED", "params": ["bob" 100.0], "module-hash": (at 'hash (describe-module "fixed-supply-token")) } ]
+  (env-events true))
+(commit-tx)
+
+;; ---------------------------------------------------------------------------
+;; Cross-chain is disabled
+;; ---------------------------------------------------------------------------
+(begin-tx "xchain disabled")
+(env-sigs [{"key": "alice-key", "caps": []}])
+(expect-failure "transfer-crosschain step 0 always aborts" "cross-chain transfers are disabled"
+  (fixed-supply-token.transfer-crosschain "alice" "bob" (read-keyset "bob") "1" 10.0))
+(commit-tx)
+
+(print "fixed-supply-token suite complete")

--- a/contracts/library/token-fixed-supply/fixed-supply-token.pact
+++ b/contracts/library/token-fixed-supply/fixed-supply-token.pact
@@ -1,0 +1,295 @@
+(module fixed-supply-token GOV
+
+  @doc "PCO library template: a FIXED-SUPPLY, NON-UPGRADEABLE fungible-v2     \
+  \token. The entire supply is minted exactly once at initialization and can  \
+  \only ever decrease afterwards (holders may burn their own tokens). There   \
+  \is no owner, no admin function, and no upgrade path: what you deploy is    \
+  \the token, forever. That immutability is the product - holders never have  \
+  \to trust an operator not to mint, freeze, or rewrite the rules.           \
+  \                                                                          \
+  \Deploy-time parameterization (transaction data, baked into constants):     \
+  \  symbol        - display symbol                                          \
+  \  precision     - decimal precision, 0..12                                \
+  \  total-supply  - the fixed supply, positive, at 'precision' units        \
+  \  token-minter  - keyset authorized to call init-mint EXACTLY ONCE        \
+  \                                                                          \
+  \Deployment checklist (see README.md):                                     \
+  \  1. Rename the module and wrap it in your namespace.                     \
+  \  2. Deploy WITH the parameters above in the same transaction - the      \
+  \     (create-table ...) calls at the end of this file MUST stay in the    \
+  \     deploy transaction: governance is frozen, so tables can never be     \
+  \     created afterwards.                                                  \
+  \  3. Call init-mint with the full distribution; a second call is          \
+  \     impossible by construction.                                          \
+  \  4. Run the co-located REPL suite, then validate on devnet before any    \
+  \     production deployment.                                               \
+  \                                                                          \
+  \This token is SINGLE-CHAIN by design: transfer-crosschain is disabled.    \
+  \A frozen module cannot coordinate upgrades across chains, so honest       \
+  \cross-chain support would require a different (governed) template."
+
+  (implements fungible-v2)
+
+  ;; -----------------------------
+  ;; Governance: frozen forever
+  ;; -----------------------------
+
+  (defcap GOV ()
+    @doc "Deliberately unsatisfiable: the deployed module is non-upgradeable."
+    (enforce false "frozen: this token is non-upgradeable"))
+
+  ;; -----------------------------
+  ;; Deploy-time constants
+  ;; -----------------------------
+
+  (defconst SYMBOL (read-string 'symbol)
+    "Display symbol, fixed at deploy.")
+
+  (defconst PRECISION:integer
+    (let ((p (read-integer 'precision)))
+      (enforce (and (>= p 0) (<= p 12)) "precision must be in 0..12")
+      p)
+    "Decimal precision, fixed at deploy (12 matches coin).")
+
+  (defconst TOTAL-SUPPLY:decimal
+    (let ((s (read-decimal 'total-supply)))
+      (enforce (> s 0.0) "total-supply must be positive")
+      (enforce (= (floor s PRECISION) s) "total-supply must respect precision")
+      s)
+    "The fixed supply: minted exactly once, only ever decreased by burns.")
+
+  (defconst MINT-GUARD:guard (read-keyset 'token-minter)
+    "The keyset allowed to perform the ONE initial mint. Powerless afterwards.")
+
+  (defconst MINIMUM_ACCOUNT_LENGTH 3
+    "Minimum account name length")
+
+  (defconst MAXIMUM_ACCOUNT_LENGTH 256
+    "Maximum account name length")
+
+  (defconst SUPPLY-KEY "supply")
+
+  ;; -----------------------------
+  ;; Schemas and Tables
+  ;; -----------------------------
+
+  (defschema account
+    @doc "Account row with balance and guard"
+    @model [(invariant (>= balance 0.0))]
+    balance:decimal
+    guard:guard)
+
+  (deftable accounts:{account})
+
+  (defschema supply-row
+    @doc "Singleton supply ledger: the one-shot insert here is what makes a \
+         \second init-mint impossible (insert fails on an existing key)."
+    initial:decimal
+    burned:decimal)
+
+  (deftable supply:{supply-row})
+
+  (defschema recipient
+    @doc "One initial-distribution entry for init-mint."
+    account:string
+    guard:guard
+    amount:decimal)
+
+  ;; -----------------------------
+  ;; Capabilities
+  ;; -----------------------------
+
+  (defcap DEBIT (sender:string)
+    @doc "Internal debit permission: enforces the sender's account guard."
+    (enforce-guard (at 'guard (read accounts sender))))
+
+  (defcap CREDIT (receiver:string)
+    @doc "Internal credit permission. Safe as a weak-body cap: only ever \
+         \required by code paths that already validated the credit."
+    true)
+
+  (defcap MINT ()
+    @doc "The one-shot initial mint, guarded by the deploy-time minter keyset."
+    (enforce-guard MINT-GUARD))
+
+  (defcap BURN (account:string)
+    @doc "Self-burn permission: the account's own guard, nobody else's."
+    (enforce-guard (at 'guard (read accounts account))))
+
+  (defcap ROTATE (account:string)
+    @doc "Guard-rotation authorization: the account's CURRENT guard. A       \
+         \capability-scoped signature can target exactly this rotation."
+    (enforce-guard (at 'guard (read accounts account))))
+
+  (defcap BURNED (account:string amount:decimal)
+    @event
+    true)
+
+  (defcap TRANSFER:bool (sender:string receiver:string amount:decimal)
+    @managed amount TRANSFER-mgr
+    (enforce (!= sender receiver) "same sender and receiver")
+    (enforce (> amount 0.0) "amount must be positive")
+    (enforce-unit amount)
+    (compose-capability (DEBIT sender))
+    (compose-capability (CREDIT receiver)))
+
+  (defun TRANSFER-mgr:decimal (managed:decimal requested:decimal)
+    (let ((newbal (- managed requested)))
+      (enforce (>= newbal 0.0) "TRANSFER exceeded for balance")
+      newbal))
+
+  ;; -----------------------------
+  ;; Account name protocol
+  ;; -----------------------------
+
+  (defun validate-account (account:string)
+    @doc "Enforce account name length bounds and latin-1 charset."
+    (enforce (is-charset CHARSET_LATIN1 account)
+      (format "Account does not conform to the token contract charset: {}" [account]))
+    (let ((account-length (length account)))
+      (enforce (>= account-length MINIMUM_ACCOUNT_LENGTH)
+        (format "Account name does not conform to the min length requirement: {}" [account]))
+      (enforce (<= account-length MAXIMUM_ACCOUNT_LENGTH)
+        (format "Account name does not conform to the max length requirement: {}" [account]))))
+
+  (defun check-reserved:string (account:string)
+    @doc "Return reserved-name protocol prefix ('k' for 'k:...'), or ''."
+    (let ((pfx (take 2 account)))
+      (if (= ":" (take -1 pfx)) (take 1 pfx) "")))
+
+  (defun enforce-reserved:bool (account:string guard:guard)
+    @doc "Enforce reserved account name protocols: a 'k:'-prefixed account \
+         \must be the principal of its guard (prevents account squatting)."
+    (if (validate-principal guard account)
+      true
+      (let ((r (check-reserved account)))
+        (if (= r "")
+          true
+          (if (= r "k")
+            (enforce false "Single-key account protocol violation")
+            (enforce false
+              (format "Reserved protocol guard violation: {}" [r])))))))
+
+  ;; -----------------------------
+  ;; fungible-v2 surface
+  ;; -----------------------------
+
+  (defun transfer:string (sender:string receiver:string amount:decimal)
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (with-read accounts receiver { "guard" := g }
+        (credit receiver g amount))))
+
+  (defun transfer-create:string
+      (sender:string receiver:string receiver-guard:guard amount:decimal)
+    (with-capability (TRANSFER sender receiver amount)
+      (debit sender amount)
+      (credit receiver receiver-guard amount)))
+
+  (defpact transfer-crosschain:string
+      (sender:string receiver:string receiver-guard:guard
+       target-chain:string amount:decimal)
+    (step (enforce false "cross-chain transfers are disabled: single-chain token")))
+
+  (defun debit (account:string amount:decimal)
+    (require-capability (DEBIT account))
+    (with-read accounts account { "balance" := b }
+      (enforce (<= amount b) "insufficient funds")
+      (update accounts account { "balance": (- b amount) })))
+
+  (defun credit (account:string guard:guard amount:decimal)
+    (require-capability (CREDIT account))
+    (validate-account account)
+    (enforce-reserved account guard)
+    (with-default-read accounts account
+      { "balance": 0.0, "guard": guard }
+      { "balance" := b, "guard" := g }
+      (enforce (= g guard) "account guard mismatch")
+      (write accounts account { "balance": (+ b amount), "guard": g })))
+
+  (defun get-balance:decimal (account:string)
+    (at 'balance (read accounts account)))
+
+  (defun details:object{fungible-v2.account-details} (account:string)
+    (with-read accounts account { "balance" := b, "guard" := g }
+      { "account": account, "balance": b, "guard": g }))
+
+  (defun precision:integer ()
+    PRECISION)
+
+  (defun enforce-unit:bool (amount:decimal)
+    (enforce (= (floor amount PRECISION) amount) "precision violation"))
+
+  (defun create-account:string (account:string guard:guard)
+    (validate-account account)
+    (enforce-reserved account guard)
+    (insert accounts account { "balance": 0.0, "guard": guard })
+    (format "created {}" [account]))
+
+  (defun rotate:string (account:string new-guard:guard)
+    ;; principal accounts must not rotate away from their proper guard -
+    ;; a rotated 'k:' account would falsify the reserved-name protocol.
+    (enforce (or (not (is-principal account))
+                 (validate-principal new-guard account))
+      "It is unsafe for principal accounts to rotate their guard")
+    (with-capability (ROTATE account)
+      (update accounts account { "guard": new-guard }))
+    (format "rotated {}" [account]))
+
+  ;; -----------------------------
+  ;; One-shot mint, burn, supply views
+  ;; -----------------------------
+
+  (defun init-mint:string (recipients:[object{recipient}])
+    @doc "One-shot: mint EXACTLY TOTAL-SUPPLY across the recipients. The     \
+         \insert into the supply row makes a second call impossible by       \
+         \construction (insert fails on an existing key), so the minter      \
+         \keyset is powerless after this returns. Distribute to principal    \
+         \(k:/w:) accounts, or mint in the deploy transaction itself: a      \
+         \pre-created vanity name under a foreign guard aborts the mint      \
+         \(griefing, not theft - principal names are immune)."
+    (with-capability (MINT)
+      (insert supply SUPPLY-KEY { "initial": TOTAL-SUPPLY, "burned": 0.0 })
+      (let ((total (fold (lambda (acc:decimal r:object{recipient})
+                           (+ acc (at 'amount r)))
+                         0.0 recipients)))
+        (enforce (= total TOTAL-SUPPLY) "mint must distribute exactly TOTAL-SUPPLY"))
+      (map (lambda (r:object{recipient})
+             (let ((amt:decimal (at 'amount r)))
+               (enforce (> amt 0.0) "recipient amount must be positive")
+               (enforce-unit amt)
+               (with-capability (CREDIT (at 'account r))
+                 (credit (at 'account r) (at 'guard r) amt))))
+           recipients)
+      "minted"))
+
+  (defun burn:string (account:string amount:decimal)
+    @doc "Self-burn under the account's own guard; decrements live supply."
+    (enforce (> amount 0.0) "amount must be positive")
+    (enforce-unit amount)
+    (with-capability (BURN account)
+      (with-read accounts account { "balance" := b }
+        (enforce (<= amount b) "insufficient funds")
+        (update accounts account { "balance": (- b amount) }))
+      (with-read supply SUPPLY-KEY { "burned" := bu }
+        (update supply SUPPLY-KEY { "burned": (+ bu amount) })))
+    (emit-event (BURNED account amount))
+    "burned")
+
+  (defun initial-supply:decimal ()
+    @doc "The fixed supply as minted (0.0 before init-mint)."
+    (with-default-read supply SUPPLY-KEY { "initial": 0.0 } { "initial" := i } i))
+
+  (defun burned-total:decimal ()
+    @doc "Cumulative burned amount."
+    (with-default-read supply SUPPLY-KEY { "burned": 0.0 } { "burned" := b } b))
+
+  (defun circulating-supply:decimal ()
+    @doc "initial - burned: the live supply."
+    (- (initial-supply) (burned-total)))
+)
+
+;; Frozen governance means module admin exists ONLY inside the deploy
+;; transaction - tables MUST be created here, they can never be created later.
+(create-table accounts)
+(create-table supply)

--- a/contracts/library/token-fixed-supply/metadata.yaml
+++ b/contracts/library/token-fixed-supply/metadata.yaml
@@ -1,0 +1,11 @@
+name: 'Fixed-Supply Token (frozen, one-shot mint)'
+slug: 'token-fixed-supply'
+version: '1.0.0'
+repository: 'https://github.com/Pact-Community-Organization/pact-contract-catalog'
+license: 'Apache-2.0'
+authors:
+  - name: 'Pact Community Organization'
+    email: 'info@pact-community.org'
+audit_status: 'self-reviewed'
+tags: ['token', 'fungible', 'fixed-supply', 'non-upgradeable', 'template', 'library']
+keywords: ['pact', 'smart-contract', 'fungible-v2', 'fixed-supply', 'burn', 'immutable']

--- a/docs/index.json
+++ b/docs/index.json
@@ -209,6 +209,69 @@
 }
 ,
 {
+  "name": "Fixed-Supply Token with Advisory Governance",
+  "slug": "token-fixed-supply-gov",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "token",
+    "fungible",
+    "fixed-supply",
+    "governance",
+    "voting",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "fungible-v2",
+    "fixed-supply",
+    "live-vote",
+    "advisory-governance"
+  ]
+}
+,
+{
+  "name": "Fixed-Supply Token (frozen, one-shot mint)",
+  "slug": "token-fixed-supply",
+  "version": "1.0.0",
+  "repository": "https://github.com/Pact-Community-Organization/pact-contract-catalog",
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Pact Community Organization",
+      "email": "info@pact-community.org"
+    }
+  ],
+  "audit_status": "self-reviewed",
+  "tags": [
+    "token",
+    "fungible",
+    "fixed-supply",
+    "non-upgradeable",
+    "template",
+    "library"
+  ],
+  "keywords": [
+    "pact",
+    "smart-contract",
+    "fungible-v2",
+    "fixed-supply",
+    "burn",
+    "immutable"
+  ]
+}
+,
+{
   "name": "Token (fungible-v2 + fungible-xchain-v1)",
   "slug": "token-fungible",
   "version": "0.2.0",

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ _Generated from `contracts/**/metadata.yaml`._
 | Oracle Feed (median, staleness-guarded) | oracle-feed | 1.0.0 | self-reviewed | oracle, price-feed, median, template, library |
 | Property Lease (rental rails) | property-lease | 1.0.0 | self-reviewed | lease, rental, escrow, revenue-split, template, library |
 | Royalty Sale (conservation-checked NFT marketplace) | royalty-sale | 1.0.0 | self-reviewed | nft, royalty, marketplace, escrow, template, library |
+| Fixed-Supply Token with Advisory Governance | token-fixed-supply-gov | 1.0.0 | self-reviewed | token, fungible, fixed-supply, governance, voting, template, library |
+| Fixed-Supply Token (frozen, one-shot mint) | token-fixed-supply | 1.0.0 | self-reviewed | token, fungible, fixed-supply, non-upgradeable, template, library |
 | Token (fungible-v2 + fungible-xchain-v1) | token-fungible | 0.2.0 | self-reviewed | token, fungible, template, library |
 | Token Vesting (cliff + linear) | vesting | 1.0.0 | self-reviewed | vesting, escrow, timelock, template, library |
 


### PR DESCRIPTION
Two new library templates for the niche the governed `token-fungible` deliberately does not serve: tokens where **immutability is the product**.

## token-fixed-supply
A frozen, non-upgradeable `fungible-v2` token: entire supply minted exactly once (`init-mint`, one-shot by the singleton supply-row insert; distribution must sum exactly to `TOTAL-SUPPLY`), self-burn as the only supply change, no admin surface, single-chain by design. Deploy-time parameterization (symbol / precision / total-supply / minter keyset) via tx data baked into defconsts with load-time bound enforcement. Coin-pattern ledger throughout: managed `TRANSFER` + budget manager, reserved-name protocol on every credit path, account-name validation, principal-rotation ban, scoped-signable `ROTATE`.

## token-fixed-supply-gov
The same core plus **advisory** governance: proposals + live balance-weighted yes/no/abstain votes with permanent tallies that execute nothing. Weight = current balance; every balance decrease automatically releases the moved weight from open votes (vote-then-transfer double-counting is impossible by construction); credits never vote; `release-votes` is public and shrink-only; ≤ 3 open proposals bound the governance load — worst case measured **and asserted** in-suite at 489 gas vs the 150k ceiling. `PROPOSE` / `VOTE` / `ROTATE` capabilities make every governance action capability-scoped-signable (no unscoped keys anywhere); the proposal threshold is deploy-enforced positive.

## Gates
- Self-contained assertion-heavy suites (kip interfaces from the registry tree) — green; full library sweep green (no regressions in the other nine).
- Static pass: 0 VIOLATIONs (WARN dispositions in the AUDIT.mds).
- **Independent adversarial review per entry, documented in each AUDIT.md with dispositions.** The governance template's initial review returned 1 MEDIUM (bare `enforce-guard` authorization forcing unscoped voter signatures) + 1 LOW (threshold able to floor to 0.0 on degenerate deploy params) — both fixed exactly as prescribed and **re-verified by the reviewer to a confirmed GO** (scoped-sig spoofing, vote-transfer-revote cycles, hostile syncs, degenerate deploys all re-exercised). Base template GO, re-confirmed after the ROTATE parity change.
- Catalog validator OK on both entries; index regenerated; README library table now eleven.

## Suite discipline note (applies catalog-wide)
Pact 5.4 REPL `expect-failure` does **not** roll back the failed action's partial writes, and cannot wrap `load` (state corruption). Both suites therefore put every write-capable negative case in its own `(rollback-tx)` transaction. Existing library suites may silently rely on rollback that isn't happening — worth a follow-up sweep.